### PR TITLE
Add -ApplicationTag parameter to New-RubrikManagedVolume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-05-31 
+
+### Added [New-RubrikManagedVolume update]
+
+* Added `-ApplicationTag` parameter support to New-RubrikManagedVolume so users can specify which application the managed volume will be used for. This addresses issue [285](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/285).
+
+
 ## 2019-05-30
 
 ### Changed [Resolving issues]

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -891,6 +891,7 @@ function Get-RubrikAPIData($endpoint) {
                     numChannels = 'numChannels'
                     subnet = 'subnet'
                     volumeSize =  'volumeSize'
+                    applicationTag = 'applicationTag'
                 }
                 Query       = ''
                 Result      = ''

--- a/Rubrik/Public/New-RubrikManagedVolume.ps1
+++ b/Rubrik/Public/New-RubrikManagedVolume.ps1
@@ -26,6 +26,12 @@ function New-RubrikManagedVolume
       New-RubrikManagedVolume -Name foo -Channels 2 -VolumeSize (500 * 1GB) -Subnet 172.21.10.0/23
 
       Creates a new managed volume named 'foo' with 2 channels, 536870912000 bytes (500 GB) in size, on the 172.21.10.0/23 subnet
+
+      .EXAMPLE
+      New-RubrikManagedVolume -Name foo -Channels 2-VolumeSize (500 * 1GB) -ApplicationTag "PostgreSql"
+
+      Creates a new managed volume named 'foo' with 2 channels, 536870912000 bytes (500 GB) in size, configured for PostreSQL backups
+      Valid ApplicationTag values are 'Oracle', 'OracleIncremental', 'MsSql', 'SapHana', 'MySql', 'PostgreSql', and 'RecoverX'
   #>
 
   [CmdletBinding()]
@@ -41,6 +47,9 @@ function New-RubrikManagedVolume
     [String]$Subnet,
     #Size of the Managed Volume in Bytes
     [int64]$VolumeSize,
+    #Application whose data will be stored in managed volume
+    [ValidateSet('Oracle', 'OracleIncremental', 'MsSql', 'SapHana', 'MySql', 'PostgreSql', 'RecoverX')]
+    [string]$applicationTag,
     #Export config, such as host hints and host name patterns
     [PSCustomObject[]]$exportConfig,
     # Rubrik server IP or FQDN

--- a/Rubrik/Public/New-RubrikManagedVolume.ps1
+++ b/Rubrik/Public/New-RubrikManagedVolume.ps1
@@ -28,7 +28,7 @@ function New-RubrikManagedVolume
       Creates a new managed volume named 'foo' with 2 channels, 536870912000 bytes (500 GB) in size, on the 172.21.10.0/23 subnet
 
       .EXAMPLE
-      New-RubrikManagedVolume -Name foo -Channels 2-VolumeSize (500 * 1GB) -ApplicationTag "PostgreSql"
+      New-RubrikManagedVolume -Name foo -Channels 2 -VolumeSize (500 * 1GB) -ApplicationTag "PostgreSql"
 
       Creates a new managed volume named 'foo' with 2 channels, 536870912000 bytes (500 GB) in size, configured for PostreSQL backups
       Valid ApplicationTag values are 'Oracle', 'OracleIncremental', 'MsSql', 'SapHana', 'MySql', 'PostgreSql', and 'RecoverX'

--- a/docs/reference/New-RubrikManagedVolume.md
+++ b/docs/reference/New-RubrikManagedVolume.md
@@ -37,6 +37,14 @@ New-RubrikManagedVolume -Name foo -Channels 2 -VolumeSize (500 * 1GB) -Subnet 17
 
 Creates a new managed volume named 'foo' with 2 channels, 536870912000 bytes (500 GB) in size, on the 172.21.10.0/23 subnet
 
+### EXAMPLE 3
+```
+New-RubrikManagedVolume -Name foo -Channels 2-VolumeSize (500 * 1GB) -ApplicationTag "PostgreSql"
+```
+
+Creates a new managed volume named 'foo' with 2 channels, 536870912000 bytes (500 GB) in size, configured for PostreSQL backups
+Valid ApplicationTag values are 'Oracle', 'OracleIncremental', 'MsSql', 'SapHana', 'MySql', 'PostgreSql', and 'RecoverX'
+
 ## PARAMETERS
 
 ### -Name
@@ -99,6 +107,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ApplicationTag
+Application whose data will be stored in managed volume
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -exportConfig
 Export config, such as host hints and host name patterns
 
@@ -108,7 +131,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -123,7 +146,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 7
 Default value: $global:RubrikConnection.server
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -138,7 +161,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 8
 Default value: $global:RubrikConnection.api
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/reference/New-RubrikManagedVolume.md
+++ b/docs/reference/New-RubrikManagedVolume.md
@@ -39,7 +39,7 @@ Creates a new managed volume named 'foo' with 2 channels, 536870912000 bytes (50
 
 ### EXAMPLE 3
 ```
-New-RubrikManagedVolume -Name foo -Channels 2-VolumeSize (500 * 1GB) -ApplicationTag "PostgreSql"
+New-RubrikManagedVolume -Name foo -Channels 2 -VolumeSize (500 * 1GB) -ApplicationTag "PostgreSql"
 ```
 
 Creates a new managed volume named 'foo' with 2 channels, 536870912000 bytes (500 GB) in size, configured for PostreSQL backups

--- a/docs/reference/Remove-RubrikManagedVolume.md
+++ b/docs/reference/Remove-RubrikManagedVolume.md
@@ -18,7 +18,7 @@ Remove-RubrikManagedVolume [-id] <String> [[-Server] <String>] [[-api] <String>]
 ```
 
 ## DESCRIPTION
-The Remove-RubrikManagedVolume cmdlet is used to dlete a Managed Volume
+The Remove-RubrikManagedVolume cmdlet is used to delete a Managed Volume
 
 ## EXAMPLES
 
@@ -28,7 +28,7 @@ Remove-RubrikManagedVolume -id ManagedVolume:::f68ecd45-bdb9-46dd-aea4-8f041fb2d
 ```
 
 Remove the specified managed volume.
-All associated snapshots will become unmaged objects.
+All associated snapshots will become unmanaged objects.
 
 ## PARAMETERS
 


### PR DESCRIPTION
# Description

dded `-ApplicationTag` parameter support to New-RubrikManagedVolume so users can specify which application the managed volume will be used for. This addresses issue #285 

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/285

## Motivation and Context

Why is this change required? What problem does it solve?

An Application Tag can be applied to a Managed Volume so optimize deduplication settings. This change will allow the Application Tag to be set via New-RubrikManagedVoume.

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

Tested against Rubrik CDM 5.0.1-1280 from MacOS

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
