### PR TITLE
Resolve bugs in Move-RubrikMountVMDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-05-30
+
+### Changed [Resolving issues]
+
+* Updated Move-RubrikMountVMDK and Test-DateDifference to resolve bugs reported in [250](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/250). Mouve-RubrikMountVMDK will try to find the snapshot closest to the date specified, within one day. Any valid PowerShell `datetime` formatted string will be accepted as an input, but greater specificity will lead to a much better chance of matching the intended snapshot.
+
 ## 2019-05-27
 
 ### Changed [Added functionality and resolved issues]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed [Resolving issues]
 
-* Updated Move-RubrikMountVMDK and Test-DateDifference to resolve bugs reported in [250](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/250). Mouve-RubrikMountVMDK will try to find the snapshot closest to the date specified, within one day. Any valid PowerShell `datetime` formatted string will be accepted as an input, but greater specificity will lead to a much better chance of matching the intended snapshot.
+* Updated Move-RubrikMountVMDK and Test-DateDifference to resolve bugs reported in [250](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/250). Move-RubrikMountVMDK will try to find the snapshot closest to the date specified, within one day. Any valid PowerShell `datetime` formatted string will be accepted as an input, but greater specificity will lead to a much better chance of matching the intended snapshot.
 
 ## 2019-05-27
 

--- a/Rubrik/Private/Test-DateDifference.ps1
+++ b/Rubrik/Private/Test-DateDifference.ps1
@@ -34,7 +34,7 @@
     if ($datematrix.value -eq 0) { break }
   }
   
