### PR TITLE
Fixed: Get-RubrikEvent submits 2 limit flags issue 353

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Removed unnecessary braces for the frequencies array in the request body when using API v2 to address [Issue 391](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/391)
 * Fixed the $FirstFullBackupDay variable to be an integer when the value is retrieved from the pipeline with Get-RubrikSLA
 
+### Fixed [Get-RubrikEvent]
+
+* Multiple limit flags were added to the GET query as reported in [Issue 353](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/353), this has been fixed
+
 ## 2019-07-22
 
 ### Changed [New-RubrikSLA]

--- a/Rubrik/Private/Test-QueryParam.ps1
+++ b/Rubrik/Private/Test-QueryParam.ps1
@@ -86,7 +86,12 @@
     }
   }
   # After all query options are exhausted, build a new URI with all defined query options
-  $uri = New-QueryString -query $querystring -uri $uri -nolimit $true
+  
+  if ($parameters.name -contains 'limit') {
+    $uri = New-QueryString -query $querystring -uri $uri
+  } else {  
+    $uri = New-QueryString -query $querystring -uri $uri -nolimit $true
+  }
   Write-Verbose -Message "URI = $uri"
     
   return $uri

--- a/Rubrik/Public/New-RubrikSLA.ps1
+++ b/Rubrik/Public/New-RubrikSLA.ps1
@@ -189,7 +189,21 @@ function New-RubrikSLA
 
     # Populate the body with the allowed backup window settings fort the first full
     if (($FirstFullBackupStartHour -ge 0) -and ($FirstFullBackupStartMinute -ge 0) -and $FirstFullBackupDay -and $FirstFullBackupWindowDuration) {
-      $FirstFullBackupDay = ([System.DayOfWeek]::$FirstFullBackupDay -as [int])+1
+      if ($FirstFullBackupDay -eq 'Sunday') {
+        [int]$FirstFullBackupDay = 1
+      } elseif ($FirstFullBackupDay -eq 'Monday') {
+        [int]$FirstFullBackupDay = 2
+      } elseif ($FirstFullBackupDay -eq 'Tuesday') {
+        [int]$FirstFullBackupDay = 3
+      } elseif ($FirstFullBackupDay -eq 'Wednesday') {
+        [int]$FirstFullBackupDay = 4
+      } elseif ($FirstFullBackupDay -eq 'Thursday') {
+        [int]$FirstFullBackupDay = 5
+      } elseif ($FirstFullBackupDay -eq 'Friday') {
+        [int]$FirstFullBackupDay = 6
+      } elseif ($FirstFullBackupDay -eq 'Saturday') {
+        [int]$FirstFullBackupDay = 7
+      }
       $body.FirstFullAllowedBackupWindows += @{
           startTimeAttributes = @{hour=$FirstFullBackupStartHour;minutes=$FirstFullBackupStartMinute;dayOfWeek=$FirstFullBackupDay};
           durationInHours = $FirstFullBackupWindowDuration


### PR DESCRIPTION
# Description

Get-RubrikEvent submits 2 limit flags

## Related Issue

Resolve #353 

## Motivation and Context

Expects the query to the endpoint to only contain a single limit flag.

## How Has This Been Tested?
Tested against cluster

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12744735/61754428-fed32d00-ad67-11e9-9719-d0f9bf23fb2c.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] All new and existing tests passed.
