### PR TITLE
Added parameter validation and parameter sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-03-24 [Parameter validation for Get-RubrikVM]
+
+### Added
+
+* Added parameter sets and parameter validation to Get-RubrikVM
+* Added ValidateNullNotEmpty to selected parameters in Get-RubrikVM
+* Added additional 5 tests to validate parameters sets and validation work as intended
+
+## 2019-03-17 [Added new functionality and fixed help]
+
 ### Added
 
 * Updated example 2 in comment-based help of Invoke-RubrikRESTCall

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -33,7 +33,7 @@ function Get-RubrikVM
       This will return the VM object with all properties, including additional details such as snapshots taken of the VM. Using this switch parameter negatively affects performance 
   #>
 
-  [CmdletBinding()]
+  [CmdletBinding(DefaultParameterSetName = 'Query')]
   Param(
     # Name of the virtual machine
     [Parameter(
@@ -57,6 +57,7 @@ function Get-RubrikVM
     [Parameter(ParameterSetName='Query')]
     [Switch]$DetailedObject,
     # SLA Domain policy assigned to the virtual machine
+    [Parameter(ParameterSetName='Query')]
     [String]$SLA, 
     # Filter by SLA Domain assignment type
     [Parameter(ParameterSetName='Query')]

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -36,32 +36,48 @@ function Get-RubrikVM
   [CmdletBinding()]
   Param(
     # Name of the virtual machine
-    [Parameter(Position = 0,ValueFromPipelineByPropertyName = $true)]
+    [Parameter(
+      ParameterSetName='Query',
+      Position = 0,
+      ValueFromPipelineByPropertyName = $true)]
     [Alias('VM')]
     [String]$Name,
+    # Virtual machine id
+    [Parameter(
+      ParameterSetName='ID',
+      Position = 0,
+      Mandatory = $true,
+      ValueFromPipelineByPropertyName = $true)]
+    [String]$id,
     # Filter results to include only relic (removed) virtual machines
+    [Parameter(ParameterSetName='Query')]
     [Alias('is_relic')]    
     [Switch]$Relic,
     # DetailedObject will retrieved the detailed VM object, the default behavior of the API is to only retrieve a subset of the full VM object unless we query directly by ID. Using this parameter does affect performance as more data will be retrieved and more API-queries will be performed.
+    [Parameter(ParameterSetName='Query')]
     [Switch]$DetailedObject,
     # SLA Domain policy assigned to the virtual machine
     [String]$SLA, 
     # Filter by SLA Domain assignment type
-    [Alias('sla_assignment')]
+    [Parameter(ParameterSetName='Query')]
     [ValidateSet('Derived', 'Direct','Unassigned')]
+    [Alias('sla_assignment')]
     [String]$SLAAssignment,     
     # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    [Parameter(ParameterSetName='Query')]
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,        
-    # Virtual machine id
-    [Parameter(ValueFromPipelineByPropertyName = $true)]
-    [String]$id,
     # SLA id value
+    [Parameter(ParameterSetName='Query')]
     [Alias('effective_sla_domain_id')]
     [String]$SLAID,    
     # Rubrik server IP or FQDN
+    [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='ID')]
     [String]$Server = $global:RubrikConnection.server,
     # API version
+    [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='ID')]
     [String]$api = $global:RubrikConnection.api
   )
 

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -40,6 +40,7 @@ function Get-RubrikVM
       ParameterSetName='Query',
       Position = 0,
       ValueFromPipelineByPropertyName = $true)]
+    [ValidateNotNullOrEmpty()]
     [Alias('VM')]
     [String]$Name,
     # Virtual machine id
@@ -48,6 +49,7 @@ function Get-RubrikVM
       Position = 0,
       Mandatory = $true,
       ValueFromPipelineByPropertyName = $true)]
+    [ValidateNotNullOrEmpty()]
     [String]$id,
     # Filter results to include only relic (removed) virtual machines
     [Parameter(ParameterSetName='Query')]
