### PR TITLE
Changed Get-RubrikAPIData.ps1

### DIFF
--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -226,6 +226,7 @@ function Get-RubrikAPIData($endpoint) {
                     operating_system_type = 'operating_system_type'
                     primary_cluster_id    = 'primary_cluster_id'
                     hostname              = 'hostname'
+                    name                  = 'name'
                 }
                 Result      = 'data'
                 Filter      = ''


### PR DESCRIPTION
# Description

Changed Get-RubrikAPIData.ps1

## Motivation and Context

Get-RubrikHost -> hostname is deprecitated in 5.0:
(Deprecated) Retrieve hosts with a host name matching the provided name. The search type is infix.

Added "name".