### PR TITLE
Issue 354 - Added DetailedObject parameter to Get-RubrikDatabase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-07-08
+
+### Changed [Get-RubrikDatabase]
+
+* Added ability to specify -DetailedObject on Get-RubrikDatabase to address [Issue 354](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/354)
+
 ## 2019-07-03
 
 ### Added [Unit tests]

--- a/Rubrik/Public/Get-RubrikDatabase.ps1
+++ b/Rubrik/Public/Get-RubrikDatabase.ps1
@@ -23,6 +23,10 @@ function Get-RubrikDatabase
       This will return details on all databases named DB1 protected by the Gold SLA Domain on any known host or instance.
 
       .EXAMPLE
+      Get-RubrikDatabase -Name 'DB1' -DetailedObject
+      This will return the Database object with all properties, including additional details such as snapshots taken of the database and recovery point date/time information. Using this switch parameter negatively affects performance 
+
+      .EXAMPLE
       Get-RubrikDatabase -Name 'DB1' -Host 'Host1' -Instance 'MSSQLSERVER'
       This will return details on a database named "DB1" living on an instance named "MSSQLSERVER" on the host named "Host1".
 

--- a/Rubrik/Public/Get-RubrikDatabase.ps1
+++ b/Rubrik/Public/Get-RubrikDatabase.ps1
@@ -76,7 +76,10 @@ function Get-RubrikDatabase
     [String]$id,
     # SLA id value
     [Alias('effective_sla_domain_id')]
-    [String]$SLAID,     
+    [String]$SLAID,
+    # DetailedObject will retrieved the detailed database object, the default behavior of the API is to only retrieve a subset of the database object unless we query directly by ID. Using this parameter does affect performance as more data will be retrieved and more API-queries will be performed.
+    [Parameter(ParameterSetName='Query')]
+    [Switch]$DetailedObject,     
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
     # API version
@@ -136,8 +139,17 @@ function Get-RubrikDatabase
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
     $result = Test-FilterObject -filter ($resources.Filter) -result $result
-
-    return $result
+    
+    # If the Get-RubrikDatabase function has been called with the -DetailedObject parameter a separate API query will be performed if the initial query was not based on ID
+    if (($DetailedObject) -and (-not $PSBoundParameters.containskey('id'))) {
+      for ($i = 0; $i -lt @($result).Count; $i++) {
+        $Percentage = [int]($i/@($result).count*100)
+        Write-Progress -Activity "DetailedObject queries in Progress, $($i+1) out of $(@($result).count)" -Status "$Percentage% Complete:" -PercentComplete $Percentage
+        Get-RubrikDatabase -id $result[$i].id
+      }
+    } else {
+      return $result
+    }
 
   } # End of process
 } # End of function


### PR DESCRIPTION
# Description

Added the -DetailedObject parameter to the Get-RubrikDatabase cmdlet in order to support pulling down more information.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

[Issue 354](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/354)

## Motivation and Context

Why is this change required? What problem does it solve?

Allows customers to retrieve more detailed information around a database without having to know the specific id of the database.

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

Tested in the TM lab against CDM 5.0

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
