### PR TITLE
Issue 346 - Various Unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-07-19
+
+### Added [Various Unit Tests]
+
+* Added Unit Tests for Get-RubrikMount, Set-RubrikMount, New-RubrikMount, Remove-RubrikMount, Set-RubrikBlackout, Get-RubrikSupportTunnel, Set-RubrikSupportTunnel, Get-RubrikVersion, Get-RubrikAPIVersion and Get-RubrikSoftwareVersion
+* Added filtering abilities in Get-RubrikAPIData to support id and vmid filtering in the Get-RubrikMount cmdlet
+* Resolves [Issue 346](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/346)
+
 ## 2019-07-17
 
 ### Changed [Connect-Rubrik]

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -403,7 +403,10 @@ function Get-RubrikAPIData($endpoint) {
                     limit  = 'limit'
                 }
                 Result      = 'data'
-                Filter      = ''
+                Filter      = @{
+                    id = 'id'
+                    vmId = 'vmId'    
+                }
                 Success     = '200'
             }
         }

--- a/Tests/Get-RubrikAPIVersion.Tests.ps1
+++ b/Tests/Get-RubrikAPIVersion.Tests.ps1
@@ -1,0 +1,35 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikAPIVersion' -Tag 'Public', 'Get-RubrikAPIVersion' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith { return 1}
+        It -Name 'Should return 1' -Test {
+            ( Get-RubrikAPIVersion -Server 'server') |
+                Should -BeExactly 1
+        }
+        It -Name 'Server cannot be null' -Test {
+            { Get-RubrikAPIVersion -Server $null } |
+                Should -Throw "Cannot bind argument to parameter 'Server' because it is an empty string."
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}

--- a/Tests/Get-RubrikAPIVersion.Tests.ps1
+++ b/Tests/Get-RubrikAPIVersion.Tests.ps1
@@ -30,6 +30,6 @@ Describe -Name 'Public/Get-RubrikAPIVersion' -Tag 'Public', 'Get-RubrikAPIVersio
                 Should -Throw "Cannot bind argument to parameter 'Server' because it is an empty string."
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
     }
 }

--- a/Tests/Get-RubrikMount.Tests.ps1
+++ b/Tests/Get-RubrikMount.Tests.ps1
@@ -64,7 +64,7 @@ Describe -Name 'Public/Get-RubrikMount' -Tag 'Public', 'Get-RubrikMount' -Fixtur
                 Should -BeExactly 0
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 4
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 4
     }
 }

--- a/Tests/Get-RubrikMount.Tests.ps1
+++ b/Tests/Get-RubrikMount.Tests.ps1
@@ -1,0 +1,70 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikMount' -Tag 'Public', 'Get-RubrikMount' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'id'                    = '11-22-33'
+                'vmId'                  = 'VirtualMachine:::111'
+                'isReady'               = 'True'
+                'hostId'                = 'Host:::111'
+            },
+            @{ 
+                'id'                    = '11-22-44'
+                'vmId'                  = 'VirtualMachine:::111'
+                'isReady'               = 'True'
+                'hostId'                = 'Host:::222'
+            },
+            @{ 
+                'id'                    = '11-22-55'
+                'vmId'                  = 'VirtualMachine:::222'
+                'isReady'               = 'True'
+                'hostId'                = 'Host:::111'
+            },
+            @{ 
+                'id'                    = '11-22-66'
+                'vmId'                  = 'VirtualMachine:::333'
+                'isReady'               = 'True'
+                'hostId'                = 'Host:::111'
+            }
+        }
+        It -Name 'No filter should return count of 4' -Test {
+            ( Get-RubrikMount).Count |
+                Should -BeExactly 4
+        }
+        It -Name 'Should return proper host' -Test {
+            (Get-RubrikMount -id '11-22-44').hostId |
+                Should -BeExactly 'Host:::222'
+        }
+        It -Name 'Filter vmId should return count of 2' -Test {
+            ( Get-RubrikMount -VMID 'VirtualMachine:::111').Count |
+                Should -BeExactly 2
+        }
+        It -Name 'Nonexistant id should return count of 0 ' -Test {
+            (Get-RubrikMount -id 'nonexistant').count |
+                Should -BeExactly 0
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}

--- a/Tests/Get-RubrikMount.Tests.ps1
+++ b/Tests/Get-RubrikMount.Tests.ps1
@@ -47,7 +47,7 @@ Describe -Name 'Public/Get-RubrikMount' -Tag 'Public', 'Get-RubrikMount' -Fixtur
                 'hostId'                = 'Host:::111'
             }
         }
