### PR TITLE
Get-RubrikFileset -HostName is returning a wildcard match instead of an exact match - Issue #384

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 2019-07-31
 
+### Changed [Get-RubrikFileset]
+
+* Behavior of `-Name` and `-Hostname` changed to only do an exact match as reported in [Issue 384](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/384)
+* Added new `-NameFilter` and `-HostNameFilter` parameters to allow for in-fix matching
+* Added new tests for `Get-RubrikFileSet`
+
 ### Fixed [Get-RubrikSQLInstance]
 
 * The Get-RubrikSQLInstance PrimaryClusterID had a bug as reported in issue [Issue 399](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/399)

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -53,18 +53,18 @@ function Get-RubrikFileset
     [ValidateNotNullOrEmpty()]
     [Alias('Fileset')]
     [String]$Name,
-    [Parameter(ParameterSetName='NameFilter')]
+    [Parameter(ParameterSetName='Filter')]
     [ValidateNotNullOrEmpty()]
-    [String]$NameFilter,
+    [String]$Filter,
     # Exact name of the host using a fileset
     [Parameter(ParameterSetName='Query')]
     [Alias('host_name')]
     [ValidateNotNullOrEmpty()]
     # Partial match of hostname, using an 'in fix' search.
     [String]$HostName,
-    [Parameter(ParameterSetName='HostFilter')]
+    [Parameter(ParameterSetName='Filter')]
     [ValidateNotNullOrEmpty()]
-    [String]$HostNameFilter,
+    [String]$HostFilter,
     # Rubrik's fileset id
     [Parameter(ParameterSetName='ID')]
     [Parameter(ValueFromPipelineByPropertyName = $true)]    
@@ -73,58 +73,49 @@ function Get-RubrikFileset
     # Filter results to include only relic (removed) filesets
     [Alias('is_relic')]
     [Parameter(ParameterSetName='Query')]
-    [Parameter(ParameterSetName='NameFilter')]
-    [Parameter(ParameterSetName='HostFilter')]
+    [Parameter(ParameterSetName='Filter')]
     [Switch]$Relic,
     # DetailedObject will retrieved the detailed VM object, the default behavior of the API is to only retrieve a subset of the full Fileset object unless we query directly by ID. Using this parameter does affect performance as more data will be retrieved and more API-queries will be performed.
     [Parameter(ParameterSetName='Query')]
-    [Parameter(ParameterSetName='NameFilter')]
-    [Parameter(ParameterSetName='HostFilter')]
+    [Parameter(ParameterSetName='Filter')]
     [switch]$DetailedObject,
     # SLA Domain policy assigned to the database
     [Parameter(ParameterSetName='Query')]
-    [Parameter(ParameterSetName='NameFilter')]
-    [Parameter(ParameterSetName='HostFilter')]
+    [Parameter(ParameterSetName='Filter')]
     [ValidateNotNullOrEmpty()]
     [String]$SLA,
     # Filter the summary information based on the ID of a fileset template.
     [Parameter(ParameterSetName='Query')]
-    [Parameter(ParameterSetName='NameFilter')]
-    [Parameter(ParameterSetName='HostFilter')]
+    [Parameter(ParameterSetName='Filter')]
     [Alias('template_id')]
     [ValidateNotNullOrEmpty()]
     [String]$TemplateID,
     # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Parameter(ParameterSetName='Query')]
-    [Parameter(ParameterSetName='NameFilter')]
-    [Parameter(ParameterSetName='HostFilter')]
+    [Parameter(ParameterSetName='Filter')]
     [Alias('primary_cluster_id')]
     [ValidateNotNullOrEmpty()]
     [String]$PrimaryClusterID,
     # Rubrik's Share id
     [Parameter(ParameterSetName='Query')]
-    [Parameter(ParameterSetName='NameFilter')]
-    [Parameter(ParameterSetName='HostFilter')]
+    [Parameter(ParameterSetName='Filter')]
     [Alias('share_id')]
     [ValidateNotNullOrEmpty()]
     [String]$ShareID,
     # SLA id value
     [Parameter(ParameterSetName='Query')]
