### PR TITLE
Fixes to address Get-RubrikRequest

### DIFF
--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -463,16 +463,6 @@ function Get-RubrikAPIData($endpoint) {
                 Filter      = ''
                 Success     = '200'
             }
-            'internal' = @{
-                Description = 'Get details about an async request.'
-                URI         = '/api/internal/{type}/request/{id}'
-                Method      = 'Get'
-                Body        = ''
-                Query       = ''
-                Result      = ''
-                Filter      = ''
-                Success     = '200'
-            }
         }
         'Get-RubrikSLA'                = @{
             '1.0' = @{

--- a/Rubrik/Public/Get-RubrikRequest.ps1
+++ b/Rubrik/Public/Get-RubrikRequest.ps1
@@ -29,7 +29,7 @@ function Get-RubrikRequest
     [String]$id,
     # The type of request
     [Parameter(Mandatory = $true)]
-    [ValidateSet('fileset','mssql','vmware/vm','hyperv/vm','managedvolume')]
+    [ValidateSet('fileset','mssql','vmware/vm','hyperv/vm','managed_volume')]
     [String]$Type,    
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
@@ -63,6 +63,11 @@ function Get-RubrikRequest
 
     #region one-off
     $uri = $uri -replace '{type}', $Type
+    #Place any internal API request calls into this collection, the replace will fix the URI
+    $internaltypes = @('managed_volume')
+    if($internaltypes -contains $Type){
+      $uri = $uri -replace 'v1', 'internal'
+    }
     #endregion
 
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri

--- a/Tests/Get-RubrikAPIData.Tests.ps1
+++ b/Tests/Get-RubrikAPIData.Tests.ps1
@@ -1,0 +1,46 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Private/Get-RubrikAPIData' -Tag 'Private', 'Get-RubrikAPIData' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0'
+    }
+
+    #Function List
+    $ignorelist = @('Invoke-RubrikRESTCall','Move-RubrikMountVMDK','Sync-RubrikAnnotation','Sync-RubrikTag') 
+    $functions = ( Get-ChildItem -Path './Rubrik/Public' | Where-Object extension -eq '.ps1').Name.Replace('.ps1','')
+    $functions = $functions | Where-Object {$ignorelist -notcontains $_}
+
+    #CDM versions
+    $versions = @('4.0','4.1','4.2','5.0')
+
+    $cases =@()
+    foreach($version in $versions){
+        foreach($function in $functions){
+         $cases += @{'v'=$version;'f' = $function}
+        }
+    }
+    #endregion
+    it -Name "Get-RubrikAPIData <v> - <f> test" -TestCases $cases {
+        param($v,$f)
+        $global:rubrikConnection.version = $v
+        $resources = Get-RubrikAPIData -endpoint $f
+        $resources.Method | Should -BeIn @('Get','Post','Patch','Delete')
+        $resources.URI | Should -Not -Be $null 
+
+    }
+
+
+}


### PR DESCRIPTION
-Removed 'internal' block from Get-RubrikAPIData for Get-RubrikRequest
-Added replace for internal API in the event of a managed volume request
-Added test to validate Get-RubrikAPIData entries

# Description
A recent update to correct version sorting broke Get-RubrikRequest. This repairs it.

## How Has This Been Tested?
Created Pester test to validate Get-RubrikAPIData for all functions using CDM versions 4.0, 4.1, 4.2, and 5.0.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
