### PR TITLE
Add new cmdlet Update-RubrikVMwareVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-06-18
+
+### Added [Update-RubrikVMwareVM]
+
+* Added new `Update-RubrikVMwareVM` cmdlet to refresh a single VMware VM's metadata. This addresses issue [305](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/305)
+
 ## 2019-06-04
 
 ### Changed [Resolved issues]

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -1723,7 +1723,21 @@ function Get-RubrikAPIData($endpoint) {
                 Filter      = ''
                 Success     = '202'
             }
-        }        
+        }
+        'Update-RubrikVMwareVM'         = @{
+            '1.0' = @{
+                Description = 'Refresh the metadata for the specified VMware VM'
+                URI         = '/api/internal/vmware/vcenter/{id}/refresh_vm'
+                Method      = 'Post'
+                Body        = @{
+                    vmMoid = 'vmMoid'
+                }
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '204'
+            }
+        }      
 
     } # End of API
 

--- a/Rubrik/Public/Update-RubrikVMwareVM.ps1
+++ b/Rubrik/Public/Update-RubrikVMwareVM.ps1
@@ -19,6 +19,14 @@ function Update-RubrikVMwareVM
       .EXAMPLE
       Get-RubrikVM -Name 'myvm.domain.local' | Update-RubrikVMwareVM
       This will refresh the VMware VM metadata on the currently connected Rubrik cluster
+
+      .EXAMPLE
+      Update-RubrikVMwareVM -Id vCenter:::1226ff04-6100-454f-905b-5df817b6981a -moid vm-100
+      This will refresh the VMware VM metadata, for the VM and vcCenter specified, on the currently connected Rubrik cluster
+      
+      .EXAMPLE
+      Import-Csv .\RefreshVM.csv | Update-RubrikVMwareVM -Verbose
+      This will refresh the VMware VM metadata, for the VM and vcCenter specified in the csv file, on the currently connected Rubrik cluster while displaying verbose information. Please note that the .csv file should contain the id and moid fields.
   #>
 
   [CmdletBinding()]

--- a/Rubrik/Public/Update-RubrikVMwareVM.ps1
+++ b/Rubrik/Public/Update-RubrikVMwareVM.ps1
@@ -1,0 +1,79 @@
+#Requires -Version 3
+function Update-RubrikVMwareVM
+{
+  <#  
+      .SYNOPSIS
+      Connects to Rubrik to refresh the metadata for the specified VMware VM
+            
+      .DESCRIPTION
+      The Update-RubrikVMwareVM cmdlet will refresh the specified VMware VM metadata known to the connected Rubrik cluster.
+            
+      .NOTES
+      Written by Pierre-François Guglielmi for community usage
+      Twitter: @pfguglielmi
+      GitHub: pfguglielmi
+
+      .LINK
+      http://rubrikinc.github.io/rubrik-sdk-for-powershell/reference/Update-RubrikVMwareVM.html
+      
+      .EXAMPLE
+      Get-RubrikVM -Name 'myvm.domain.local' | Update-RubrikVMwareVM
+      This will refresh the VMware VM metadata on the currently connected Rubrik cluster
+  #>
+
+  [CmdletBinding()]
+  Param(
+    # vCenter id value from the Rubrik Cluster
+    [Parameter(
+      ValueFromPipelineByPropertyName = $true,
+      Mandatory = $true )]
+    [ValidateNotNullOrEmpty()]
+    [Alias('id')]
+    [String]$vcenterId,
+    # VMware VM id value from the Rubrik Cluster
+    [Parameter(
+      ValueFromPipelineByPropertyName = $true,
+      Mandatory = $true )]
+    [ValidateNotNullOrEmpty()]
+    [Alias('moid')]
+    [String]$vmMoid,
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [ValidateNotNullorEmpty()]
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+    
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+        
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = Get-RubrikAPIData -endpoint $function
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+  
+  }
+
+  Process {
+
+    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $vcenterId
+    $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+    $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+    return $result
+
+  } # End of process
+} # End of function

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -109,7 +109,7 @@ FunctionsToExport = @('Connect-Rubrik', 'Disconnect-Rubrik', 'Export-RubrikDatab
                'Set-RubrikVCenter', 'Set-RubrikVM', 
                'Start-RubrikManagedVolumeSnapshot', 
                'Stop-RubrikManagedVolumeSnapshot', 'Sync-RubrikAnnotation', 
-               'Sync-RubrikTag', 'Update-RubrikHost', 'Update-RubrikVCenter')
+               'Sync-RubrikTag', 'Update-RubrikHost', 'Update-RubrikVCenter','Update-RubrikVMwareVM')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -109,7 +109,8 @@ FunctionsToExport = @('Connect-Rubrik', 'Disconnect-Rubrik', 'Export-RubrikDatab
                'Set-RubrikVCenter', 'Set-RubrikVM', 
                'Start-RubrikManagedVolumeSnapshot', 
                'Stop-RubrikManagedVolumeSnapshot', 'Sync-RubrikAnnotation', 
-               'Sync-RubrikTag', 'Update-RubrikHost', 'Update-RubrikVCenter','Update-RubrikVMwareVM')
+               'Sync-RubrikTag', 'Update-RubrikHost', 'Update-RubrikVCenter',
+               'Update-RubrikVMwareVM')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/Tests/Update-RubrikVMwareVM.Tests.ps1
+++ b/Tests/Update-RubrikVMwareVM.Tests.ps1
@@ -48,14 +48,12 @@ Describe -Name 'Public/Update-RubrikVMwareVM' -Tag 'Public', 'Update-RubrikVMwar
         }
 
         Get-RubrikVM 
