### PR TITLE
Resolve Oracle DB Snapshot issue #394

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-07-22
+
+### Fixed [Get-RubrikSnapshot]
+
+* Incorrect endpoint was used for Oracle database in combination Get-RubrikSnapshot [Issue 394](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/394)
+
 ## 2019-07-20
 
 ### Changed [Set-RubrikSLA]

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -617,7 +617,7 @@ function Get-RubrikAPIData($endpoint) {
         }
         'Get-RubrikSnapshot'           = @{
             '1.0' = @{
-                Description = 'Retrieve information for all snapshots '
+                Description = 'Retrieve information for all snapshots'
                 URI         = @{
                     Fileset = '/api/v1/fileset/{id}/snapshot'
                     MSSQL   = '/api/v1/mssql/db/{id}/snapshot'
@@ -626,7 +626,7 @@ function Get-RubrikAPIData($endpoint) {
                     ManagedVolume = '/api/internal/managed_volume/{id}/snapshot'
                     Nutanix = '/api/internal/nutanix/vm/{id}/snapshot'
                     VolumeGroup = '/api/internal/volume_group/{id}/snapshot'
-                    Oracle = '/api/internal/oracle/{id}/snapshot'
+                    Oracle = '/api/internal/oracle/db/{id}/snapshot'
                 }
                 Method      = 'Get'
                 Body        = ''


### PR DESCRIPTION
Current Behavior:

Provide information about the failure by issuing the command using the -Verbose command.

WARNING: The endpoint supplied to Rubrik is invalid. Likely this is due to an incompatible version of the API or references pointing to a non-existent endpoint. The URI passed was: https://<hidden ip>/api/internal/oracle/OracleDatabase:::577a78fb-e8eb-4b43-9f76-88138a25e814/snapshot
Expected Behavior:

Oracle db snapshot endpoint should be /oracle/db/{id}/snapshot.

Steps to Reproduce:

Please provide detailed steps for reproducing the issue.

Get-RubrikSnapshot -id
Context:

Please provide any relevant information about your setup. This is important in case the issue is not reproducible except for under certain conditions.


Resolve #394 