### PR TITLE
Issue 311 - Removed Relics from Protect-RubrikTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-06-27
+
+### Fixed [Protect-RubrikTag]
+
+* modified Protect-RubrikTag in order to ignore relic's when retrieving the vCenter UUID.
+* Addresses [Issue 311](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/311)
+* added associated Unit test for the cmdlet.
+
 ## 2019-06-26
 
 ### Added [Tests for Get-RubrikHost]

--- a/Rubrik/Public/Protect-RubrikTag.ps1
+++ b/Rubrik/Public/Protect-RubrikTag.ps1
@@ -95,7 +95,7 @@ function Protect-RubrikTag
       $DoNotProtect = $false
       $Inherit = $false
       if ($vmlist.count -gt 0) {
-        $vcuuid = ((Get-RubrikVM -VM ($vmlist[0].Name) -PrimaryClusterID 'local').vCenterId) -replace 'vCenter:::', ''
+        $vcuuid = ((Get-RubrikVM -VM ($vmlist[0].Name) -PrimaryClusterID 'local' | where-object {$_.isRelic -eq $false}).vCenterId) -replace 'vCenter:::', ''
       }
     }
     catch

--- a/Tests/Protect-RubrikTag.Tests.ps1
+++ b/Tests/Protect-RubrikTag.Tests.ps1
@@ -1,0 +1,41 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Protect-RubrikTag' -Tag 'Public', 'Protect-RubrikTag' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.0'
+    }
+    #endregion
+
+    Context -Name 'Parameter Validation' {
+        It -Name 'Parameter Tag is mandatory' -Test {
+            { Protect-RubrikTag } |
+                Should -Throw "Parameter set cannot be resolved using the specified named parameters."
+        }
+        It -Name 'Parameter Category is mandatory' -Test {
+            { Protect-RubrikTag -Tag 'mytag' } |
+                Should -Throw "Parameter set cannot be resolved using the specified named parameters."
+        }
+        It -Name 'Parameter Tag is null or empty' -Test {
+            { Protect-RubrikTag -Tag '' -Category 'mycategory'} |
+                Should -Throw "Cannot bind argument to parameter 'Tag' because it is an empty string."
+        }
+        It -Name 'Parameter Category is null or empty' -Test {
+            { Protect-RubrikTag -Tag 'mytag' -Category $null} |
+                Should -Throw "Cannot bind argument to parameter 'Category' because it is an empty string."
+        }
+
+    }
+}


### PR DESCRIPTION
# Description

Modified the Protect-RubrikTag cmdlet in order to ignore relic's when grabbing the vCenter UUID. With Relics it was concatenating all UUIDs from each VM.
Added associated unit test for Protect-RubrikTag to perform parameter validation

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

Addresses and resolves [Issue 311](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/311)

## Motivation and Context

Why is this change required? What problem does it solve?

The cmdlet was throwing error messages when dealing with relics.

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

Tested within the Tech Marketing lab.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