-        It -Name 'Get-VM' -Test {
+        It -Name 'Get-TestVM should return id / vmmoid' -Test {
             Get-TestVM -Name 'Jaap' | Should -Be '@{vcenterId=vCenter:::1226ff04-6100-454f-905b-5df817b6981a; vmMoid=vm-100}'
         }
 
-        It -Name 'Valid execution' -Test {
-            Get-TestVM -Name 'Jaap' | ForEach-Object {
-                Update-RubrikVMwareVM -vcenterId $_.vcenterId -vmMoid $_.vmMoid
-            } | Should -Be $null
+        It -Name 'Valid execution based on Get-TestVM' -Test {
+            Get-TestVM -Name 'Jaap' | Update-RubrikVMwareVM | Should -Be $null
         }
 
         Assert-VerifiableMock

--- a/Tests/Update-RubrikVMwareVM.Tests.ps1
+++ b/Tests/Update-RubrikVMwareVM.Tests.ps1
@@ -36,7 +36,8 @@ Describe -Name 'Public/Update-RubrikVMwareVM' -Tag 'Public', 'Update-RubrikVMwar
 
     Context -Name 'Request Succeeds' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
-        Mock -CommandName Get-RubrikVM -Verifiable -ModuleName 'Rubrik' -MockWith {
+        function Get-TestVM {}
+        Mock -CommandName Get-TestVM -MockWith {
             [pscustomobject]@{
                 vcenterId = 'vCenter:::1226ff04-6100-454f-905b-5df817b6981a'
                 vmMoid = 'vm-100'
@@ -48,21 +49,18 @@ Describe -Name 'Public/Update-RubrikVMwareVM' -Tag 'Public', 'Update-RubrikVMwar
 
         Get-RubrikVM 
         It -Name 'Get-VM' -Test {
-            Get-RubrikVM | Should -Be ([pscustomobject]@{
-                vcenterId = 'vCenter:::1226ff04-6100-454f-905b-5df817b6981a'
-                vmMoid = 'vm-100'
-            })
+            Get-TestVM -Name 'Jaap' | Should -Be '@{vcenterId=vCenter:::1226ff04-6100-454f-905b-5df817b6981a; vmMoid=vm-100}'
         }
 
         It -Name 'Valid execution' -Test {
-            Get-RubrikVM | ForEach-Object {
-                Update-RubrikVMwareVM -vcenterId $_.vcenter -vmMoid $_.vmMoid
+            Get-TestVM -Name 'Jaap' | ForEach-Object {
+                Update-RubrikVMwareVM -vcenterId $_.vcenterId -vmMoid $_.vmMoid
             } | Should -Be $null
         }
 
         Assert-VerifiableMock
         Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
         Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Get-RubrikVM -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Get-TestVM -Times 2
     }
 }

--- a/Tests/Update-RubrikVMwareVM.ps1
+++ b/Tests/Update-RubrikVMwareVM.ps1
@@ -1,0 +1,35 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Update-RubrikVMwareVM' -Tag 'Public', 'Update-RubrikVMwareVM' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Request Fails' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            throw
+        }
+        It -Name 'Should return local' -Test {
+            Update-RubrikVMwareVM -Id vCenter:::doesnotexist -moid vm-1337 | Should -Throw
+        }
+
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}


### PR DESCRIPTION
# Description

Added new cmdlet Update-RubrikVMwareVM

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

[Issue 305(https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/305)]

## Motivation and Context

Why is this change required? What problem does it solve?

Doing a full vCenter refresh can be time and resource intensive when managing a very large VMware environment.
Create a cmdlet to refresh a single VM's metadata using the following endpoint: /vmware/vcenter/{id}/refresh_vm

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