@@ -58,18 +60,22 @@ function Get-RubrikVM
     [Switch]$DetailedObject,
     # SLA Domain policy assigned to the virtual machine
     [Parameter(ParameterSetName='Query')]
+    [ValidateNotNullOrEmpty()]
     [String]$SLA, 
     # Filter by SLA Domain assignment type
     [Parameter(ParameterSetName='Query')]
+    [ValidateNotNullOrEmpty()]
     [ValidateSet('Derived', 'Direct','Unassigned')]
     [Alias('sla_assignment')]
     [String]$SLAAssignment,     
     # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Parameter(ParameterSetName='Query')]
+    [ValidateNotNullOrEmpty()]
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,        
     # SLA id value
     [Parameter(ParameterSetName='Query')]
+    [ValidateNotNullOrEmpty()]
     [Alias('effective_sla_domain_id')]
     [String]$SLAID,    
     # Rubrik server IP or FQDN

--- a/Tests/Get-RubrikVM.Tests.ps1
+++ b/Tests/Get-RubrikVM.Tests.ps1
@@ -60,4 +60,27 @@ Describe -Name 'Public/Get-RubrikVM' -Tag 'Public', 'Get-RubrikVM' -Fixture {
         Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
         Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
     }
+
+    Context -Name 'Parameter Validation' {
+        It -Name 'Parameter Name cannot be $null' -Test {
+            { Get-RubrikVM -Name $null } |
+                Should -Throw "Cannot validate argument on parameter 'Name'"
+        }
+        It -Name 'Parameter Name cannot be empty' -Test {
+            { Get-RubrikVM -Name '' } |
+                Should -Throw "Cannot validate argument on parameter 'Name'"
+        }
+        It -Name 'Parameter ID cannot be $null' -Test {
+            { Get-RubrikVM -Id $null } |
+                Should -Throw "Cannot validate argument on parameter 'ID'"
+        }
+        It -Name 'Parameter ID cannot be empty' -Test {
+            { Get-RubrikVM -Id '' } |
+                Should -Throw "Cannot validate argument on parameter 'ID'"
+        }
+        It -Name 'Parameters Id and Name cannot be simultaneously used' -Test {
+            { Get-RubrikVM -Id VirtualMachine:::1226ff04-6100-454f-905b-5df817b6981a-vm-1025 -Name 'swagsanta'  } |
+                Should -Throw "Parameter set cannot be resolved using the specified named parameters."
+        }
+    }
 }

--- a/Tests/Get-RubrikVM.Tests.ps1
+++ b/Tests/Get-RubrikVM.Tests.ps1
@@ -79,7 +79,7 @@ Describe -Name 'Public/Get-RubrikVM' -Tag 'Public', 'Get-RubrikVM' -Fixture {
                 Should -Throw "Cannot validate argument on parameter 'ID'"
         }
         It -Name 'Parameters Id and Name cannot be simultaneously used' -Test {
-            { Get-RubrikVM -Id VirtualMachine:::1226ff04-6100-454f-905b-5df817b6981a-vm-1025 -Name 'swagsanta'  } |
+            { Get-RubrikVM -Id VirtualMachine:::1226ff04-6100-454f-905b-5df817b6981a-vm-1025 -Name 'swagsanta' } |
                 Should -Throw "Parameter set cannot be resolved using the specified named parameters."
         }
     }


### PR DESCRIPTION
# Description

Any empty query parameter for Get-RubrikVM can result in querying for all objects. This is confusing for our end-users and can have disastrous results. We have implemented parameter validation to combat this, so the Get-RubrikVM function will error out on empty variables, empty strings or $null-values 

## Related Issue

#267 

## Motivation and Context

It solves the problem 

## How Has This Been Tested?

Tested this on both Windows PowerShell and PowerShell Core

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12744735/54897084-35656d80-4e84-11e9-89e2-1066c82a1018.png)
![image](https://user-images.githubusercontent.com/12744735/54897093-457d4d00-4e84-11e9-9cfd-a95af7f8cfd7.png)
![image](https://user-images.githubusercontent.com/12744735/54897106-4c0bc480-4e84-11e9-864a-6545db2462e5.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