-        It -Name 'No filter should return count of 4' -Test {
+        It -Name 'Filter should return count of 4' -Test {
             ( Get-RubrikMount).Count |
                 Should -BeExactly 4
         }

--- a/Tests/Get-RubrikSoftwareVersion.Tests.ps1
+++ b/Tests/Get-RubrikSoftwareVersion.Tests.ps1
@@ -30,6 +30,6 @@ Describe -Name 'Public/Get-RubrikSoftwareVersion' -Tag 'Public', 'Get-RubrikSoft
                 Should -Throw "Cannot bind argument to parameter 'Server' because it is an empty string."
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
     }
 }

--- a/Tests/Get-RubrikSoftwareVersion.Tests.ps1
+++ b/Tests/Get-RubrikSoftwareVersion.Tests.ps1
@@ -1,0 +1,35 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikSoftwareVersion' -Tag 'Public', 'Get-RubrikSoftwareVersion' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith { return '5.0.1-p2-1592'}
+        It -Name 'Should return 1' -Test {
+            ( Get-RubrikSoftwareVersion -Server 'server') |
+                Should -BeExactly '5.0.1-p2-1592'
+        }
+        It -Name 'Server cannot be null' -Test {
+            { Get-RubrikSoftwareVersion -Server $null } |
+                Should -Throw "Cannot bind argument to parameter 'Server' because it is an empty string."
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}

--- a/Tests/Get-RubrikSupportTunnel.Tests.ps1
+++ b/Tests/Get-RubrikSupportTunnel.Tests.ps1
@@ -1,0 +1,39 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikSupportTunnel' -Tag 'Public', 'Get-RubrikSupportTunnel' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+ 
+    Context -Name 'Parameter Validation' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                'inactivityTimeoutInSeconds'        = '1000'
+                'port'                              = '11874'
+                'isTunnelEnabled'                   = 'True'
+            }
+        }
+        It -Name 'Results filtering' -Test {
+            (Get-RubrikSupportTunnel).isTunnelEnabled |
+                Should -BeExactly 'True'
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Times 1
+    }
+}

--- a/Tests/Get-RubrikSupportTunnel.Tests.ps1
+++ b/Tests/Get-RubrikSupportTunnel.Tests.ps1
@@ -33,7 +33,7 @@ Describe -Name 'Public/Get-RubrikSupportTunnel' -Tag 'Public', 'Get-RubrikSuppor
                 Should -BeExactly 'True'
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Exactly 1
     }
 }

--- a/Tests/Get-RubrikVersion.Tests.ps1
+++ b/Tests/Get-RubrikVersion.Tests.ps1
@@ -38,7 +38,7 @@ Describe -Name 'Public/Get-RubrikVersion' -Tag 'Public', 'Get-RubrikVersion' -Fi
                 Should -BeExactly 'Cluster_B'
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 2
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 2
     }
 }

--- a/Tests/Get-RubrikVersion.Tests.ps1
+++ b/Tests/Get-RubrikVersion.Tests.ps1
@@ -1,0 +1,44 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikVersion' -Tag 'Public', 'Get-RubrikVersion' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'name'                   = 'Cluster_B'
+                'id'                     = '111111'
+                'version'                = '5.0.1-p2-1592'
+                'apiVersion'             = '1'
+            }
+        }
+        It -Name 'Should Return count of 4' -Test {
+            ( Get-RubrikVersion).Count |
+                Should -BeExactly 4
+        }
+        It -Name 'Should Return Cluster_B' -Test {
+            (Get-RubrikVersion).Name |
+                Should -BeExactly 'Cluster_B'
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}

--- a/Tests/New-RubrikMount.Tests.ps1
+++ b/Tests/New-RubrikMount.Tests.ps1
@@ -55,7 +55,7 @@ Describe -Name 'Public/New-RubrikMount' -Tag 'Public', 'New-RubrikMount' -Fixtur
                 Should -Throw "Cannot process argument transformation on parameter 'PowerOn'. Cannot convert value `"System.String`" to type `"System.Boolean`"."
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Exactly 1
     }
 }

