### PR TITLE
Bug with -TargetFilePaths logic that got by earlier review

### DIFF
--- a/Rubrik/Public/Export-RubrikDatabase.ps1
+++ b/Rubrik/Public/Export-RubrikDatabase.ps1
@@ -57,6 +57,7 @@ function Export-RubrikDatabase
     [string]$TargetInstanceId,
     # Name to give database upon export
     [string]$TargetDatabaseName,
+    [Switch]$Overwrite,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
     # API version
@@ -114,10 +115,12 @@ function Export-RubrikDatabase
       $body.Add($resources.Body.maxDataStreams,$MaxDataStreams)
     }
 
-    if([string]::IsNullOrWhiteSpace($TargetFilePaths) -eq $false){
+    if($TargetFilePaths){
+      Write-Verbose "Adding Advanced Mode File Paths"
       if($TargetDataFilePath -or $TargetLogFilePath) {Write-Warning 'Use of -TargetFilePaths overrides -TargetDataFilePath and -TargetLogFilePath.'}
       $body.Add('targetFilePaths',$TargetFilePaths)
     } else {
+      Write-Verbose "Adding Simple Mode File Paths"
       if($TargetDataFilePath){ $body.Add('targetDataFilePath',$TargetDataFilePath) }
       if($TargetLogFilePath){ $body.Add('targetLogFilePath',$TargetLogFilePath) }
     }
@@ -127,6 +130,10 @@ function Export-RubrikDatabase
       $body.recoveryPoint += @{lsnPoint=@{lsn=$RecoveryLSN}}
     } else {
       $body.recoveryPoint += @{timestampMs = $TimestampMs}
+    }
+
+    if($Overwrite){
+      $body.add('allowOverwrite',$true)
     }
 
     $body = ConvertTo-Json $body -Depth 10


### PR DESCRIPTION
# Description
Changed argument check to not use [string]::IsWitespaceOrNull (argument is an object). This was not properly triggering when a value was passed to -TargetFilePaths
Added verbose logging messages for which item is used.

## Motivation and Context
Bug fix

## How Has This Been Tested?
Ran Export-RubrikDatabase with:
- -TargetDataFilePath and -TargetLogFilePath, success with appropriate paths
- -TargetFilePaths, success with appropriate paths
- No argument, success with appropriate paths
## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