-    [Parameter(ParameterSetName='NameFilter')]
-    [Parameter(ParameterSetName='HostFilter')]
+    [Parameter(ParameterSetName='Filter')]
     [Alias('effective_sla_domain_id')]
     [ValidateNotNullOrEmpty()]
     [String]$SLAID,
     # Rubrik server IP or FQDN
     [Parameter(ParameterSetName='Query')]
-    [Parameter(ParameterSetName='NameFilter')]
-    [Parameter(ParameterSetName='HostFilter')]
+    [Parameter(ParameterSetName='Filter')]
     [Parameter(ParameterSetName='ID')]
     [String]$Server = $global:RubrikConnection.server,
     # API version
     [Parameter(ParameterSetName='Query')]
-    [Parameter(ParameterSetName='NameFilter')]
-    [Parameter(ParameterSetName='HostFilter')]
+    [Parameter(ParameterSetName='Filter')]
     [Parameter(ParameterSetName='ID')]
     [String]$api = $global:RubrikConnection.api
   )

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -156,6 +156,24 @@ function Get-RubrikFileset
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
     $result = Test-FilterObject -filter ($resources.Filter) -result $result
 
+    # This block of code will filter results if -Name or -Hostname are used, probably should move to a private function
+    if ('Query' -eq $PSCmdlet.ParameterSetName) {
+      if ($null -ne $PSBoundParameters.Name) {
+        $OldCount = @($Result).count
+
+        $result = $result | Where-Object {$Name -eq $_.name}
+
+        Write-Verbose ('Excluded results not matching -Name ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $Name,(@($Result).count-$OldCount),@($Result).count)
+      }
+      if ($null -ne $PSBoundParameters.HostName) {
+        $OldCount = @($Result).count
+
+        $result = $result | Where-Object {$HostName -eq $_.hostName}
+
+        Write-Verbose ('Excluded results not matching -HostName ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $HostName,(@($Result).count-$OldCount),@($Result).count)
+      }
+    }
+
     # If the Get-RubrikFileset function has been called with the -DetailedObject parameter a separate API query will be performed if the initial query was not based on ID
     if (($DetailedObject) -and (-not $PSBoundParameters.containskey('id'))) {
       for ($i = 0; $i -lt @($result).Count; $i++) {

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -147,8 +147,16 @@ function Get-RubrikFileset
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
-    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Load API data for $($resources.URI)"
     Write-Verbose -Message "Description: $($resources.Description)"
+
+    # Set Hostname and Name parameters if the filter parameters are specified. Logic later on in the script will do additional filtering
+    if (-not [string]::IsNullOrWhiteSpace($HostNameFilter)) {
+      $HostName = $HostNameFilter
+    }
+    if ($null -ne $NameFilter) {
+      $Name = $NameFilter
+    }
   
   }
 
@@ -177,7 +185,7 @@ function Get-RubrikFileset
 
         Write-Verbose ('Excluded results not matching -Name ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $Name,($OldCount-@($Result).count),@($Result).count)
       }
-      
+
       if ($null -ne $PSBoundParameters.HostName) {
         $OldCount = @($Result).count
 

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -31,6 +31,18 @@ function Get-RubrikFileset
       This will return details on the fileset named "C_Drive" assigned to any hosts with an SLA Domain matching "Gold"
 
       .EXAMPLE
+      Get-RubrikFileset -NameFilter '_Drive' -SLA Gold
+      This will return details on the filesets that contain the string "_Drive" in its name and are assigned to any hosts with an SLA Domain matching "Gold"
+
+      .EXAMPLE
+      Get-RubrikFileset -HostName 'mssqlserver01' -SLA Gold
+      This will return details on the filesets for the hostname "mssqlserver01" and are assigned to any hosts with an SLA Domain matching "Gold"
+
+      .EXAMPLE
+      Get-RubrikFileset -HostNameFilter 'mssql' -SLA Gold
+      This will return details on the filesets that contain the string "mssql" in its parent's hostname and are assigned to any hosts with an SLA Domain matching "Gold"
+
+      .EXAMPLE
       Get-RubrikFileset -id 'Fileset:::111111-2222-3333-4444-555555555555'
       This will return the filset matching the Rubrik global id value of "Fileset:::111111-2222-3333-4444-555555555555"
 
@@ -55,7 +67,7 @@ function Get-RubrikFileset
     [String]$Name,
     [Parameter(ParameterSetName='Filter')]
     [ValidateNotNullOrEmpty()]
-    [String]$Filter,
+    [String]$NameFilter,
     # Exact name of the host using a fileset
     [Parameter(ParameterSetName='Query')]
     [Alias('host_name')]
@@ -64,7 +76,7 @@ function Get-RubrikFileset
     [String]$HostName,
     [Parameter(ParameterSetName='Filter')]
     [ValidateNotNullOrEmpty()]
-    [String]$HostFilter,
+    [String]$HostNameFilter,
     # Rubrik's fileset id
     [Parameter(ParameterSetName='ID')]
     [Parameter(ValueFromPipelineByPropertyName = $true)]    

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -53,56 +53,78 @@ function Get-RubrikFileset
     [ValidateNotNullOrEmpty()]
     [Alias('Fileset')]
     [String]$Name,
-    # Filter results to include only relic (removed) filesets
-    [Alias('is_relic')]
-    [Parameter(ParameterSetName='Query')]
-    [Switch]$Relic,
-    # DetailedObject will retrieved the detailed VM object, the default behavior of the API is to only retrieve a subset of the full Fileset object unless we query directly by ID. Using this parameter does affect performance as more data will be retrieved and more API-queries will be performed.
-    [Parameter(ParameterSetName='Query')]
-    [switch]$DetailedObject,
-    # SLA Domain policy assigned to the database
-    [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='NameFilter')]
     [ValidateNotNullOrEmpty()]
-    [String]$SLA,
+    [String]$NameFilter,
     # Exact name of the host using a fileset
     [Parameter(ParameterSetName='Query')]
     [Alias('host_name')]
     [ValidateNotNullOrEmpty()]
+    # Partial match of hostname, using an 'in fix' search.
     [String]$HostName,
     [Parameter(ParameterSetName='HostFilter')]
     [ValidateNotNullOrEmpty()]
     [String]$HostNameFilter,
-    # Filter the summary information based on the ID of a fileset template.
-    [Parameter(ParameterSetName='Query')]
-    [Alias('template_id')]
-    [ValidateNotNullOrEmpty()]
-    [String]$TemplateID,
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
-    [Parameter(ParameterSetName='Query')]
-    [Alias('primary_cluster_id')]
-    [ValidateNotNullOrEmpty()]
-    [String]$PrimaryClusterID,
-    # Rubrik's Share id
-    [Parameter(ParameterSetName='Query')]
-    [Alias('share_id')]
-    [ValidateNotNullOrEmpty()]
-    [String]$ShareID,
     # Rubrik's fileset id
     [Parameter(ParameterSetName='ID')]
     [Parameter(ValueFromPipelineByPropertyName = $true)]    
     [ValidateNotNullOrEmpty()]
     [String]$id,
+    # Filter results to include only relic (removed) filesets
+    [Alias('is_relic')]
+    [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='NameFilter')]
+    [Parameter(ParameterSetName='HostFilter')]
+    [Switch]$Relic,
+    # DetailedObject will retrieved the detailed VM object, the default behavior of the API is to only retrieve a subset of the full Fileset object unless we query directly by ID. Using this parameter does affect performance as more data will be retrieved and more API-queries will be performed.
+    [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='NameFilter')]
+    [Parameter(ParameterSetName='HostFilter')]
+    [switch]$DetailedObject,
+    # SLA Domain policy assigned to the database
+    [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='NameFilter')]
+    [Parameter(ParameterSetName='HostFilter')]
+    [ValidateNotNullOrEmpty()]
+    [String]$SLA,
+    # Filter the summary information based on the ID of a fileset template.
+    [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='NameFilter')]
+    [Parameter(ParameterSetName='HostFilter')]
+    [Alias('template_id')]
+    [ValidateNotNullOrEmpty()]
+    [String]$TemplateID,
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='NameFilter')]
+    [Parameter(ParameterSetName='HostFilter')]
+    [Alias('primary_cluster_id')]
+    [ValidateNotNullOrEmpty()]
+    [String]$PrimaryClusterID,
+    # Rubrik's Share id
+    [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='NameFilter')]
+    [Parameter(ParameterSetName='HostFilter')]
+    [Alias('share_id')]
+    [ValidateNotNullOrEmpty()]
+    [String]$ShareID,
     # SLA id value
     [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='NameFilter')]