--- a/Tests/New-RubrikMount.Tests.ps1
+++ b/Tests/New-RubrikMount.Tests.ps1
@@ -1,0 +1,61 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/New-RubrikMount' -Tag 'Public', 'New-RubrikMount' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Parameter Validation' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                'id'       = 'MOUNT_SNAPSHOT_11111'
+                'status'   = 'QUEUED'
+                'progress' = '0'
+            }
+        }
+
+        It -Name 'Should create mount with QUEUED status' -Test {
+            ( New-RubrikMount -Id 'snapshotid').status |
+                Should -BeExactly 'QUEUED'
+        }
+        
+        It -Name 'Parameter id is missing' -Test {
+            { New-RubrikMount -Id  } |
+                Should -Throw "Missing an argument for parameter 'Id'. Specify a parameter of type 'System.String' and try again."
+        }
+        It -Name 'Parameter id is empty' -Test {
+            { New-RubrikMount -id ''  } |
+                Should -Throw "Cannot bind argument to parameter 'Id' because it is an empty string."
+        }
+        It -Name 'Validate Disable Network Boolean' -Test {
+            { New-RubrikMount -id 'id' -DisableNetwork yes  } |
+                Should -Throw "Cannot process argument transformation on parameter 'DisableNetwork'. Cannot convert value `"System.String`" to type `"System.Boolean`"."
+        }
+        It -Name 'Validate Remove Network Devices Boolean' -Test {
+            { New-RubrikMount -id 'id' -RemoveNetworkDevices yes  } |
+                Should -Throw "Cannot process argument transformation on parameter 'RemoveNetworkDevices'. Cannot convert value `"System.String`" to type `"System.Boolean`"."
+        }
+        It -Name 'Validate PowerOn Boolean' -Test {
+            { New-RubrikMount -id 'id' -PowerOn yes  } |
+                Should -Throw "Cannot process argument transformation on parameter 'PowerOn'. Cannot convert value `"System.String`" to type `"System.Boolean`"."
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Times 1
+    }
+}

--- a/Tests/Remove-RubrikMount.Tests.ps1
+++ b/Tests/Remove-RubrikMount.Tests.ps1
@@ -1,0 +1,49 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Remove-RubrikMount' -Tag 'Public', 'Remove-RubrikMount' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Parameter Validation' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                'id'       = 'UNMOUNT_SNAPSHOT_11111'
+                'status'   = 'QUEUED'
+                'progress' = '0'
+            }
+        }
+
+        It -Name 'Should remove mount with QUEUED' -Test {
+            ( Remove-RubrikMount -Id 'snapshotid').status |
+                Should -BeExactly 'QUEUED'
+        }
+        
+        It -Name 'Parameter id is missing' -Test {
+            { Remove-RubrikMount -Id  } |
+                Should -Throw "Missing an argument for parameter 'Id'. Specify a parameter of type 'System.String' and try again."
+        }
+        It -Name 'Parameter id is empty' -Test {
+            { Remove-RubrikMount -id ''  } |
+                Should -Throw "Cannot bind argument to parameter 'Id' because it is an empty string."
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Times 1
+    }
+}

--- a/Tests/Remove-RubrikMount.Tests.ps1
+++ b/Tests/Remove-RubrikMount.Tests.ps1
@@ -43,7 +43,7 @@ Describe -Name 'Public/Remove-RubrikMount' -Tag 'Public', 'Remove-RubrikMount' -
                 Should -Throw "Cannot bind argument to parameter 'Id' because it is an empty string."
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
     }
 }

--- a/Tests/Set-RubrikBlackout.Tests.ps1
+++ b/Tests/Set-RubrikBlackout.Tests.ps1
@@ -1,0 +1,37 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Set-RubrikBlackout' -Tag 'Public', 'Set-RubrikBlackout' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                isGlobalBlackoutActive = 'true'
+            }
+        }
+        It -Name 'Should return true' -Test {
+            (Set-RubrikBlackout -Set:$true).isGlobalBlackoutActive |
+                Should -BeExactly 'true'
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}

--- a/Tests/Set-RubrikBlackout.Tests.ps1
+++ b/Tests/Set-RubrikBlackout.Tests.ps1
@@ -31,7 +31,7 @@ Describe -Name 'Public/Set-RubrikBlackout' -Tag 'Public', 'Set-RubrikBlackout' -
                 Should -BeExactly 'true'
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
     }
 }

