### PR TITLE
Improvements in Connect-Rubrik

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-07-17
+
+### Changed [Connect-Rubrik]
+
+* Added Userid to RubrikConnection variable when connecting using an API-token
+* Resolves [Issue 381](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/381)
+
 ## 2019-07-16
 
 ### Changed [New-RubrikSLA]

--- a/Rubrik/Public/Connect-Rubrik.ps1
+++ b/Rubrik/Public/Connect-Rubrik.ps1
@@ -115,9 +115,15 @@ function Connect-Rubrik {
                 version = Get-RubrikSoftwareVersion -Server $Server
                 authType = 'Token'
             }
-            
+
             try {
-                $null = Get-RubrikVersion -ErrorAction Stop
+                $RestSplat = @{
+                    Endpoint = 'user/me'
+                    Method = 'get'
+                    Api = 'internal'
+                }
+                $global:rubrikConnection.userid = (Invoke-RubrikRESTCall @RestSplat -ErrorAction Stop).id -replace '.*?:::'
+
             } catch {
                 Write-Verbose -Message 'Removing API token from $RubrikConnection using Disconnect-Rubrik'
                 Disconnect-Rubrik


### PR DESCRIPTION
# Description

Get-RubrikAPIToken fails with unclear error message

## Related Issue

#381

## Motivation and Context

Get-RubrikAPIToken fails with unclear error message, this is because there is no userid in the rubrikconnection variable when connecting with a token

## How Has This Been Tested?

Tested against Tech Marketing Clusters

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
