### PR TITLE
Adding Instance_ID as a parameter for Get-RubrikDatabase

### DIFF
--- a/Rubrik/Public/Get-RubrikDatabase.ps1
+++ b/Rubrik/Public/Get-RubrikDatabase.ps1
@@ -53,6 +53,9 @@ function Get-RubrikDatabase
     [String]$Hostname,
     #ServerInstance name (combined hostname\instancename)
     [String]$ServerInstance,
+    #SQL InstanceID
+    [Alias('instance_id')]
+    [string]$InstanceID,
     # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,    
@@ -89,12 +92,16 @@ function Get-RubrikDatabase
 
     #region one-off
     if($ServerInstance){
+
       $SIobj = ConvertFrom-SqlServerInstance $ServerInstance
       $Hostname = $SIobj.hostname
       $Instance = $SIobj.instancename
     }
+      
+   if($Hostname.Length -gt 0 -and $Instance.Length -gt 0 -and $InstanceID.Length -eq 0){
+      $InstanceID = (Get-RubrikSQLInstance -Hostname $Hostname -Name $Instance).id
+    }
     #endregion
-  
   }
 
   Process {

--- a/Rubrik/Public/Get-RubrikDatabase.ps1
+++ b/Rubrik/Public/Get-RubrikDatabase.ps1
@@ -35,6 +35,10 @@ function Get-RubrikDatabase
       This will return details on a single database matching the Rubrik ID of "MssqlDatabase:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
       Note that the database ID is globally unique and is often handy to know if tracking a specific database for longer workflows,
       whereas some values are not unique (such as nearly all hosts having one or more databases named "model") and more difficult to track by name.
+  
+      .EXAMPLE
+      Get-RubrikDatabase -InstanceID MssqlInstance:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+      This will return details on a single SQL instance matching the Rubrik ID of "MssqlInstance:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
   #>
 
   [CmdletBinding()]
@@ -53,7 +57,7 @@ function Get-RubrikDatabase
     [String]$Hostname,
     #ServerInstance name (combined hostname\instancename)
     [String]$ServerInstance,
-    #SQL InstanceID
+    #SQL InstanceID, used as a unique identifier
     [Alias('instance_id')]
     [string]$InstanceID,
     # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.


### PR DESCRIPTION
# Description
Adding InstanceID(instance_id) for Get-RubrikDatabase to provide more efficient database retrieval. Also added logic that if a hostname and instance name are provided (including ServerInstance), the cmdlet will use that to pull the correct InstanceID. 

## Related Issue
#278 

## Motivation and Context
Customer request and general enhancement.

## How Has This Been Tested?
Tested in Rubrik Gaia lab. Ran the following commands to validate functionality:

`Get-RubrikDatabase -ServerInstance am2-sql16-1` (6 seconds for completion)
`Get-RubrikDatabase -InstanceID MssqlInstance:::dc54ad38-41d7-437c-9639-301d8f09e01a` (1 second for completion)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