--- a/Tests/Set-RubrikMount.Tests.ps1
+++ b/Tests/Set-RubrikMount.Tests.ps1
@@ -1,0 +1,53 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Set-RubrikMount' -Tag 'Public', 'Set-RubrikMount' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'id'                    = '11-22-33'
+                'vmId'                  = 'VirtualMachine:::111'
+                'isReady'               = 'True'
+                'hostId'                = 'Host:::111'
+                'powerStatus'           = 'poweredOff'
+            }
+        }
+        It -Name 'Should return poweredOff status' -Test {
+            (Set-RubrikMount -id '11-22-33' -PowerOn $false).powerStatus |
+                Should -BeExactly 'poweredOff'
+        }
+        It -Name 'Parameter ID cannot be $null' -Test {
+            { Set-RubrikMount -Id $null } |
+                Should -Throw "Cannot bind argument to parameter 'id' because it is an empty string."
+        }
+        It -Name 'Parameter ID cannot be empty' -Test {
+            { Set-RubrikMount -Id '' } |
+                Should -Throw "Cannot bind argument to parameter 'id' because it is an empty string."
+        }
+        It -Name 'Validate PowerOn Boolean' -Test {
+            { Set-RubrikMount -id 'id' -PowerOn yes  } |
+                Should -Throw "Cannot process argument transformation on parameter 'PowerOn'. Cannot convert value `"System.String`" to type `"System.Boolean`"."
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}

--- a/Tests/Set-RubrikMount.Tests.ps1
+++ b/Tests/Set-RubrikMount.Tests.ps1
@@ -41,13 +41,13 @@ Describe -Name 'Public/Set-RubrikMount' -Tag 'Public', 'Set-RubrikMount' -Fixtur
         It -Name 'Parameter ID cannot be empty' -Test {
             { Set-RubrikMount -Id '' } |
                 Should -Throw "Cannot bind argument to parameter 'id' because it is an empty string."
-        }
+        } 
         It -Name 'Validate PowerOn Boolean' -Test {
             { Set-RubrikMount -id 'id' -PowerOn yes  } |
                 Should -Throw "Cannot process argument transformation on parameter 'PowerOn'. Cannot convert value `"System.String`" to type `"System.Boolean`"."
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
     }
 }

--- a/Tests/Set-RubrikSupportTunnel.Tests.ps1
+++ b/Tests/Set-RubrikSupportTunnel.Tests.ps1
@@ -41,7 +41,7 @@ Describe -Name 'Public/Set-RubrikSupportTunnel' -Tag 'Public', 'Set-RubrikSuppor
                 Should -Throw "Missing an argument for parameter 'EnableTunnel'. Specify a parameter of type 'System.Boolean' and try again."
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Exactly 1
     }
 }

--- a/Tests/Set-RubrikSupportTunnel.Tests.ps1
+++ b/Tests/Set-RubrikSupportTunnel.Tests.ps1
@@ -1,0 +1,47 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Set-RubrikSupportTunnel' -Tag 'Public', 'Set-RubrikSupportTunnel' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+ 
+    Context -Name 'Parameter Validation' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                'inactivityTimeoutInSeconds'        = '1000'
+                'port'                              = '11874'
+                'isTunnelEnabled'                   = 'True'
+            }
+        }
+        It -Name 'Enabling Tunnel' -Test {
+            (Set-RubrikSupportTunnel -EnableTunnel $true).isTunnelEnabled |
+                Should -BeExactly 'True'
+        }
+        It -Name 'Parameter EnableTunnel cannot be $null' -Test {
+            { Set-RubrikSupportTunnel -EnableTunnel $null } |
+                Should -Throw "Cannot process argument transformation on parameter 'EnableTunnel'. Cannot convert value `"`" to type `"System.Boolean`". Boolean parameters accept only Boolean values and numbers, such as `$True, `$False, 1 or 0."
+        }
+        It -Name 'Parameter EnableTunnel must be specified' -Test {
+            { Set-RubrikSupportTunnel -EnableTunnel } |
+                Should -Throw "Missing an argument for parameter 'EnableTunnel'. Specify a parameter of type 'System.Boolean' and try again."
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Times 1
+    }
+}


### PR DESCRIPTION
# Description

* Added Unit Tests for Get-RubrikMount, Set-RubrikMount, New-RubrikMount, Remove-RubrikMount, Set-RubrikBlackout, Get-RubrikSupportTunnel, Set-RubrikSupportTunnel, Get-RubrikVersion, Get-RubrikAPIVersion and Get-RubrikSoftwareVersion
* Added filtering abilities in Get-RubrikAPIData to support id and vmid filtering in the Get-RubrikMount cmdlet

## Related Issue

 [Issue 346](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/346)

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

Helps with automated testing

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
Executed individual scripts as well as Invoke-Pester
## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
