### PR TITLE
Issue with Get-RubrikSQLInstance and documentation update - Issue #399

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-07-31
+
+### Fixed [Get-RubrikSQLInstance]
+
+* The Get-RubrikSQLInstance PrimaryClusterID had a bug as reported in issue [Issue 399](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/399)
+* Updated parameter help to correctly suggest `local` to be used
+* Added additional examples that describe usage of the -PrimaryClusterID parameter
+
 ## 2019-07-30
 
 ### Changed [readme.md]

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -659,6 +659,7 @@ function Get-RubrikAPIData($endpoint) {
                 Body        = ''
                 Query       = @{
                     instance_id = 'instance_id'
+                    primary_cluster_id = 'primary_cluster_id'
                 }
                 Result      = 'data'
                 Filter      = @{

--- a/Rubrik/Public/Get-RubrikSQLInstance.ps1
+++ b/Rubrik/Public/Get-RubrikSQLInstance.ps1
@@ -30,7 +30,11 @@ function Get-RubrikSQLInstance
 
     .EXAMPLE
     Get-RubrikSQLInstance -PrimaryClusterID local
-    Only return local as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    Only return SQLInstances of the Rubrik cluster that is hosting the current REST API session.
+
+    .EXAMPLE
+    Get-RubrikSQLInstance -PrimaryClusterID 8b4fe6f6-cc87-4354-a125-b65e23cf8c90
+    Only return SQLInstances of the specified id of the Rubrik cluster that is hosting the current REST API session.
 #>
 
   [CmdletBinding()]

--- a/Rubrik/Public/Get-RubrikSQLInstance.ps1
+++ b/Rubrik/Public/Get-RubrikSQLInstance.ps1
@@ -41,7 +41,7 @@ function Get-RubrikSQLInstance
        [String]$Hostname,
        #ServerInstance name (combined hostname\instancename)
        [String]$ServerInstance,
-       # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+       # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use: local as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
        [Alias('primary_cluster_id')]
        [String]$PrimaryClusterID,    
        # Rubrik's database id value

--- a/Rubrik/Public/Get-RubrikSQLInstance.ps1
+++ b/Rubrik/Public/Get-RubrikSQLInstance.ps1
@@ -1,34 +1,37 @@
 #requires -Version 3
 function Get-RubrikSQLInstance
 {
-  <#  
-      .SYNOPSIS
-      Gets internal Rubrik object that represents a SQL Server instance
+<#  
+    .SYNOPSIS
+    Gets internal Rubrik object that represents a SQL Server instance
 
-      .DESCRIPTION
-      Returns internal Rubrik object that represents a SQL Server instance. This 
+    .DESCRIPTION
+    Returns internal Rubrik object that represents a SQL Server instance. This 
 
-      .NOTES
-      Written by Mike Fal for community usage
-      Twitter: @Mike_Fal
-      GitHub: MikeFal
+    .NOTES
+    Written by Mike Fal for community usage
+    Twitter: @Mike_Fal
+    GitHub: MikeFal
 
-      .LINK
-      http://rubrikinc.github.io/rubrik-sdk-for-powershell/
+    .LINK
+    http://rubrikinc.github.io/rubrik-sdk-for-powershell/
 
-      .EXAMPLE
-      Get-RubrikSQLInstance -Name MSSQLSERVER
-      Retrieve all default SQL instances managed by Rubrik
+    .EXAMPLE
+    Get-RubrikSQLInstance -Name MSSQLSERVER
+    Retrieve all default SQL instances managed by Rubrik
 
-      .EXAMPLE
-      Get-RubrikSQLInstance -ServerInstance msf-sql2016
-      Retrieve the default SQL instance on host msf-sql2016
+    .EXAMPLE
+    Get-RubrikSQLInstance -ServerInstance msf-sql2016
+    Retrieve the default SQL instance on host msf-sql2016
 
-      .EXAMPLE
-      Get-RubrikSQLInstance -Hostname msf-sql2016
-      Retrieves all the SQL instances on host msf-sql2016
+    .EXAMPLE
+    Get-RubrikSQLInstance -Hostname msf-sql2016
+    Retrieves all the SQL instances on host msf-sql2016
 
-  #>
+    .EXAMPLE
+    Get-RubrikSQLInstance -PrimaryClusterID local
+    Only return local as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+#>
 
   [CmdletBinding()]
   Param(


### PR DESCRIPTION
# Description

Provide information about the failure by issuing the command using the -Verbose command.
* Get-RubrikSQLInstance seems to ignore the local value for PrimaryClusterID
From what I have seen, running Get-RubrikSQLInstance to pull back all SQL Instances gets all instances including instances on a remote Rubrik Cluster. Using the local flag should exclude all instances from a remote rubrik cluster.
* Help text is incorrect in the value it should use for PrimaryClusterID. It states you should use _local, when the value should be local

## Related Issue

Resolve #399 

## Motivation and Context

Bug in the Get-RubrikSQLInstance function

## How Has This Been Tested?

By running local tests and testing against TM test clusters

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
