### PR TITLE
Added DetailedObject parameter to Get-RubrikVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-* Testing for MacOS and Linux as per [143](https://github.com/rubrikinc/PowerShell-Module/issues/143)
+* Added -DetailedObject parameter for Get-RubrikVM
 
 ### Fixed
 

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -29,7 +29,7 @@ function Get-RubrikVM
       This will return all removed virtual machines that were formerly protected by Rubrik.
 
       .EXAMPLE
-      Get-RubrikVM -id myserver01 -DetailedObject
+      Get-RubrikVM -Name myserver01 -DetailedObject
       This will return the VM object with all properties, including additional details such as snapshots taken of the VM. Using this switch parameter negatively affects performance 
   #>
 

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -102,9 +102,10 @@ function Get-RubrikVM
 
     # If the Get-RubrikVM function has been called with the -DetailedObject parameter a separate API query will be performed if the initial query was not based on ID
     if (($DetailedObject) -and (-not $PSBoundParameters.containskey('id'))) {
-      $result | ForEach-Object {
-        $result = Get-RubrikVM -id $_.id
-        return $result
+      for ($i = 0; $i -lt $result.Count; $i++) {
+        $Percentage = [int]($i/$result.count*100)
+        Write-Progress -Activity "DetailedObject queries in Progress, $($i+1) out of $($result.count)" -Status "$Percentage% Complete:" -PercentComplete $Percentage
+        Get-RubrikVM -id $result[$i].id
       }
     } else {
       return $result


### PR DESCRIPTION
# Description

Get-RubrikVM inconsistent results

## Related Issue

#262 

_Please link to the issue here_

## Motivation and Context

Currently Get-RubrikVM -Name and Get-RubrikVM -id return different datasets, which can be confusing from a user perspective. I added the -DetailedObject parameter, to execute an additional query by ID to retrieve the full details on the computer object.

## How Has This Been Tested?

I created an if-else statement that will execute a second query. I tested this code against the TM lab environment

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
