### PR TITLE
Updated Get-RubrikVM.md

### DIFF
--- a/docs/commands/Get-RubrikVM.md
+++ b/docs/commands/Get-RubrikVM.md
@@ -152,7 +152,7 @@ Accept wildcard characters: False
 
 ### -PrimaryClusterID
 Filter the summary information based on the primarycluster_id of the primary Rubrik cluster.
-Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+Use **local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
 
 ```yaml
 Type: String


### PR DESCRIPTION
# Description

Updated Get-RubrikVM.md file within the docs/commands directory
In the PrimaryClusterId section it instructed users to use _local to default to the local cluster hosting the VM, however this doesn't work.  Updated to say to use 'local' rather than '_local'.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

Why is this change required? What problem does it solve?

More clear documentation on the Get-RubrikVM cmdlet.

## How Has This Been Tested?

* Please describe in detail how you tested your changes.

Just a doc change, however I tested trying to use '_local' on both PrimaryClusterID and -Primary_Cluster_id - neither returned the proper information.  'local' worked.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