+    [Parameter(ParameterSetName='HostFilter')]
     [Alias('effective_sla_domain_id')]
     [ValidateNotNullOrEmpty()]
     [String]$SLAID,
     # Rubrik server IP or FQDN
     [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='NameFilter')]
+    [Parameter(ParameterSetName='HostFilter')]
     [Parameter(ParameterSetName='ID')]
     [String]$Server = $global:RubrikConnection.server,
     # API version
     [Parameter(ParameterSetName='Query')]
+    [Parameter(ParameterSetName='NameFilter')]
+    [Parameter(ParameterSetName='HostFilter')]
     [Parameter(ParameterSetName='ID')]
     [String]$api = $global:RubrikConnection.api
   )

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -154,7 +154,7 @@ function Get-RubrikFileset
     if (-not [string]::IsNullOrWhiteSpace($HostNameFilter)) {
       $HostName = $HostNameFilter
     }
-    if ($null -ne $NameFilter) {
+    if (-not [string]::IsNullOrWhiteSpace($NameFilter)) {
       $Name = $NameFilter
     }
   

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -175,14 +175,15 @@ function Get-RubrikFileset
 
         $result = $result | Where-Object {$Name -eq $_.name}
 
-        Write-Verbose ('Excluded results not matching -Name ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $Name,(@($Result).count-$OldCount),@($Result).count)
+        Write-Verbose ('Excluded results not matching -Name ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $Name,($OldCount-@($Result).count),@($Result).count)
       }
+      
       if ($null -ne $PSBoundParameters.HostName) {
         $OldCount = @($Result).count
 
         $result = $result | Where-Object {$HostName -eq $_.hostName}
 
-        Write-Verbose ('Excluded results not matching -HostName ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $HostName,(@($Result).count-$OldCount),@($Result).count)
+        Write-Verbose ('Excluded results not matching -HostName ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $HostName,($OldCount-@($Result).count),@($Result).count)
       }
     }
 

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -62,22 +62,30 @@ function Get-RubrikFileset
     [switch]$DetailedObject,
     # SLA Domain policy assigned to the database
     [Parameter(ParameterSetName='Query')]
+    [ValidateNotNullOrEmpty()]
     [String]$SLA,
-    # Name of the host using a fileset
+    # Exact name of the host using a fileset
     [Parameter(ParameterSetName='Query')]
     [Alias('host_name')]
+    [ValidateNotNullOrEmpty()]
     [String]$HostName,
+    [Parameter(ParameterSetName='HostFilter')]
+    [ValidateNotNullOrEmpty()]
+    [String]$HostNameFilter,
     # Filter the summary information based on the ID of a fileset template.
     [Parameter(ParameterSetName='Query')]
     [Alias('template_id')]
+    [ValidateNotNullOrEmpty()]
     [String]$TemplateID,
     # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Parameter(ParameterSetName='Query')]
     [Alias('primary_cluster_id')]
-    [String]$PrimaryClusterID,        
+    [ValidateNotNullOrEmpty()]
+    [String]$PrimaryClusterID,
     # Rubrik's Share id
     [Parameter(ParameterSetName='Query')]
     [Alias('share_id')]
+    [ValidateNotNullOrEmpty()]
     [String]$ShareID,
     # Rubrik's fileset id
     [Parameter(ParameterSetName='ID')]
@@ -87,7 +95,8 @@ function Get-RubrikFileset
     # SLA id value
     [Parameter(ParameterSetName='Query')]
     [Alias('effective_sla_domain_id')]
-    [String]$SLAID,    
+    [ValidateNotNullOrEmpty()]
+    [String]$SLAID,
     # Rubrik server IP or FQDN
     [Parameter(ParameterSetName='Query')]
     [Parameter(ParameterSetName='ID')]

--- a/Tests/Get-RubrikFileset.Tests.ps1
+++ b/Tests/Get-RubrikFileset.Tests.ps1
@@ -54,17 +54,38 @@ Describe -Name 'Public/Get-RubrikFileset' -Tag 'Public', 'Get-RubrikFileset' -Fi
             }
         }
         It -Name 'No parameters returns all results' -Test {
-            ( Get-RubrikFileset).Count |
+            @( Get-RubrikFileset).Count |
                 Should -BeExactly 3
         }
 
         It -Name '-Name should filter and not use in-fix search' -Test {
-            ( Get-RubrikFileset -Name 'Fileset').Count |
+            @( Get-RubrikFileset -Name 'Fileset').Count |
                 Should -BeExactly 1
         }
 
         It -Name '-NameFilter should not filter and use in-fix search' -Test {
-            ( Get-RubrikFileset -NameFilter 'Fileset').Count |
+            @( Get-RubrikFileset -NameFilter 'Fileset').Count |
+                Should -BeExactly 3
+        }
+
+        It -Name '-NameFilter should not filter and use in-fix search-partial' -Test {
+            Write-Verbose ( Get-RubrikFileset -NameFilter 'Fileset2'|Out-string) -Verbose
+            @( Get-RubrikFileset -NameFilter 'Fileset2').Count |
+                Should -BeExactly 2
+        }
+
+        It -Name '-HostName should filter and not use in-fix search' -Test {
+            @( Get-RubrikFileset -HostName 'Server').Count |
+                Should -BeExactly 1
+        }
+
+        It -Name '-HostNameFilter should not filter and use in-fix search' -Test {
+            @( Get-RubrikFileset -HostNameFilter 'Server').Count |
+                Should -BeExactly 3
+        }
+
+        It -Name '-HostNameFilter should not filter and use in-fix search-partial' -Test {
+            @( Get-RubrikFileset -HostNameFilter 'Server2').Count |
                 Should -BeExactly 2
         }
 
@@ -74,9 +95,9 @@ Describe -Name 'Public/Get-RubrikFileset' -Tag 'Public', 'Get-RubrikFileset' -Fi
         } 
    
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Get-RubrikSLA -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 8
+        Assert-MockCalled -CommandName Get-RubrikSLA -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 8
     }
     Context -Name 'Parameter Validation' {
         It -Name 'ID Missing' -Test {

--- a/Tests/Get-RubrikFileset.Tests.ps1
+++ b/Tests/Get-RubrikFileset.Tests.ps1
@@ -45,7 +45,18 @@ Describe -Name 'Public/Get-RubrikFileset' -Tag 'Public', 'Get-RubrikFileset' -Fi
         It -Name 'No parameters returns all results' -Test {
             ( Get-RubrikFileset).Count |
                 Should -BeExactly 2
-        } 
+        }
+
+        It -Name '-Name should filter and not use in-fix search' -Test {
+            ( Get-RubrikFileset -Name 'Fileset').Count |
+                Should -BeExactly 1
+        }
+
+        It -Name '-NameFilter should not filter and use in-fix search' -Test {
+            ( Get-RubrikFileset -Name 'Fileset').Count |
+                Should -BeExactly 2
+        }
+
         It -Name 'SLA mapping' -Test {
             ( Get-RubrikFileset -SLA 'sla_name').effectiveSlaDomainName |
                 Should -BeExactly 'sla_name'

--- a/Tests/Get-RubrikFileset.Tests.ps1
+++ b/Tests/Get-RubrikFileset.Tests.ps1
@@ -68,12 +68,6 @@ Describe -Name 'Public/Get-RubrikFileset' -Tag 'Public', 'Get-RubrikFileset' -Fi
                 Should -BeExactly 3
         }
 
-        It -Name '-NameFilter should not filter and use in-fix search-partial' -Test {
-            Write-Verbose ( Get-RubrikFileset -NameFilter 'Fileset2'|Out-string) -Verbose
-            @( Get-RubrikFileset -NameFilter 'Fileset2').Count |
-                Should -BeExactly 2
-        }
-
         It -Name '-HostName should filter and not use in-fix search' -Test {
             @( Get-RubrikFileset -HostName 'Server').Count |
                 Should -BeExactly 1
@@ -84,20 +78,15 @@ Describe -Name 'Public/Get-RubrikFileset' -Tag 'Public', 'Get-RubrikFileset' -Fi
                 Should -BeExactly 3
         }
 
-        It -Name '-HostNameFilter should not filter and use in-fix search-partial' -Test {
-            @( Get-RubrikFileset -HostNameFilter 'Server2').Count |
-                Should -BeExactly 2
-        }
-
         It -Name 'SLA mapping' -Test {
             ( Get-RubrikFileset -SLA 'sla_name').effectiveSlaDomainName |
                 Should -BeExactly 'sla_name'
         } 
    
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 8
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 6
         Assert-MockCalled -CommandName Get-RubrikSLA -ModuleName 'Rubrik' -Exactly 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 8
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 6
     }
     Context -Name 'Parameter Validation' {
         It -Name 'ID Missing' -Test {

--- a/Tests/Get-RubrikFileset.Tests.ps1
+++ b/Tests/Get-RubrikFileset.Tests.ps1
@@ -26,7 +26,8 @@ Describe -Name 'Public/Get-RubrikFileset' -Tag 'Public', 'Get-RubrikFileset' -Fi
         }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             @{ 
-                'name'                   = 'Fileset1'
+                'name'                   = 'Fileset'
+                'hostname'               = 'Server'
                 'id'                     = 'Fileset:::111111-2222-3333-4444-555555555555'
                 'isRelic'                = 'False'
                 'effectiveSlaDomainName' = 'sla_name'
@@ -35,7 +36,17 @@ Describe -Name 'Public/Get-RubrikFileset' -Tag 'Public', 'Get-RubrikFileset' -Fi
             },
             @{ 
                 'name'                   = 'Fileset2'
+                'hostname'               = 'Server2'
                 'id'                     = 'Fileset:::111111-2222-3333-4444-6666666666666'
+                'isRelic'                = 'False'
+                'effectiveSlaDomainName' = 'sla_name2'
+                'effectiveSlaDomainId'   = 'sla_id2'
+                'primaryClusterId'       = 'cluster_id2'   
+            },
+            @{ 
+                'name'                   = 'Fileset20'
+                'hostname'               = 'Server20'
+                'id'                     = 'Fileset:::111111-2222-3333-4444-7777777777777'
                 'isRelic'                = 'False'
                 'effectiveSlaDomainName' = 'sla_name2'
                 'effectiveSlaDomainId'   = 'sla_id2'
@@ -44,7 +55,7 @@ Describe -Name 'Public/Get-RubrikFileset' -Tag 'Public', 'Get-RubrikFileset' -Fi
         }
         It -Name 'No parameters returns all results' -Test {
             ( Get-RubrikFileset).Count |
-                Should -BeExactly 2
+                Should -BeExactly 3
         }
 
         It -Name '-Name should filter and not use in-fix search' -Test {
@@ -53,7 +64,7 @@ Describe -Name 'Public/Get-RubrikFileset' -Tag 'Public', 'Get-RubrikFileset' -Fi
         }
 
         It -Name '-NameFilter should not filter and use in-fix search' -Test {
-            ( Get-RubrikFileset -Name 'Fileset').Count |
+            ( Get-RubrikFileset -NameFilter 'Fileset').Count |
                 Should -BeExactly 2
         }
 


### PR DESCRIPTION
# Description

Get-RubrikFileset -HostName is returning wildcard matches instead of exact matches on hostname.

## Related Issue

Resolve #384 

## Motivation and Context

The current behavior is not in line with how other -Name and -HostName parameters work, because of the api endpoint. We should make the behavior consistent.

## How Has This Been Tested?

Ran the code against the TM test cluster, created additional unit tests to test for this behavior.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
