### PR TITLE
Updated links to documentation

### DIFF
--- a/Rubrik/Public/Connect-Rubrik.ps1
+++ b/Rubrik/Public/Connect-Rubrik.ps1
@@ -16,7 +16,7 @@ function Connect-Rubrik {
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Connect-Rubrik -Server 192.168.1.1 -Username admin

--- a/Rubrik/Public/Connect-Rubrik.ps1
+++ b/Rubrik/Public/Connect-Rubrik.ps1
@@ -16,7 +16,7 @@ function Connect-Rubrik {
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Connect-Rubrik.html
 
       .EXAMPLE
       Connect-Rubrik -Server 192.168.1.1 -Username admin

--- a/Rubrik/Public/Connect-Rubrik.ps1
+++ b/Rubrik/Public/Connect-Rubrik.ps1
@@ -16,7 +16,7 @@ function Connect-Rubrik {
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Connect-Rubrik -Server 192.168.1.1 -Username admin

--- a/Rubrik/Public/Disconnect-Rubrik.ps1
+++ b/Rubrik/Public/Disconnect-Rubrik.ps1
@@ -15,7 +15,7 @@ function Disconnect-Rubrik
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Disconnect-Rubrik.html
 
       .EXAMPLE
       Disconnect-Rubrik -Confirm:$false

--- a/Rubrik/Public/Disconnect-Rubrik.ps1
+++ b/Rubrik/Public/Disconnect-Rubrik.ps1
@@ -15,7 +15,7 @@ function Disconnect-Rubrik
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Disconnect-Rubrik -Confirm:$false

--- a/Rubrik/Public/Disconnect-Rubrik.ps1
+++ b/Rubrik/Public/Disconnect-Rubrik.ps1
@@ -15,7 +15,7 @@ function Disconnect-Rubrik
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Disconnect-Rubrik -Confirm:$false

--- a/Rubrik/Public/Export-RubrikDatabase.ps1
+++ b/Rubrik/Public/Export-RubrikDatabase.ps1
@@ -32,7 +32,7 @@ function Export-RubrikDatabase
       $targetfiles += @{logicalName='BAR_LOG';exportPath='E:\SQLFiles\Log\BAREXP\'}
       
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
   #>
 
   [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]

--- a/Rubrik/Public/Export-RubrikDatabase.ps1
+++ b/Rubrik/Public/Export-RubrikDatabase.ps1
@@ -32,7 +32,7 @@ function Export-RubrikDatabase
       $targetfiles += @{logicalName='BAR_LOG';exportPath='E:\SQLFiles\Log\BAREXP\'}
       
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Export-RubrikDatabase.html
   #>
 
   [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]

--- a/Rubrik/Public/Export-RubrikDatabase.ps1
+++ b/Rubrik/Public/Export-RubrikDatabase.ps1
@@ -32,7 +32,7 @@ function Export-RubrikDatabase
       $targetfiles += @{logicalName='BAR_LOG';exportPath='E:\SQLFiles\Log\BAREXP\'}
       
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
   #>
 
   [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]

--- a/Rubrik/Public/Export-RubrikReport.ps1
+++ b/Rubrik/Public/Export-RubrikReport.ps1
@@ -14,7 +14,7 @@ function Export-RubrikReport
       GitHub: basvinken
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Export-RubrikReport.html
 
       .EXAMPLE
       Export-RubrikReport -id '11111111-2222-3333-4444-555555555555' -timezone_offset 120

--- a/Rubrik/Public/Export-RubrikReport.ps1
+++ b/Rubrik/Public/Export-RubrikReport.ps1
@@ -14,7 +14,7 @@ function Export-RubrikReport
       GitHub: basvinken
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Export-RubrikReport -id '11111111-2222-3333-4444-555555555555' -timezone_offset 120

--- a/Rubrik/Public/Export-RubrikReport.ps1
+++ b/Rubrik/Public/Export-RubrikReport.ps1
@@ -14,7 +14,7 @@ function Export-RubrikReport
       GitHub: basvinken
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Export-RubrikReport -id '11111111-2222-3333-4444-555555555555' -timezone_offset 120

--- a/Rubrik/Public/Get-RubrikAPIVersion.ps1
+++ b/Rubrik/Public/Get-RubrikAPIVersion.ps1
@@ -14,7 +14,7 @@ function Get-RubrikAPIVersion
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikAPIVersion -Server 192.168.1.100

--- a/Rubrik/Public/Get-RubrikAPIVersion.ps1
+++ b/Rubrik/Public/Get-RubrikAPIVersion.ps1
@@ -14,7 +14,7 @@ function Get-RubrikAPIVersion
       GitHub: chriswahl
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikAPIVersion.html
             
       .EXAMPLE
       Get-RubrikAPIVersion -Server 192.168.1.100

--- a/Rubrik/Public/Get-RubrikAPIVersion.ps1
+++ b/Rubrik/Public/Get-RubrikAPIVersion.ps1
@@ -14,7 +14,7 @@ function Get-RubrikAPIVersion
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikAPIVersion -Server 192.168.1.100

--- a/Rubrik/Public/Get-RubrikAvailabilityGroup.ps1
+++ b/Rubrik/Public/Get-RubrikAvailabilityGroup.ps1
@@ -16,7 +16,7 @@ function Get-RubrikAvailabilityGroup
       GitHub: clumnah
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikAvailabilityGroup -GroupName 'am1-sql16ag-1ag'

--- a/Rubrik/Public/Get-RubrikAvailabilityGroup.ps1
+++ b/Rubrik/Public/Get-RubrikAvailabilityGroup.ps1
@@ -16,7 +16,7 @@ function Get-RubrikAvailabilityGroup
       GitHub: clumnah
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikAvailabilityGroup -GroupName 'am1-sql16ag-1ag'

--- a/Rubrik/Public/Get-RubrikDatabase.ps1
+++ b/Rubrik/Public/Get-RubrikDatabase.ps1
@@ -16,7 +16,7 @@ function Get-RubrikDatabase
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikDatabase.html
 
       .EXAMPLE
       Get-RubrikDatabase -Name 'DB1' -SLA Gold

--- a/Rubrik/Public/Get-RubrikDatabase.ps1
+++ b/Rubrik/Public/Get-RubrikDatabase.ps1
@@ -16,7 +16,7 @@ function Get-RubrikDatabase
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikDatabase -Name 'DB1' -SLA Gold

--- a/Rubrik/Public/Get-RubrikDatabase.ps1
+++ b/Rubrik/Public/Get-RubrikDatabase.ps1
@@ -16,7 +16,7 @@ function Get-RubrikDatabase
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikDatabase -Name 'DB1' -SLA Gold

--- a/Rubrik/Public/Get-RubrikDatabaseFiles.ps1
+++ b/Rubrik/Public/Get-RubrikDatabaseFiles.ps1
@@ -20,7 +20,7 @@ function Get-RubrikDatabaseFiles
       GitHub: MikeFal
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikDatabaseFiles -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/Get-RubrikDatabaseFiles.ps1
+++ b/Rubrik/Public/Get-RubrikDatabaseFiles.ps1
@@ -20,7 +20,7 @@ function Get-RubrikDatabaseFiles
       GitHub: MikeFal
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikDatabaseFiles.html
             
       .EXAMPLE
       Get-RubrikDatabaseFiles -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/Get-RubrikDatabaseFiles.ps1
+++ b/Rubrik/Public/Get-RubrikDatabaseFiles.ps1
@@ -20,7 +20,7 @@ function Get-RubrikDatabaseFiles
       GitHub: MikeFal
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikDatabaseFiles -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/Get-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/Get-RubrikDatabaseMount.ps1
@@ -15,7 +15,7 @@ function Get-RubrikDatabaseMount
       GitHub: MikeFal
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikDatabaseMount.html
             
       .EXAMPLE
       Get-RubrikDatabaseMount

--- a/Rubrik/Public/Get-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/Get-RubrikDatabaseMount.ps1
@@ -15,7 +15,7 @@ function Get-RubrikDatabaseMount
       GitHub: MikeFal
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikDatabaseMount

--- a/Rubrik/Public/Get-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/Get-RubrikDatabaseMount.ps1
@@ -15,7 +15,7 @@ function Get-RubrikDatabaseMount
       GitHub: MikeFal
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikDatabaseMount

--- a/Rubrik/Public/Get-RubrikDatabaseRecoverableRange.ps1
+++ b/Rubrik/Public/Get-RubrikDatabaseRecoverableRange.ps1
@@ -15,7 +15,7 @@ function Get-RubrikDatabaseRecoverableRange
       GitHub: MikeFal
       
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikDatabase -Hostname FOO -Database BAR | Get-RubrikDatabaseRecoverableRange

--- a/Rubrik/Public/Get-RubrikDatabaseRecoverableRange.ps1
+++ b/Rubrik/Public/Get-RubrikDatabaseRecoverableRange.ps1
@@ -15,7 +15,7 @@ function Get-RubrikDatabaseRecoverableRange
       GitHub: MikeFal
       
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikDatabase -Hostname FOO -Database BAR | Get-RubrikDatabaseRecoverableRange

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -16,7 +16,7 @@ function Get-RubrikFileset
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikFileset -Name 'C_Drive' 

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -16,7 +16,7 @@ function Get-RubrikFileset
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikFileset.html
 
       .EXAMPLE
       Get-RubrikFileset -Name 'C_Drive' 

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -16,7 +16,7 @@ function Get-RubrikFileset
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikFileset -Name 'C_Drive' 

--- a/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
+++ b/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
@@ -14,7 +14,7 @@ function Get-RubrikFilesetTemplate
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikFilesetTemplate.html
 
       .EXAMPLE
       Get-RubrikFilesetTemplate -Name 'Template1'

--- a/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
+++ b/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
@@ -14,7 +14,7 @@ function Get-RubrikFilesetTemplate
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikFilesetTemplate -Name 'Template1'

--- a/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
+++ b/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
@@ -14,7 +14,7 @@ function Get-RubrikFilesetTemplate
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikFilesetTemplate -Name 'Template1'

--- a/Rubrik/Public/Get-RubrikHost.ps1
+++ b/Rubrik/Public/Get-RubrikHost.ps1
@@ -14,7 +14,7 @@ function Get-RubrikHost
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikHost.html
 
       .EXAMPLE
       Get-RubrikHost

--- a/Rubrik/Public/Get-RubrikHost.ps1
+++ b/Rubrik/Public/Get-RubrikHost.ps1
@@ -14,7 +14,7 @@ function Get-RubrikHost
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikHost

--- a/Rubrik/Public/Get-RubrikHost.ps1
+++ b/Rubrik/Public/Get-RubrikHost.ps1
@@ -14,7 +14,7 @@ function Get-RubrikHost
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikHost

--- a/Rubrik/Public/Get-RubrikHyperVVM.ps1
+++ b/Rubrik/Public/Get-RubrikHyperVVM.ps1
@@ -14,7 +14,7 @@ function Get-RubrikHyperVVM
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikHyperVVM -Name 'Server1'

--- a/Rubrik/Public/Get-RubrikHyperVVM.ps1
+++ b/Rubrik/Public/Get-RubrikHyperVVM.ps1
@@ -14,7 +14,7 @@ function Get-RubrikHyperVVM
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikHyperVVM -Name 'Server1'

--- a/Rubrik/Public/Get-RubrikLogShipping.ps1
+++ b/Rubrik/Public/Get-RubrikLogShipping.ps1
@@ -15,7 +15,7 @@ function Get-RubrikLogShipping
       Any other links you'd like here
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get all log shipping configurations

--- a/Rubrik/Public/Get-RubrikLogShipping.ps1
+++ b/Rubrik/Public/Get-RubrikLogShipping.ps1
@@ -15,7 +15,7 @@ function Get-RubrikLogShipping
       Any other links you'd like here
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get all log shipping configurations

--- a/Rubrik/Public/Get-RubrikManagedVolume.ps1
+++ b/Rubrik/Public/Get-RubrikManagedVolume.ps1
@@ -16,7 +16,7 @@ function Get-RubrikManagedVolume
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikManagedVolume -name sqltest

--- a/Rubrik/Public/Get-RubrikManagedVolume.ps1
+++ b/Rubrik/Public/Get-RubrikManagedVolume.ps1
@@ -16,7 +16,7 @@ function Get-RubrikManagedVolume
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikManagedVolume -name sqltest

--- a/Rubrik/Public/Get-RubrikManagedVolumeExport.ps1
+++ b/Rubrik/Public/Get-RubrikManagedVolumeExport.ps1
@@ -15,7 +15,7 @@ function Get-RubrikManagedVolumeExport
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikManagedVolumeExport

--- a/Rubrik/Public/Get-RubrikManagedVolumeExport.ps1
+++ b/Rubrik/Public/Get-RubrikManagedVolumeExport.ps1
@@ -15,7 +15,7 @@ function Get-RubrikManagedVolumeExport
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikManagedVolumeExport

--- a/Rubrik/Public/Get-RubrikMount.ps1
+++ b/Rubrik/Public/Get-RubrikMount.ps1
@@ -17,7 +17,7 @@ function Get-RubrikMount
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikMount

--- a/Rubrik/Public/Get-RubrikMount.ps1
+++ b/Rubrik/Public/Get-RubrikMount.ps1
@@ -17,7 +17,7 @@ function Get-RubrikMount
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikMount

--- a/Rubrik/Public/Get-RubrikMount.ps1
+++ b/Rubrik/Public/Get-RubrikMount.ps1
@@ -17,7 +17,7 @@ function Get-RubrikMount
       GitHub: chriswahl
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikMount.html
             
       .EXAMPLE
       Get-RubrikMount

--- a/Rubrik/Public/Get-RubrikNASShare.ps1
+++ b/Rubrik/Public/Get-RubrikNASShare.ps1
@@ -14,7 +14,7 @@ function Get-RubrikNASShare
       GitHub: MikeFal
       
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikNASShare -ShareType 'SMB'

--- a/Rubrik/Public/Get-RubrikNASShare.ps1
+++ b/Rubrik/Public/Get-RubrikNASShare.ps1
@@ -14,7 +14,7 @@ function Get-RubrikNASShare
       GitHub: MikeFal
       
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikNASShare -ShareType 'SMB'

--- a/Rubrik/Public/Get-RubrikNutanixVM.ps1
+++ b/Rubrik/Public/Get-RubrikNutanixVM.ps1
@@ -14,7 +14,7 @@ function Get-RubrikNutanixVM
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikNutanixVM -Name 'Server1'

--- a/Rubrik/Public/Get-RubrikNutanixVM.ps1
+++ b/Rubrik/Public/Get-RubrikNutanixVM.ps1
@@ -14,7 +14,7 @@ function Get-RubrikNutanixVM
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikNutanixVM -Name 'Server1'

--- a/Rubrik/Public/Get-RubrikOrganization.ps1
+++ b/Rubrik/Public/Get-RubrikOrganization.ps1
@@ -15,7 +15,7 @@ function Get-RubrikOrganization
       GitHub: MikeFal
       
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikOrganization

--- a/Rubrik/Public/Get-RubrikOrganization.ps1
+++ b/Rubrik/Public/Get-RubrikOrganization.ps1
@@ -15,7 +15,7 @@ function Get-RubrikOrganization
       GitHub: MikeFal
       
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikOrganization

--- a/Rubrik/Public/Get-RubrikReport.ps1
+++ b/Rubrik/Public/Get-RubrikReport.ps1
@@ -14,7 +14,7 @@ function Get-RubrikReport
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikReport

--- a/Rubrik/Public/Get-RubrikReport.ps1
+++ b/Rubrik/Public/Get-RubrikReport.ps1
@@ -14,7 +14,7 @@ function Get-RubrikReport
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikReport.html
 
       .EXAMPLE
       Get-RubrikReport

--- a/Rubrik/Public/Get-RubrikReport.ps1
+++ b/Rubrik/Public/Get-RubrikReport.ps1
@@ -14,7 +14,7 @@ function Get-RubrikReport
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikReport

--- a/Rubrik/Public/Get-RubrikReportData.ps1
+++ b/Rubrik/Public/Get-RubrikReportData.ps1
@@ -14,7 +14,7 @@ function Get-RubrikReportData
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikReport -Name 'SLA Compliance Summary' | Get-RubrikReportData

--- a/Rubrik/Public/Get-RubrikReportData.ps1
+++ b/Rubrik/Public/Get-RubrikReportData.ps1
@@ -14,7 +14,7 @@ function Get-RubrikReportData
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikReportData.html
 
       .EXAMPLE
       Get-RubrikReport -Name 'SLA Compliance Summary' | Get-RubrikReportData

--- a/Rubrik/Public/Get-RubrikReportData.ps1
+++ b/Rubrik/Public/Get-RubrikReportData.ps1
@@ -14,7 +14,7 @@ function Get-RubrikReportData
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikReport -Name 'SLA Compliance Summary' | Get-RubrikReportData

--- a/Rubrik/Public/Get-RubrikRequest.ps1
+++ b/Rubrik/Public/Get-RubrikRequest.ps1
@@ -15,7 +15,7 @@ function Get-RubrikRequest
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikRequest -id 'MOUNT_SNAPSHOT_123456789:::0' -Type 'vmware/vm'

--- a/Rubrik/Public/Get-RubrikRequest.ps1
+++ b/Rubrik/Public/Get-RubrikRequest.ps1
@@ -15,7 +15,7 @@ function Get-RubrikRequest
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikRequest -id 'MOUNT_SNAPSHOT_123456789:::0' -Type 'vmware/vm'

--- a/Rubrik/Public/Get-RubrikRequest.ps1
+++ b/Rubrik/Public/Get-RubrikRequest.ps1
@@ -15,7 +15,7 @@ function Get-RubrikRequest
       GitHub: chriswahl
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikRequest.html
             
       .EXAMPLE
       Get-RubrikRequest -id 'MOUNT_SNAPSHOT_123456789:::0' -Type 'vmware/vm'

--- a/Rubrik/Public/Get-RubrikSLA.ps1
+++ b/Rubrik/Public/Get-RubrikSLA.ps1
@@ -15,7 +15,7 @@ function Get-RubrikSLA
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikSLA

--- a/Rubrik/Public/Get-RubrikSLA.ps1
+++ b/Rubrik/Public/Get-RubrikSLA.ps1
@@ -15,7 +15,7 @@ function Get-RubrikSLA
       GitHub: chriswahl
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikSLA.html
             
       .EXAMPLE
       Get-RubrikSLA

--- a/Rubrik/Public/Get-RubrikSLA.ps1
+++ b/Rubrik/Public/Get-RubrikSLA.ps1
@@ -15,7 +15,7 @@ function Get-RubrikSLA
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikSLA

--- a/Rubrik/Public/Get-RubrikSQLInstance.ps1
+++ b/Rubrik/Public/Get-RubrikSQLInstance.ps1
@@ -14,7 +14,7 @@ function Get-RubrikSQLInstance
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikSQLInstance -Name MSSQLSERVER

--- a/Rubrik/Public/Get-RubrikSQLInstance.ps1
+++ b/Rubrik/Public/Get-RubrikSQLInstance.ps1
@@ -14,7 +14,7 @@ function Get-RubrikSQLInstance
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikSQLInstance -Name MSSQLSERVER

--- a/Rubrik/Public/Get-RubrikSnapshot.ps1
+++ b/Rubrik/Public/Get-RubrikSnapshot.ps1
@@ -16,7 +16,7 @@ function Get-RubrikSnapshot
       GitHub: chriswahl
       
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
       
       .EXAMPLE
       Get-RubrikSnapshot -id 'VirtualMachine:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-vm-12345'

--- a/Rubrik/Public/Get-RubrikSnapshot.ps1
+++ b/Rubrik/Public/Get-RubrikSnapshot.ps1
@@ -16,7 +16,7 @@ function Get-RubrikSnapshot
       GitHub: chriswahl
       
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikSnapshot.html
       
       .EXAMPLE
       Get-RubrikSnapshot -id 'VirtualMachine:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-vm-12345'

--- a/Rubrik/Public/Get-RubrikSnapshot.ps1
+++ b/Rubrik/Public/Get-RubrikSnapshot.ps1
@@ -16,7 +16,7 @@ function Get-RubrikSnapshot
       GitHub: chriswahl
       
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
       
       .EXAMPLE
       Get-RubrikSnapshot -id 'VirtualMachine:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-vm-12345'

--- a/Rubrik/Public/Get-RubrikSoftwareVersion.ps1
+++ b/Rubrik/Public/Get-RubrikSoftwareVersion.ps1
@@ -14,7 +14,7 @@ function Get-RubrikSoftwareVersion
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikSoftwareVersion -Server 192.168.1.100

--- a/Rubrik/Public/Get-RubrikSoftwareVersion.ps1
+++ b/Rubrik/Public/Get-RubrikSoftwareVersion.ps1
@@ -14,7 +14,7 @@ function Get-RubrikSoftwareVersion
       GitHub: chriswahl
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikSoftwareVersion.html
             
       .EXAMPLE
       Get-RubrikSoftwareVersion -Server 192.168.1.100

--- a/Rubrik/Public/Get-RubrikSoftwareVersion.ps1
+++ b/Rubrik/Public/Get-RubrikSoftwareVersion.ps1
@@ -14,7 +14,7 @@ function Get-RubrikSoftwareVersion
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikSoftwareVersion -Server 192.168.1.100

--- a/Rubrik/Public/Get-RubrikSupportTunnel.ps1
+++ b/Rubrik/Public/Get-RubrikSupportTunnel.ps1
@@ -15,7 +15,7 @@ function Get-RubrikSupportTunnel
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikSupportTunnel

--- a/Rubrik/Public/Get-RubrikSupportTunnel.ps1
+++ b/Rubrik/Public/Get-RubrikSupportTunnel.ps1
@@ -15,7 +15,7 @@ function Get-RubrikSupportTunnel
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikSupportTunnel

--- a/Rubrik/Public/Get-RubrikUnmanagedObject.ps1
+++ b/Rubrik/Public/Get-RubrikUnmanagedObject.ps1
@@ -15,7 +15,7 @@ function Get-RubrikUnmanagedObject
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikUnmanagedObject -Type 'WindowsFileset'

--- a/Rubrik/Public/Get-RubrikUnmanagedObject.ps1
+++ b/Rubrik/Public/Get-RubrikUnmanagedObject.ps1
@@ -15,7 +15,7 @@ function Get-RubrikUnmanagedObject
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikUnmanagedObject -Type 'WindowsFileset'

--- a/Rubrik/Public/Get-RubrikUnmanagedObject.ps1
+++ b/Rubrik/Public/Get-RubrikUnmanagedObject.ps1
@@ -15,7 +15,7 @@ function Get-RubrikUnmanagedObject
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikUnmanagedObject.html
 
       .EXAMPLE
       Get-RubrikUnmanagedObject -Type 'WindowsFileset'

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -14,7 +14,7 @@ function Get-RubrikVM
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikVM -Name 'Server1'

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -14,7 +14,7 @@ function Get-RubrikVM
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikVM.html
 
       .EXAMPLE
       Get-RubrikVM -Name 'Server1'

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -14,7 +14,7 @@ function Get-RubrikVM
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikVM -Name 'Server1'

--- a/Rubrik/Public/Get-RubrikVMSnapshot.ps1
+++ b/Rubrik/Public/Get-RubrikVMSnapshot.ps1
@@ -13,7 +13,7 @@ function Get-RubrikVMSnapshot
       Twitter: @PierreFlammer
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikVMSnapshot -id 'cc1b363a-a0d4-40b7-9b09-7b8f3a805b27'

--- a/Rubrik/Public/Get-RubrikVMSnapshot.ps1
+++ b/Rubrik/Public/Get-RubrikVMSnapshot.ps1
@@ -13,7 +13,7 @@ function Get-RubrikVMSnapshot
       Twitter: @PierreFlammer
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikVMSnapshot -id 'cc1b363a-a0d4-40b7-9b09-7b8f3a805b27'

--- a/Rubrik/Public/Get-RubrikVersion.ps1
+++ b/Rubrik/Public/Get-RubrikVersion.ps1
@@ -14,7 +14,7 @@ function Get-RubrikVersion
       GitHub: chriswahl
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Get-RubrikVersion.html
             
       .EXAMPLE
       Get-RubrikVersion

--- a/Rubrik/Public/Get-RubrikVersion.ps1
+++ b/Rubrik/Public/Get-RubrikVersion.ps1
@@ -14,7 +14,7 @@ function Get-RubrikVersion
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikVersion

--- a/Rubrik/Public/Get-RubrikVersion.ps1
+++ b/Rubrik/Public/Get-RubrikVersion.ps1
@@ -14,7 +14,7 @@ function Get-RubrikVersion
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikVersion

--- a/Rubrik/Public/Get-RubrikVolumeGroup.ps1
+++ b/Rubrik/Public/Get-RubrikVolumeGroup.ps1
@@ -13,7 +13,7 @@ function Get-RubrikVolumeGroup
       Twitter: @PierreFlammer
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikVolumeGroup -Name 'Server1'

--- a/Rubrik/Public/Get-RubrikVolumeGroup.ps1
+++ b/Rubrik/Public/Get-RubrikVolumeGroup.ps1
@@ -13,7 +13,7 @@ function Get-RubrikVolumeGroup
       Twitter: @PierreFlammer
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikVolumeGroup -Name 'Server1'

--- a/Rubrik/Public/Get-RubrikVolumeGroupMount.ps1
+++ b/Rubrik/Public/Get-RubrikVolumeGroupMount.ps1
@@ -14,7 +14,7 @@ function Get-RubrikVolumeGroupMount
       Twitter: @PierreFlammer
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikVolumeGroupMount

--- a/Rubrik/Public/Get-RubrikVolumeGroupMount.ps1
+++ b/Rubrik/Public/Get-RubrikVolumeGroupMount.ps1
@@ -14,7 +14,7 @@ function Get-RubrikVolumeGroupMount
       Twitter: @PierreFlammer
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikVolumeGroupMount

--- a/Rubrik/Public/Invoke-RubrikRESTCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikRESTCall.ps1
@@ -17,7 +17,7 @@ function Invoke-RubrikRESTCall {
       GitHub: mikefal
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Invoke-RubrikRESTCall.html
 
       .EXAMPLE
       Invoke-RubrikRESTCall -Endpoint 'vmware/vm' -Method GET

--- a/Rubrik/Public/Invoke-RubrikRESTCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikRESTCall.ps1
@@ -17,7 +17,7 @@ function Invoke-RubrikRESTCall {
       GitHub: mikefal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Invoke-RubrikRESTCall -Endpoint 'vmware/vm' -Method GET

--- a/Rubrik/Public/Invoke-RubrikRESTCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikRESTCall.ps1
@@ -17,7 +17,7 @@ function Invoke-RubrikRESTCall {
       GitHub: mikefal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Invoke-RubrikRESTCall -Endpoint 'vmware/vm' -Method GET

--- a/Rubrik/Public/Move-RubrikMountVMDK.ps1
+++ b/Rubrik/Public/Move-RubrikMountVMDK.ps1
@@ -14,7 +14,7 @@ function Move-RubrikMountVMDK
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Move-RubrikMountVMDK -SourceVMID (Get-RubrikVM -Name 'SourceVM').id -TargetVM 'TargetVM'

--- a/Rubrik/Public/Move-RubrikMountVMDK.ps1
+++ b/Rubrik/Public/Move-RubrikMountVMDK.ps1
@@ -14,7 +14,7 @@ function Move-RubrikMountVMDK
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Move-RubrikMountVMDK.html
 
       .EXAMPLE
       Move-RubrikMountVMDK -SourceVMID (Get-RubrikVM -Name 'SourceVM').id -TargetVM 'TargetVM'

--- a/Rubrik/Public/Move-RubrikMountVMDK.ps1
+++ b/Rubrik/Public/Move-RubrikMountVMDK.ps1
@@ -14,7 +14,7 @@ function Move-RubrikMountVMDK
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Move-RubrikMountVMDK -SourceVMID (Get-RubrikVM -Name 'SourceVM').id -TargetVM 'TargetVM'

--- a/Rubrik/Public/New-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/New-RubrikDatabaseMount.ps1
@@ -14,7 +14,7 @@ function New-RubrikDatabaseMount
       GitHub: MikeFal
       
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/New-RubrikDatabaseMount.html
 
       .EXAMPLE
       New-RubrikDatabaseMount -id $db.id -targetInstanceId $db.instanceId -mountedDatabaseName 'BAR-LM' -recoveryDateTime (Get-date (Get-RubrikDatabase -id $db.id).latestRecoveryPoint)

--- a/Rubrik/Public/New-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/New-RubrikDatabaseMount.ps1
@@ -14,7 +14,7 @@ function New-RubrikDatabaseMount
       GitHub: MikeFal
       
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       New-RubrikDatabaseMount -id $db.id -targetInstanceId $db.instanceId -mountedDatabaseName 'BAR-LM' -recoveryDateTime (Get-date (Get-RubrikDatabase -id $db.id).latestRecoveryPoint)

--- a/Rubrik/Public/New-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/New-RubrikDatabaseMount.ps1
@@ -14,7 +14,7 @@ function New-RubrikDatabaseMount
       GitHub: MikeFal
       
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       New-RubrikDatabaseMount -id $db.id -targetInstanceId $db.instanceId -mountedDatabaseName 'BAR-LM' -recoveryDateTime (Get-date (Get-RubrikDatabase -id $db.id).latestRecoveryPoint)

--- a/Rubrik/Public/New-RubrikFileset.ps1
+++ b/Rubrik/Public/New-RubrikFileset.ps1
@@ -15,7 +15,7 @@ function New-RubrikFileset
       Any other links you'd like here
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       New-RubrikFileset -TemplateID '1111-1111-1111-1111' -HostID 'Host::::2222-2222-2222-2222'

--- a/Rubrik/Public/New-RubrikFileset.ps1
+++ b/Rubrik/Public/New-RubrikFileset.ps1
@@ -15,7 +15,7 @@ function New-RubrikFileset
       Any other links you'd like here
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       New-RubrikFileset -TemplateID '1111-1111-1111-1111' -HostID 'Host::::2222-2222-2222-2222'

--- a/Rubrik/Public/New-RubrikFilesetTemplate.ps1
+++ b/Rubrik/Public/New-RubrikFilesetTemplate.ps1
@@ -19,7 +19,7 @@ function New-RubrikFilesetTemplate
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       New-RubrikFilesetTemplate -Name 'FOO' -UseWindowsVSS -OperatingSystemType 'Windows' -Includes 'C:\*.mp3','C:\*.csv'

--- a/Rubrik/Public/New-RubrikFilesetTemplate.ps1
+++ b/Rubrik/Public/New-RubrikFilesetTemplate.ps1
@@ -19,7 +19,7 @@ function New-RubrikFilesetTemplate
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       New-RubrikFilesetTemplate -Name 'FOO' -UseWindowsVSS -OperatingSystemType 'Windows' -Includes 'C:\*.mp3','C:\*.csv'

--- a/Rubrik/Public/New-RubrikHost.ps1
+++ b/Rubrik/Public/New-RubrikHost.ps1
@@ -14,7 +14,7 @@ function New-RubrikHost
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       New-RubrikHost -Name 'Server1.example.com'

--- a/Rubrik/Public/New-RubrikHost.ps1
+++ b/Rubrik/Public/New-RubrikHost.ps1
@@ -14,7 +14,7 @@ function New-RubrikHost
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       New-RubrikHost -Name 'Server1.example.com'

--- a/Rubrik/Public/New-RubrikHost.ps1
+++ b/Rubrik/Public/New-RubrikHost.ps1
@@ -14,7 +14,7 @@ function New-RubrikHost
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/New-RubrikHost.html
 
       .EXAMPLE
       New-RubrikHost -Name 'Server1.example.com'

--- a/Rubrik/Public/New-RubrikLogBackup.ps1
+++ b/Rubrik/Public/New-RubrikLogBackup.ps1
@@ -14,7 +14,7 @@ function New-RubrikLogBackup
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       New-RubrikLogBackup -id MssqlDatabase:::c5ecf3ef-248d-4bb2-8fe1-4d3c820a0e38 

--- a/Rubrik/Public/New-RubrikLogBackup.ps1
+++ b/Rubrik/Public/New-RubrikLogBackup.ps1
@@ -14,7 +14,7 @@ function New-RubrikLogBackup
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       New-RubrikLogBackup -id MssqlDatabase:::c5ecf3ef-248d-4bb2-8fe1-4d3c820a0e38 

--- a/Rubrik/Public/New-RubrikLogShipping.ps1
+++ b/Rubrik/Public/New-RubrikLogShipping.ps1
@@ -15,7 +15,7 @@ function New-RubrikLogShipping
   
 
   .LINK
-  https://github.com/rubrikinc/rubrik-sdk-for-powershell
+  http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
   .EXAMPLE
   $RubrikDatabase = Get-RubrikDatabase -Name 'AthenaAM1-SQL16-1-2016' -Hostname am1-sql16-1

--- a/Rubrik/Public/New-RubrikLogShipping.ps1
+++ b/Rubrik/Public/New-RubrikLogShipping.ps1
@@ -15,7 +15,7 @@ function New-RubrikLogShipping
   
 
   .LINK
-  https://github.com/rubrikinc/PowerShell-Module
+  https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
   .EXAMPLE
   $RubrikDatabase = Get-RubrikDatabase -Name 'AthenaAM1-SQL16-1-2016' -Hostname am1-sql16-1

--- a/Rubrik/Public/New-RubrikManagedVolume.ps1
+++ b/Rubrik/Public/New-RubrikManagedVolume.ps1
@@ -15,7 +15,7 @@ function New-RubrikManagedVolume
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       New-RubrikManagedVolume -Name foo -Channels 4 -VolumeSize 1073741824000

--- a/Rubrik/Public/New-RubrikManagedVolume.ps1
+++ b/Rubrik/Public/New-RubrikManagedVolume.ps1
@@ -15,7 +15,7 @@ function New-RubrikManagedVolume
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       New-RubrikManagedVolume -Name foo -Channels 4 -VolumeSize 1073741824000

--- a/Rubrik/Public/New-RubrikManagedVolumeExport.ps1
+++ b/Rubrik/Public/New-RubrikManagedVolumeExport.ps1
@@ -15,7 +15,7 @@ function New-RubrikManagedVolumeExport
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikSnapshot -id ManagedVolume:::f68ecd45-bdb9-46dd-aea4-8f041fb2dec2 | Select-Object -First 1 | New-RubrikManagedVolumeExport

--- a/Rubrik/Public/New-RubrikManagedVolumeExport.ps1
+++ b/Rubrik/Public/New-RubrikManagedVolumeExport.ps1
@@ -15,7 +15,7 @@ function New-RubrikManagedVolumeExport
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikSnapshot -id ManagedVolume:::f68ecd45-bdb9-46dd-aea4-8f041fb2dec2 | Select-Object -First 1 | New-RubrikManagedVolumeExport

--- a/Rubrik/Public/New-RubrikMount.ps1
+++ b/Rubrik/Public/New-RubrikMount.ps1
@@ -14,7 +14,7 @@ function New-RubrikMount
       GitHub: chriswahl
       
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/New-RubrikMount.html
 
       .EXAMPLE
       New-RubrikMount -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/New-RubrikMount.ps1
+++ b/Rubrik/Public/New-RubrikMount.ps1
@@ -14,7 +14,7 @@ function New-RubrikMount
       GitHub: chriswahl
       
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       New-RubrikMount -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/New-RubrikMount.ps1
+++ b/Rubrik/Public/New-RubrikMount.ps1
@@ -14,7 +14,7 @@ function New-RubrikMount
       GitHub: chriswahl
       
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       New-RubrikMount -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/New-RubrikNASShare.ps1
+++ b/Rubrik/Public/New-RubrikNASShare.ps1
@@ -16,7 +16,7 @@ function New-RubrikNASShare
       GitHub: MikeFal
       
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       New-RubrikNASShare -HostID (Get-RubrikHost 'FOO').id -ShareType NFS -ExportPoint BAR -Credential (Get-Credential)

--- a/Rubrik/Public/New-RubrikNASShare.ps1
+++ b/Rubrik/Public/New-RubrikNASShare.ps1
@@ -16,7 +16,7 @@ function New-RubrikNASShare
       GitHub: MikeFal
       
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       New-RubrikNASShare -HostID (Get-RubrikHost 'FOO').id -ShareType NFS -ExportPoint BAR -Credential (Get-Credential)

--- a/Rubrik/Public/New-RubrikReport.ps1
+++ b/Rubrik/Public/New-RubrikReport.ps1
@@ -14,7 +14,7 @@ function New-RubrikReport
       GitHub: chriswahl
       
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       New-RubrikReport -Name 'Report1' -ReportTemplate 'ProtectionTasksDetails'

--- a/Rubrik/Public/New-RubrikReport.ps1
+++ b/Rubrik/Public/New-RubrikReport.ps1
@@ -14,7 +14,7 @@ function New-RubrikReport
       GitHub: chriswahl
       
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       New-RubrikReport -Name 'Report1' -ReportTemplate 'ProtectionTasksDetails'

--- a/Rubrik/Public/New-RubrikReport.ps1
+++ b/Rubrik/Public/New-RubrikReport.ps1
@@ -14,7 +14,7 @@ function New-RubrikReport
       GitHub: chriswahl
       
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/New-RubrikReport.html
 
       .EXAMPLE
       New-RubrikReport -Name 'Report1' -ReportTemplate 'ProtectionTasksDetails'

--- a/Rubrik/Public/New-RubrikSLA.ps1
+++ b/Rubrik/Public/New-RubrikSLA.ps1
@@ -14,7 +14,7 @@ function New-RubrikSLA
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       New-RubrikSLA -SLA 'Test1' -HourlyFrequency 4 -HourlyRetention 24

--- a/Rubrik/Public/New-RubrikSLA.ps1
+++ b/Rubrik/Public/New-RubrikSLA.ps1
@@ -14,7 +14,7 @@ function New-RubrikSLA
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       New-RubrikSLA -SLA 'Test1' -HourlyFrequency 4 -HourlyRetention 24

--- a/Rubrik/Public/New-RubrikSLA.ps1
+++ b/Rubrik/Public/New-RubrikSLA.ps1
@@ -14,7 +14,7 @@ function New-RubrikSLA
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/New-RubrikSLA.html
 
       .EXAMPLE
       New-RubrikSLA -SLA 'Test1' -HourlyFrequency 4 -HourlyRetention 24

--- a/Rubrik/Public/New-RubrikSnapshot.ps1
+++ b/Rubrik/Public/New-RubrikSnapshot.ps1
@@ -14,7 +14,7 @@ function New-RubrikSnapshot
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/New-RubrikSnapshot.html
 
       .EXAMPLE
       Get-RubrikVM 'Server1' | New-RubrikSnapshot -Forever

--- a/Rubrik/Public/New-RubrikSnapshot.ps1
+++ b/Rubrik/Public/New-RubrikSnapshot.ps1
@@ -14,7 +14,7 @@ function New-RubrikSnapshot
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikVM 'Server1' | New-RubrikSnapshot -Forever

--- a/Rubrik/Public/New-RubrikSnapshot.ps1
+++ b/Rubrik/Public/New-RubrikSnapshot.ps1
@@ -14,7 +14,7 @@ function New-RubrikSnapshot
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikVM 'Server1' | New-RubrikSnapshot -Forever

--- a/Rubrik/Public/New-RubrikVMDKMount.ps1
+++ b/Rubrik/Public/New-RubrikVMDKMount.ps1
@@ -13,7 +13,7 @@ function New-RubrikVMDKMount
       Twitter: @PierreFlammer
       
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .PARAMETER
       ATTENTION: Names have to match the names configured in Rubrik!!!

--- a/Rubrik/Public/New-RubrikVMDKMount.ps1
+++ b/Rubrik/Public/New-RubrikVMDKMount.ps1
@@ -13,7 +13,7 @@ function New-RubrikVMDKMount
       Twitter: @PierreFlammer
       
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .PARAMETER
       ATTENTION: Names have to match the names configured in Rubrik!!!

--- a/Rubrik/Public/New-RubrikVolumeGroupMount.ps1
+++ b/Rubrik/Public/New-RubrikVolumeGroupMount.ps1
@@ -14,7 +14,7 @@ function New-RubrikVolumeGroupMount
       Twitter: @PierreFlammer
       
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       New-RubrikVolumeGroupMount -TargetHost 'Restore-Server1' -VolumeGroupSnapshot $snap -ExcludeDrives -$DrivestoExclude

--- a/Rubrik/Public/New-RubrikVolumeGroupMount.ps1
+++ b/Rubrik/Public/New-RubrikVolumeGroupMount.ps1
@@ -14,7 +14,7 @@ function New-RubrikVolumeGroupMount
       Twitter: @PierreFlammer
       
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       New-RubrikVolumeGroupMount -TargetHost 'Restore-Server1' -VolumeGroupSnapshot $snap -ExcludeDrives -$DrivestoExclude

--- a/Rubrik/Public/Protect-RubrikDatabase.ps1
+++ b/Rubrik/Public/Protect-RubrikDatabase.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikDatabase
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikDatabase "DB1" | Protect-RubrikDatabase -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikDatabase.ps1
+++ b/Rubrik/Public/Protect-RubrikDatabase.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikDatabase
       GitHub: chriswahl
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Protect-RubrikDatabase.html
             
       .EXAMPLE
       Get-RubrikDatabase "DB1" | Protect-RubrikDatabase -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikDatabase.ps1
+++ b/Rubrik/Public/Protect-RubrikDatabase.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikDatabase
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikDatabase "DB1" | Protect-RubrikDatabase -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikFileset.ps1
+++ b/Rubrik/Public/Protect-RubrikFileset.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikFileset
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikFileset 'C_Drive' | Protect-RubrikFileset -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikFileset.ps1
+++ b/Rubrik/Public/Protect-RubrikFileset.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikFileset
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikFileset 'C_Drive' | Protect-RubrikFileset -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikFileset.ps1
+++ b/Rubrik/Public/Protect-RubrikFileset.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikFileset
       GitHub: chriswahl
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Protect-RubrikFileset.html
             
       .EXAMPLE
       Get-RubrikFileset 'C_Drive' | Protect-RubrikFileset -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikHyperVVM.ps1
+++ b/Rubrik/Public/Protect-RubrikHyperVVM.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikHyperVVM
       GitHub: MikeFal
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikHyperVVM "VM1" | Protect-RubrikHyperVVM -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikHyperVVM.ps1
+++ b/Rubrik/Public/Protect-RubrikHyperVVM.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikHyperVVM
       GitHub: MikeFal
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikHyperVVM "VM1" | Protect-RubrikHyperVVM -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikNutanixVM.ps1
+++ b/Rubrik/Public/Protect-RubrikNutanixVM.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikNutanixVM
       GitHub: MikeFal
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikNutanixVM "VM1" | Protect-RubrikNutanixVM -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikNutanixVM.ps1
+++ b/Rubrik/Public/Protect-RubrikNutanixVM.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikNutanixVM
       GitHub: MikeFal
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikNutanixVM "VM1" | Protect-RubrikNutanixVM -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikTag.ps1
+++ b/Rubrik/Public/Protect-RubrikTag.ps1
@@ -16,7 +16,7 @@ function Protect-RubrikTag
       Twitter: @jasonburrell2
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Protect-RubrikTag.html
 
       .EXAMPLE
       Protect-RubrikTag -Tag 'Gold' -Category 'Rubrik' -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikTag.ps1
+++ b/Rubrik/Public/Protect-RubrikTag.ps1
@@ -16,7 +16,7 @@ function Protect-RubrikTag
       Twitter: @jasonburrell2
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Protect-RubrikTag -Tag 'Gold' -Category 'Rubrik' -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikTag.ps1
+++ b/Rubrik/Public/Protect-RubrikTag.ps1
@@ -16,7 +16,7 @@ function Protect-RubrikTag
       Twitter: @jasonburrell2
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Protect-RubrikTag -Tag 'Gold' -Category 'Rubrik' -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikVM.ps1
+++ b/Rubrik/Public/Protect-RubrikVM.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikVM
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikVM "VM1" | Protect-RubrikVM -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikVM.ps1
+++ b/Rubrik/Public/Protect-RubrikVM.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikVM
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikVM "VM1" | Protect-RubrikVM -SLA 'Gold'

--- a/Rubrik/Public/Protect-RubrikVM.ps1
+++ b/Rubrik/Public/Protect-RubrikVM.ps1
@@ -18,7 +18,7 @@ function Protect-RubrikVM
       GitHub: chriswahl
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Protect-RubrikVM.html
             
       .EXAMPLE
       Get-RubrikVM "VM1" | Protect-RubrikVM -SLA 'Gold'

--- a/Rubrik/Public/Remove-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/Remove-RubrikDatabaseMount.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikDatabaseMount
       GitHub: MikeFal
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Remove-RubrikDatabaseMount -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/Remove-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/Remove-RubrikDatabaseMount.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikDatabaseMount
       GitHub: MikeFal
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Remove-RubrikDatabaseMount.html
 
       .EXAMPLE
       Remove-RubrikDatabaseMount -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/Remove-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/Remove-RubrikDatabaseMount.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikDatabaseMount
       GitHub: MikeFal
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Remove-RubrikDatabaseMount -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/Remove-RubrikFileset.ps1
+++ b/Rubrik/Public/Remove-RubrikFileset.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikFileset
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikFileset -Name 'C_Drive' | Remove-RubrikHost

--- a/Rubrik/Public/Remove-RubrikFileset.ps1
+++ b/Rubrik/Public/Remove-RubrikFileset.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikFileset
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Remove-RubrikFileset.html
 
       .EXAMPLE
       Get-RubrikFileset -Name 'C_Drive' | Remove-RubrikHost

--- a/Rubrik/Public/Remove-RubrikFileset.ps1
+++ b/Rubrik/Public/Remove-RubrikFileset.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikFileset
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikFileset -Name 'C_Drive' | Remove-RubrikHost

--- a/Rubrik/Public/Remove-RubrikHost.ps1
+++ b/Rubrik/Public/Remove-RubrikHost.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikHost
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikHost -Name 'Server1.example.com' | Remove-RubrikHost

--- a/Rubrik/Public/Remove-RubrikHost.ps1
+++ b/Rubrik/Public/Remove-RubrikHost.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikHost
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikHost -Name 'Server1.example.com' | Remove-RubrikHost

--- a/Rubrik/Public/Remove-RubrikHost.ps1
+++ b/Rubrik/Public/Remove-RubrikHost.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikHost
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Remove-RubrikHost.html
 
       .EXAMPLE
       Get-RubrikHost -Name 'Server1.example.com' | Remove-RubrikHost

--- a/Rubrik/Public/Remove-RubrikLogShipping.ps1
+++ b/Rubrik/Public/Remove-RubrikLogShipping.ps1
@@ -15,7 +15,7 @@ function Remove-RubrikLogShipping
       
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikLogShipping -PrimaryDatabaseName 'AthenaAM1-SQL16-1-2016' -SecondaryDatabaseName 'AthenaAM1-SQL16-1-2016'  | Remove-RubrikLogShipping

--- a/Rubrik/Public/Remove-RubrikLogShipping.ps1
+++ b/Rubrik/Public/Remove-RubrikLogShipping.ps1
@@ -15,7 +15,7 @@ function Remove-RubrikLogShipping
       
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikLogShipping -PrimaryDatabaseName 'AthenaAM1-SQL16-1-2016' -SecondaryDatabaseName 'AthenaAM1-SQL16-1-2016'  | Remove-RubrikLogShipping

--- a/Rubrik/Public/Remove-RubrikManagedVolume.ps1
+++ b/Rubrik/Public/Remove-RubrikManagedVolume.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikManagedVolume
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Remove-RubrikManagedVolume -id ManagedVolume:::f68ecd45-bdb9-46dd-aea4-8f041fb2dec2

--- a/Rubrik/Public/Remove-RubrikManagedVolume.ps1
+++ b/Rubrik/Public/Remove-RubrikManagedVolume.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikManagedVolume
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Remove-RubrikManagedVolume -id ManagedVolume:::f68ecd45-bdb9-46dd-aea4-8f041fb2dec2

--- a/Rubrik/Public/Remove-RubrikManagedVolumeExport.ps1
+++ b/Rubrik/Public/Remove-RubrikManagedVolumeExport.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikManagedVolumeExport
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Remove-RubrikManagedVolumeExport -id deddca39-b8ca-407c-8f1c-af9866f7ba67

--- a/Rubrik/Public/Remove-RubrikManagedVolumeExport.ps1
+++ b/Rubrik/Public/Remove-RubrikManagedVolumeExport.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikManagedVolumeExport
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Remove-RubrikManagedVolumeExport -id deddca39-b8ca-407c-8f1c-af9866f7ba67

--- a/Rubrik/Public/Remove-RubrikMount.ps1
+++ b/Rubrik/Public/Remove-RubrikMount.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikMount
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Remove-RubrikMount -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/Remove-RubrikMount.ps1
+++ b/Rubrik/Public/Remove-RubrikMount.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikMount
       GitHub: chriswahl
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Remove-RubrikMount.html
 
       .EXAMPLE
       Remove-RubrikMount -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/Remove-RubrikMount.ps1
+++ b/Rubrik/Public/Remove-RubrikMount.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikMount
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Remove-RubrikMount -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/Remove-RubrikNASShare.ps1
+++ b/Rubrik/Public/Remove-RubrikNASShare.ps1
@@ -15,7 +15,7 @@ function Remove-RubrikNASShare
       Any other links you'd like here
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikNASShare -Name 'FOO' | Remove-RubrikNASShare

--- a/Rubrik/Public/Remove-RubrikNASShare.ps1
+++ b/Rubrik/Public/Remove-RubrikNASShare.ps1
@@ -15,7 +15,7 @@ function Remove-RubrikNASShare
       Any other links you'd like here
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikNASShare -Name 'FOO' | Remove-RubrikNASShare

--- a/Rubrik/Public/Remove-RubrikReport.ps1
+++ b/Rubrik/Public/Remove-RubrikReport.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikReport
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Remove-RubrikReport.html
 
       .EXAMPLE
       Get-RubrikReport | Remove-RubrikReport -Confirm:$true

--- a/Rubrik/Public/Remove-RubrikReport.ps1
+++ b/Rubrik/Public/Remove-RubrikReport.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikReport
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikReport | Remove-RubrikReport -Confirm:$true

--- a/Rubrik/Public/Remove-RubrikReport.ps1
+++ b/Rubrik/Public/Remove-RubrikReport.ps1
@@ -14,7 +14,7 @@ function Remove-RubrikReport
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikReport | Remove-RubrikReport -Confirm:$true

--- a/Rubrik/Public/Remove-RubrikSLA.ps1
+++ b/Rubrik/Public/Remove-RubrikSLA.ps1
@@ -15,7 +15,7 @@ function Remove-RubrikSLA
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
             
       .EXAMPLE
       Get-RubrikSLA -SLA 'Gold' | Remove-RubrikSLA

--- a/Rubrik/Public/Remove-RubrikSLA.ps1
+++ b/Rubrik/Public/Remove-RubrikSLA.ps1
@@ -15,7 +15,7 @@ function Remove-RubrikSLA
       GitHub: chriswahl
             
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Remove-RubrikSLA.html
             
       .EXAMPLE
       Get-RubrikSLA -SLA 'Gold' | Remove-RubrikSLA

--- a/Rubrik/Public/Remove-RubrikSLA.ps1
+++ b/Rubrik/Public/Remove-RubrikSLA.ps1
@@ -15,7 +15,7 @@ function Remove-RubrikSLA
       GitHub: chriswahl
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
             
       .EXAMPLE
       Get-RubrikSLA -SLA 'Gold' | Remove-RubrikSLA

--- a/Rubrik/Public/Remove-RubrikUnmanagedObject.ps1
+++ b/Rubrik/Public/Remove-RubrikUnmanagedObject.ps1
@@ -15,7 +15,7 @@ function Remove-RubrikUnmanagedObject
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikUnmanagedObject | Remove-RubrikUnmanagedObject

--- a/Rubrik/Public/Remove-RubrikUnmanagedObject.ps1
+++ b/Rubrik/Public/Remove-RubrikUnmanagedObject.ps1
@@ -15,7 +15,7 @@ function Remove-RubrikUnmanagedObject
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Remove-RubrikUnmanagedObject.html
 
       .EXAMPLE
       Get-RubrikUnmanagedObject | Remove-RubrikUnmanagedObject

--- a/Rubrik/Public/Remove-RubrikUnmanagedObject.ps1
+++ b/Rubrik/Public/Remove-RubrikUnmanagedObject.ps1
@@ -15,7 +15,7 @@ function Remove-RubrikUnmanagedObject
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikUnmanagedObject | Remove-RubrikUnmanagedObject

--- a/Rubrik/Public/Remove-RubrikVolumeGroupMount.ps1
+++ b/Rubrik/Public/Remove-RubrikVolumeGroupMount.ps1
@@ -13,7 +13,7 @@ function Remove-RubrikVolumeGroupMount
       Twitter: @PierreFlammer
             
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Remove-RubrikVolumeGroupMount -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/Remove-RubrikVolumeGroupMount.ps1
+++ b/Rubrik/Public/Remove-RubrikVolumeGroupMount.ps1
@@ -13,7 +13,7 @@ function Remove-RubrikVolumeGroupMount
       Twitter: @PierreFlammer
             
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Remove-RubrikVolumeGroupMount -id '11111111-2222-3333-4444-555555555555'

--- a/Rubrik/Public/Reset-RubrikLogShipping.ps1
+++ b/Rubrik/Public/Reset-RubrikLogShipping.ps1
@@ -15,7 +15,7 @@ function Reset-RubrikLogShipping
       
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikLogShipping -PrimaryDatabaseName 'AthenaAM1-SQL16-1-2016' -SecondaryDatabaseName 'AthenaAM1-SQL16-1-2016' | Reset-RubrikLogShipping -state STANDBY -DisconnectStandbyUsers

--- a/Rubrik/Public/Reset-RubrikLogShipping.ps1
+++ b/Rubrik/Public/Reset-RubrikLogShipping.ps1
@@ -15,7 +15,7 @@ function Reset-RubrikLogShipping
       
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikLogShipping -PrimaryDatabaseName 'AthenaAM1-SQL16-1-2016' -SecondaryDatabaseName 'AthenaAM1-SQL16-1-2016' | Reset-RubrikLogShipping -state STANDBY -DisconnectStandbyUsers

--- a/Rubrik/Public/Restore-RubrikDatabase.ps1
+++ b/Rubrik/Public/Restore-RubrikDatabase.ps1
@@ -25,7 +25,7 @@ function Restore-RubrikDatabase
       Restore the $db (where $db is the outoput of a Get-RubrikDatabase call) to the most recent recovery point for that database.
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
   #>
 
   [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]

--- a/Rubrik/Public/Restore-RubrikDatabase.ps1
+++ b/Rubrik/Public/Restore-RubrikDatabase.ps1
@@ -25,7 +25,7 @@ function Restore-RubrikDatabase
       Restore the $db (where $db is the outoput of a Get-RubrikDatabase call) to the most recent recovery point for that database.
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
   #>
 
   [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]

--- a/Rubrik/Public/Restore-RubrikDatabase.ps1
+++ b/Rubrik/Public/Restore-RubrikDatabase.ps1
@@ -25,7 +25,7 @@ function Restore-RubrikDatabase
       Restore the $db (where $db is the outoput of a Get-RubrikDatabase call) to the most recent recovery point for that database.
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Remove-RubrikDatabase.html
   #>
 
   [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]

--- a/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
+++ b/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
@@ -14,7 +14,7 @@ function Set-RubrikAvailabilityGroup
       GitHub: clumnah
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikAvailabilityGroup -GroupName 'am1-sql16ag-1ag' | Set-RubrikAvailabilityGroup -SLA GOLD

--- a/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
+++ b/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
@@ -14,7 +14,7 @@ function Set-RubrikAvailabilityGroup
       GitHub: clumnah
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikAvailabilityGroup -GroupName 'am1-sql16ag-1ag' | Set-RubrikAvailabilityGroup -SLA GOLD

--- a/Rubrik/Public/Set-RubrikBlackout.ps1
+++ b/Rubrik/Public/Set-RubrikBlackout.ps1
@@ -14,7 +14,7 @@ function Set-RubrikBlackout
       GitHub: pmilano1
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Set-RubrikBlackout -Set:[$true/$false]

--- a/Rubrik/Public/Set-RubrikBlackout.ps1
+++ b/Rubrik/Public/Set-RubrikBlackout.ps1
@@ -14,7 +14,7 @@ function Set-RubrikBlackout
       GitHub: pmilano1
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Set-RubrikBlacout.html
 
       .EXAMPLE
       Set-RubrikBlackout -Set:[$true/$false]

--- a/Rubrik/Public/Set-RubrikBlackout.ps1
+++ b/Rubrik/Public/Set-RubrikBlackout.ps1
@@ -14,7 +14,7 @@ function Set-RubrikBlackout
       GitHub: pmilano1
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Set-RubrikBlackout -Set:[$true/$false]

--- a/Rubrik/Public/Set-RubrikDatabase.ps1
+++ b/Rubrik/Public/Set-RubrikDatabase.ps1
@@ -14,7 +14,7 @@ function Set-RubrikDatabase
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Set-RubrikDatabase -id MssqlDatabase:::c5ecf3ef-248d-4bb2-8fe1-4d3c820a0e38 -LogBackupFrequencyInSeconds 900

--- a/Rubrik/Public/Set-RubrikDatabase.ps1
+++ b/Rubrik/Public/Set-RubrikDatabase.ps1
@@ -14,7 +14,7 @@ function Set-RubrikDatabase
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Set-RubrikDatabase -id MssqlDatabase:::c5ecf3ef-248d-4bb2-8fe1-4d3c820a0e38 -LogBackupFrequencyInSeconds 900

--- a/Rubrik/Public/Set-RubrikDatabase.ps1
+++ b/Rubrik/Public/Set-RubrikDatabase.ps1
@@ -14,7 +14,7 @@ function Set-RubrikDatabase
       GitHub: MikeFal
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Set-RubrikDatabase.html
 
       .EXAMPLE
       Set-RubrikDatabase -id MssqlDatabase:::c5ecf3ef-248d-4bb2-8fe1-4d3c820a0e38 -LogBackupFrequencyInSeconds 900

--- a/Rubrik/Public/Set-RubrikHyperVVM.ps1
+++ b/Rubrik/Public/Set-RubrikHyperVVM.ps1
@@ -14,7 +14,7 @@ function Set-RubrikHyperVVM
             GitHub: MikeFal
 
             .LINK
-            https://github.com/rubrikinc/PowerShell-Module
+            https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
             .EXAMPLE
             Get-RubrikHyperVVM 'Server1' | Set-RubrikHyperVVM -PauseBackups

--- a/Rubrik/Public/Set-RubrikHyperVVM.ps1
+++ b/Rubrik/Public/Set-RubrikHyperVVM.ps1
@@ -14,7 +14,7 @@ function Set-RubrikHyperVVM
             GitHub: MikeFal
 
             .LINK
-            https://github.com/rubrikinc/rubrik-sdk-for-powershell
+            http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
             .EXAMPLE
             Get-RubrikHyperVVM 'Server1' | Set-RubrikHyperVVM -PauseBackups

--- a/Rubrik/Public/Set-RubrikLogShipping.ps1
+++ b/Rubrik/Public/Set-RubrikLogShipping.ps1
@@ -15,7 +15,7 @@ function Set-RubrikLogShipping
       
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
        Get-RubrikLogShipping -PrimaryDatabaseName 'AthenaAM1-SQL16-1-2016' -SecondaryDatabaseName 'AthenaAM1-SQL16-1-2016' | Set-RubrikLogShipping -state STANDBY -DisconnectStandbyUsers

--- a/Rubrik/Public/Set-RubrikLogShipping.ps1
+++ b/Rubrik/Public/Set-RubrikLogShipping.ps1
@@ -15,7 +15,7 @@ function Set-RubrikLogShipping
       
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
        Get-RubrikLogShipping -PrimaryDatabaseName 'AthenaAM1-SQL16-1-2016' -SecondaryDatabaseName 'AthenaAM1-SQL16-1-2016' | Set-RubrikLogShipping -state STANDBY -DisconnectStandbyUsers

--- a/Rubrik/Public/Set-RubrikManagedVolume.ps1
+++ b/Rubrik/Public/Set-RubrikManagedVolume.ps1
@@ -14,7 +14,7 @@ function Set-RubrikManagedVolume
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Set-RubrikManagedVolume -id ManagedVolume:::f68ecd45-bdb9-46dd-aea4-8f041fb2dec2 -SLA 'Gold'

--- a/Rubrik/Public/Set-RubrikManagedVolume.ps1
+++ b/Rubrik/Public/Set-RubrikManagedVolume.ps1
@@ -14,7 +14,7 @@ function Set-RubrikManagedVolume
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Set-RubrikManagedVolume -id ManagedVolume:::f68ecd45-bdb9-46dd-aea4-8f041fb2dec2 -SLA 'Gold'

--- a/Rubrik/Public/Set-RubrikMount.ps1
+++ b/Rubrik/Public/Set-RubrikMount.ps1
@@ -14,7 +14,7 @@ function Set-RubrikMount
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikMount -id '11111111-2222-3333-4444-555555555555' | Set-RubrikMount -PowerOn:$true

--- a/Rubrik/Public/Set-RubrikMount.ps1
+++ b/Rubrik/Public/Set-RubrikMount.ps1
@@ -14,7 +14,7 @@ function Set-RubrikMount
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikMount -id '11111111-2222-3333-4444-555555555555' | Set-RubrikMount -PowerOn:$true

--- a/Rubrik/Public/Set-RubrikMount.ps1
+++ b/Rubrik/Public/Set-RubrikMount.ps1
@@ -14,7 +14,7 @@ function Set-RubrikMount
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Set-RubrikMount.html
 
       .EXAMPLE
       Get-RubrikMount -id '11111111-2222-3333-4444-555555555555' | Set-RubrikMount -PowerOn:$true

--- a/Rubrik/Public/Set-RubrikNASShare.ps1
+++ b/Rubrik/Public/Set-RubrikNASShare.ps1
@@ -16,7 +16,7 @@ function Set-RubrikNASShare
       Any other links you'd like here
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Get-RubrikNASShare -name 'FOO' | Set-RubrikNASShare -ExportPoint 'TEMP' 

--- a/Rubrik/Public/Set-RubrikNASShare.ps1
+++ b/Rubrik/Public/Set-RubrikNASShare.ps1
@@ -16,7 +16,7 @@ function Set-RubrikNASShare
       Any other links you'd like here
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Get-RubrikNASShare -name 'FOO' | Set-RubrikNASShare -ExportPoint 'TEMP' 

--- a/Rubrik/Public/Set-RubrikNutanixVM.ps1
+++ b/Rubrik/Public/Set-RubrikNutanixVM.ps1
@@ -14,7 +14,7 @@ function Set-RubrikNutanixVM
             GitHub: MikeFal
 
             .LINK
-            https://github.com/rubrikinc/PowerShell-Module
+            https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
             .EXAMPLE
             Get-RubrikNutanixVM 'Server1' | Set-RubrikNutanixVM -PauseBackups

--- a/Rubrik/Public/Set-RubrikNutanixVM.ps1
+++ b/Rubrik/Public/Set-RubrikNutanixVM.ps1
@@ -14,7 +14,7 @@ function Set-RubrikNutanixVM
             GitHub: MikeFal
 
             .LINK
-            https://github.com/rubrikinc/rubrik-sdk-for-powershell
+            http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
             .EXAMPLE
             Get-RubrikNutanixVM 'Server1' | Set-RubrikNutanixVM -PauseBackups

--- a/Rubrik/Public/Set-RubrikSQLInstance.ps1
+++ b/Rubrik/Public/Set-RubrikSQLInstance.ps1
@@ -14,7 +14,7 @@ function Set-RubrikSQLInstance
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Set-RubrikSQLInstance

--- a/Rubrik/Public/Set-RubrikSQLInstance.ps1
+++ b/Rubrik/Public/Set-RubrikSQLInstance.ps1
@@ -14,7 +14,7 @@ function Set-RubrikSQLInstance
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Set-RubrikSQLInstance

--- a/Rubrik/Public/Set-RubrikSupportTunnel.ps1
+++ b/Rubrik/Public/Set-RubrikSupportTunnel.ps1
@@ -15,7 +15,7 @@ function Set-RubrikSupportTunnel
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Set-RubrikSupportTunnel -EnableTunnel $false

--- a/Rubrik/Public/Set-RubrikSupportTunnel.ps1
+++ b/Rubrik/Public/Set-RubrikSupportTunnel.ps1
@@ -15,7 +15,7 @@ function Set-RubrikSupportTunnel
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Set-RubrikSupportTunnel -EnableTunnel $false

--- a/Rubrik/Public/Set-RubrikVM.ps1
+++ b/Rubrik/Public/Set-RubrikVM.ps1
@@ -14,7 +14,7 @@ function Set-RubrikVM
             GitHub: chriswahl
 
             .LINK
-            http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+            http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Set-RubrikVM.html
 
             .EXAMPLE
             Get-RubrikVM 'Server1' | Set-RubrikVM -PauseBackups

--- a/Rubrik/Public/Set-RubrikVM.ps1
+++ b/Rubrik/Public/Set-RubrikVM.ps1
@@ -14,7 +14,7 @@ function Set-RubrikVM
             GitHub: chriswahl
 
             .LINK
-            https://github.com/rubrikinc/PowerShell-Module
+            https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
             .EXAMPLE
             Get-RubrikVM 'Server1' | Set-RubrikVM -PauseBackups

--- a/Rubrik/Public/Set-RubrikVM.ps1
+++ b/Rubrik/Public/Set-RubrikVM.ps1
@@ -14,7 +14,7 @@ function Set-RubrikVM
             GitHub: chriswahl
 
             .LINK
-            https://github.com/rubrikinc/rubrik-sdk-for-powershell
+            http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
             .EXAMPLE
             Get-RubrikVM 'Server1' | Set-RubrikVM -PauseBackups

--- a/Rubrik/Public/Start-RubrikManagedVolumeSnapshot.ps1
+++ b/Rubrik/Public/Start-RubrikManagedVolumeSnapshot.ps1
@@ -15,7 +15,7 @@ function Start-RubrikManagedVolumeSnapshot
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Start-ManagedVolumeSnapshot -id ManagedVolume:::f68ecd45-bdb9-46dd-aea4-8f041fb2dec2

--- a/Rubrik/Public/Start-RubrikManagedVolumeSnapshot.ps1
+++ b/Rubrik/Public/Start-RubrikManagedVolumeSnapshot.ps1
@@ -15,7 +15,7 @@ function Start-RubrikManagedVolumeSnapshot
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Start-ManagedVolumeSnapshot -id ManagedVolume:::f68ecd45-bdb9-46dd-aea4-8f041fb2dec2

--- a/Rubrik/Public/Stop-RubrikManagedVolumeSnapshot.ps1
+++ b/Rubrik/Public/Stop-RubrikManagedVolumeSnapshot.ps1
@@ -15,7 +15,7 @@ function Stop-RubrikManagedVolumeSnapshot
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Stop-ManagedVolumeSnapshot -id ManagedVolume:::f68ecd45-bdb9-46dd-aea4-8f041fb2dec2

--- a/Rubrik/Public/Stop-RubrikManagedVolumeSnapshot.ps1
+++ b/Rubrik/Public/Stop-RubrikManagedVolumeSnapshot.ps1
@@ -15,7 +15,7 @@ function Stop-RubrikManagedVolumeSnapshot
       GitHub: MikeFal
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Stop-ManagedVolumeSnapshot -id ManagedVolume:::f68ecd45-bdb9-46dd-aea4-8f041fb2dec2

--- a/Rubrik/Public/Sync-RubrikAnnotation.ps1
+++ b/Rubrik/Public/Sync-RubrikAnnotation.ps1
@@ -17,7 +17,7 @@ function Sync-RubrikAnnotation
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Sync-RubrikAnnotation.html
 
       .EXAMPLE
       Sync-RubrikAnnotation

--- a/Rubrik/Public/Sync-RubrikAnnotation.ps1
+++ b/Rubrik/Public/Sync-RubrikAnnotation.ps1
@@ -17,7 +17,7 @@ function Sync-RubrikAnnotation
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Sync-RubrikAnnotation

--- a/Rubrik/Public/Sync-RubrikAnnotation.ps1
+++ b/Rubrik/Public/Sync-RubrikAnnotation.ps1
@@ -17,7 +17,7 @@ function Sync-RubrikAnnotation
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Sync-RubrikAnnotation

--- a/Rubrik/Public/Sync-RubrikTag.ps1
+++ b/Rubrik/Public/Sync-RubrikTag.ps1
@@ -14,7 +14,7 @@ function Sync-RubrikTag
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/PowerShell-Module
+      https://github.com/rubrikinc/rubrik-sdk-for-powershell
 
       .EXAMPLE
       Sync-RubrikTag -vCenter 'vcenter1.demo' -Category 'Rubrik'

--- a/Rubrik/Public/Sync-RubrikTag.ps1
+++ b/Rubrik/Public/Sync-RubrikTag.ps1
@@ -14,7 +14,7 @@ function Sync-RubrikTag
       GitHub: chriswahl
 
       .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Sync-RubrikTag.html
 
       .EXAMPLE
       Sync-RubrikTag -vCenter 'vcenter1.demo' -Category 'Rubrik'

--- a/Rubrik/Public/Sync-RubrikTag.ps1
+++ b/Rubrik/Public/Sync-RubrikTag.ps1
@@ -14,7 +14,7 @@ function Sync-RubrikTag
       GitHub: chriswahl
 
       .LINK
-      https://github.com/rubrikinc/rubrik-sdk-for-powershell
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
       .EXAMPLE
       Sync-RubrikTag -vCenter 'vcenter1.demo' -Category 'Rubrik'

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -135,10 +135,10 @@ PrivateData = @{
         Tags = 'Rubrik','Converged_Data_Management','CDM','Backup','Recovery','Data_Protection'
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/rubrikinc/PowerShell-Module/blob/master/LICENSE'
+        LicenseUri = 'https://github.com/rubrikinc/rubrik-sdk-for-powershell/blob/master/LICENSE'
 
         # A URL to the main website for this project.
-        ProjectUri = 'https://github.com/rubrikinc/PowerShell-Module'
+        ProjectUri = 'https://github.com/rubrikinc/rubrik-sdk-for-powershell'
 
         # A URL to an icon representing this module.
         IconUri = 'http://i.imgur.com/Zbdd4Ko.jpg'


### PR DESCRIPTION
# Description

The documentation linked directly to the GitHub repository

## Related Issue

#253 

## Motivation and Context

In PowerShell using the Get-Help -Online switch gives the user the expectation that they will be taken to the online version of the help file. This was not the case with the Rubrik PowerShell module. This has now been resolved for the cmdlets that have documentation available.