-  If ($datematrix.date -ne $null) {
+  If ($null -ne $datematrix.date) {
     Write-Verbose -Message "Using date $($datematrix.date)"
   }
   else {

--- a/Rubrik/Private/Test-DateDifference.ps1
+++ b/Rubrik/Private/Test-DateDifference.ps1
@@ -1,32 +1,44 @@
 ﻿function Test-DateDifference([array]$date,[datetime]$compare)
 {
-  # The Test-DateDifference function is used to compare a series of dates against a desired date to find the closest matching date/time in the past
-  # Thus, a date/time that is one hour older than the request would be valid, but one hour in the future would not be valid
+  # The Test-DateDifference function is used to compare a series of dates against a desired date to find the closest matching date/time
+  # The Rubrik API returns snapshot dates down to the millisecond, but the user may not provide this much detail in their Date argument
+  # A snapshot date may be in the future by milliseconds, but this is considered valid since that is most likely the intent of the user
   # $date = An array of ISO 8601 style dates (e.g. YYYY-MM-DDTHH:MM:SSZ)
   # $compare = A single ISO 8601 style date to compare against the $date array
   
   # A simple hashtable is created to compare each date value against one another
   # The value that is closest to 0 (e.g. least distance away from the $compare date) is stored
-  # A "placeholder" value of 999999999 is used to find the first value that is greater than 0
+  # A "placeholder" value of 1 is used to find the first value within one day of $compare
   # Otherwise, the date of $null is returned meaning no match
+  Write-Verbose -Message "Finding closest matching date"
   $datematrix = @{
     date  = $null
-    value = 9999999999
+    value = 1
   }
  
   foreach ($_ in $date)
   {
     # The $c is just a check variable used to hold the total number of days between the current $date item and the $compare value
     $c = (New-TimeSpan -Start $_ -End $compare).TotalDays
-    # Should we find a value that is less than the existing winning value, and it's 0 or greater, store it
+    # Should we find a value that is less than the existing winning value, store it
     # Note: 0 would be a perfect match (e.g. 0 days different between what we found and what the user wants in $compare)
     # Note: Negative values indicate a future (e.g. supply yesterday for $compare but finding a $date from today)
-    if ($c -lt $datematrix.value -and $c -ge 0)
+    # Absolute values are used so negatives are igored and we find the closest actual match. 
+    if ([Math]::Abs($c) -lt $datematrix.value)
     {
       $datematrix.date = $_
-      $datematrix.value = [int]$c
+      $datematrix.value = [Math]::Abs($c)
     }
+
+    # If $c = 0, a perfect match has been found
+    if ($datematrix.value -eq 0) { break }
   }
   
+  If ($datematrix.date -ne $null) {
+    Write-Verbose -Message "Using date $($datematrix.date)"
+  }
+  else {
+    Write-Verbose -Message "Could not find matching date within one day of $($compare.ToString())"
+  }
   return $datematrix.date
 }

--- a/Rubrik/Private/Test-DateDifference.ps1
+++ b/Rubrik/Private/Test-DateDifference.ps1
@@ -23,7 +23,7 @@
     # Should we find a value that is less than the existing winning value, store it
     # Note: 0 would be a perfect match (e.g. 0 days different between what we found and what the user wants in $compare)
     # Note: Negative values indicate a future (e.g. supply yesterday for $compare but finding a $date from today)
-    # Absolute values are used so negatives are igored and we find the closest actual match. 
+    # Absolute values are used so negatives are ignored and we find the closest actual match. 
     if ([Math]::Abs($c) -lt $datematrix.value)
     {
       $datematrix.date = $_

--- a/Rubrik/Public/Move-RubrikMountVMDK.ps1
+++ b/Rubrik/Public/Move-RubrikMountVMDK.ps1
@@ -71,7 +71,7 @@ function Move-RubrikMountVMDK
     # The path to a cleanup file to remove the live mount and presented disks
     # The cleanup file is created each time the command is run and stored in the $HOME path as a text file with a random number value
     # The file contains the TargetVM name, MountID value, and a list of all presented disks
-    [Parameter(ParameterSetName = 'Destroy')]    
+    [Parameter(ParameterSetName = 'Destroy')]
     [String]$Cleanup,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
@@ -101,7 +101,7 @@ function Move-RubrikMountVMDK
 
         # Validate provided date
         try {
-          $Date = [datetime]$Date          
+          $Date = [datetime]$Date
         }
         catch {
           throw "Invalid Date"
@@ -187,11 +187,15 @@ function Move-RubrikMountVMDK
       $MountID | Out-File -FilePath $Diskfile -Encoding utf8 -Append -Force      
       $MountedVMdiskFileNames | Out-File -FilePath $Diskfile -Encoding utf8 -Append -Force
       
-      # Return information needed to cleanup the mounted disks and Live Mount      
-      $response = @{}
-      $response.Add('Status','Success')
-      $response.add('CleanupFile',$Diskfile)
-      $response.Add('Example',"Move-RubrikMountVMDK -Cleanup `'$Diskfile`'")
+      # Return information needed to cleanup the mounted disks and Live Mount
+      $response = [pscustomobject]@{
+        'Status' = 'Success'
+        'CleanupFile' = $Diskfile
+        'TargetVM' = $TargetVM
+        'MountID' = $MountID
+        'MountedVMdiskFileNames' = $MountedVMdiskFileNames
+        'Example' = "Move-RubrikMountVMDK -Cleanup '$Diskfile'"
+      }
       return $response
     }
 
@@ -202,7 +206,7 @@ function Move-RubrikMountVMDK
         throw 'File does not exist'
       }
       $TargetVM = (Get-Content -Path $Cleanup -Encoding UTF8)[0]
-      $MountID = (Get-Content -Path $Cleanup -Encoding UTF8)[1]      
+      $MountID = (Get-Content -Path $Cleanup -Encoding UTF8)[1]
       $MountedVMdiskFileNames = (Get-Content -Path $Cleanup -Encoding UTF8) | Select-Object -Skip 2
       Write-Verbose -Message 'Removing disks from the VM'
       [array]$SourceVMdisk = Get-HardDisk $TargetVM


### PR DESCRIPTION
# Description

Updated Move-RubrikMountVMDK and Test-DateDifference to resolve bugs reported in #250 . Move-RubrikMountVMDK will try to find the snapshot closest to the date specified, within one day. Any valid PowerShell `datetime` formatted string will be accepted as an input, but greater specificity will lead to a much better chance of matching the intended snapshot.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/250

## Motivation and Context

Why is this change required? What problem does it solve?

See description

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

Tested against Rubrik CDM 5.0.1-1280 from MacOS

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
