### PR TITLE
added primaryclusterid parameter to Get-RubrikNasShare (Issue 277)

### DIFF
--- a/Rubrik/Public/Get-RubrikNASShare.ps1
+++ b/Rubrik/Public/Get-RubrikNASShare.ps1
@@ -45,6 +45,11 @@ function Get-RubrikNASShare
     [String]$exportPoint,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    [Parameter(ParameterSetName='Query')]
+    [ValidateNotNullOrEmpty()]
+    [Alias('primary_cluster_id')]
+    [String]$PrimaryClusterID,
     # API version
     [String]$api = $global:RubrikConnection.api
   )


### PR DESCRIPTION
# Description

Added functionality to allow primary_cluster_id to be passed to Get-RubrikNasShare

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/277

## Motivation and Context

Why is this change required? What problem does it solve?

Allows an easy way to filter NAS shares setup within Rubrik to quickly determine which are local and which aren't.


## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

Tested on both 4.2.2 and 5.0.1 in the Tech Marketing lab.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
