### PR TITLE
re-usable private function for functions affected by 'in fix' search - Issue #419

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-08-12
+
+### Added [Select-ExactMatch] private function
+
+* As requested in issue [Issue 419](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/419)
+
+### Changed [Get-RubrikFileset]
+
+* Now uses new private function instead of the custom code in the function
+
 ## 2019-08-06
 
 ### Changed [Get-RubrikSnapshot]

--- a/Rubrik/Private/Select-ExactMatch.ps1
+++ b/Rubrik/Private/Select-ExactMatch.ps1
@@ -6,6 +6,11 @@ Helper function, filters API data when infix search is used
 .DESCRIPTION
 This function only selects exact matches based on 
 
+.NOTES
+Written by Jaap Brasser for community usage
+Twitter: @jaap_brasser
+GitHub: jaapbrasser
+
 .EXAMPLE
 $result = Select-ExactMatch -Parameter Name -Result $Result
 

--- a/Rubrik/Private/Select-ExactMatch.ps1
+++ b/Rubrik/Private/Select-ExactMatch.ps1
@@ -1,7 +1,7 @@
 function Select-ExactMatch {
 <#
 .SYNOPSIS
-Helper function, filters API data when infix search is used
+Helper function, filters API data when infix search is used to provide an exact match
 
 .DESCRIPTION
 This function only selects exact matches based on the name provided in $Parameter

--- a/Rubrik/Private/Select-ExactMatch.ps1
+++ b/Rubrik/Private/Select-ExactMatch.ps1
@@ -1,0 +1,7 @@
+function Select-ExactMatch.ps1 {
+    param (
+
+    )
+
+    
+}

--- a/Rubrik/Private/Select-ExactMatch.ps1
+++ b/Rubrik/Private/Select-ExactMatch.ps1
@@ -1,7 +1,16 @@
-function Select-ExactMatch.ps1 {
+function Select-ExactMatch {
     param (
-
+        [parameter(Mandatory)]
+        [string] $Parameter,
+        [parameter(Mandatory)]
+        [string] $Value
     )
 
-    
+    if ($null -ne $PSBoundParameters.Name) {
+        $OldCount = @($Result).count
+
+        $result = $result | Where-Object {$Name -eq $_.name}
+
+        Write-Verbose ('Excluded results not matching -Name ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $Name,($OldCount-@($Result).count),@($Result).count)
+      }
 }

--- a/Rubrik/Private/Select-ExactMatch.ps1
+++ b/Rubrik/Private/Select-ExactMatch.ps1
@@ -13,6 +13,6 @@ function Select-ExactMatch {
 
         return $result | Where-Object {$Value -eq $_.$Parameter}
 
-        Write-Verbose ('Excluded results not matching -Name ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $Name,($OldCount-@($Result).count),@($Result).count)
+        Write-Verbose ('Excluded results not matching -{0} ''{1}'' {2} object(s) filtered, {3} object(s) remaining' -f $Parameter,$Value,($OldCount-@($Result).count),@($Result).count)
     }
 }

--- a/Rubrik/Private/Select-ExactMatch.ps1
+++ b/Rubrik/Private/Select-ExactMatch.ps1
@@ -1,4 +1,5 @@
 function Select-ExactMatch {
+    [CmdletBinding()]
     param (
         [parameter(Mandatory)]
         [string] $Parameter,
@@ -11,8 +12,8 @@ function Select-ExactMatch {
     process {
         $OldCount = @($Result).count
 
-        return $result | Where-Object {$Value -eq $_.$Parameter}
-
         Write-Verbose ('Excluded results not matching -{0} ''{1}'' {2} object(s) filtered, {3} object(s) remaining' -f $Parameter,$Value,($OldCount-@($Result).count),@($Result).count)
+
+        return $result | Where-Object {$Value -eq $_.$Parameter}
     }
 }

--- a/Rubrik/Private/Select-ExactMatch.ps1
+++ b/Rubrik/Private/Select-ExactMatch.ps1
@@ -7,9 +7,9 @@ Helper function, filters API data when infix search is used
 This function only selects exact matches based on 
 
 .EXAMPLE
-$result = Select-ExactMatch -Parameter Name -Value $Name -Result $Result
+$result = Select-ExactMatch -Parameter Name -Result $Result
 
-Filters based on the Name parameter and the 
+Filters based on the Name parameter, only exact matches will be returned. Additional results supplied by the API endpoints will be filtered out
 #>
     [CmdletBinding()]
     param (

--- a/Rubrik/Private/Select-ExactMatch.ps1
+++ b/Rubrik/Private/Select-ExactMatch.ps1
@@ -3,14 +3,16 @@ function Select-ExactMatch {
         [parameter(Mandatory)]
         [string] $Parameter,
         [parameter(Mandatory)]
-        [string] $Value
+        [string] $Value,
+        [parameter(Mandatory)]
+        $Result
     )
 
-    if ($null -ne $PSBoundParameters.Name) {
+    process {
         $OldCount = @($Result).count
 
-        $result = $result | Where-Object {$Name -eq $_.name}
+        return $result | Where-Object {$Value -eq $_.$Parameter}
 
         Write-Verbose ('Excluded results not matching -Name ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $Name,($OldCount-@($Result).count),@($Result).count)
-      }
+    }
 }

--- a/Rubrik/Private/Select-ExactMatch.ps1
+++ b/Rubrik/Private/Select-ExactMatch.ps1
@@ -4,7 +4,7 @@ function Select-ExactMatch {
 Helper function, filters API data when infix search is used
 
 .DESCRIPTION
-This function only selects exact matches based on 
+This function only selects exact matches based on the name provided in $Parameter
 
 .NOTES
 Written by Jaap Brasser for community usage

--- a/Rubrik/Private/Select-ExactMatch.ps1
+++ b/Rubrik/Private/Select-ExactMatch.ps1
@@ -1,19 +1,35 @@
 function Select-ExactMatch {
+<#
+.SYNOPSIS
+Helper function, filters API data when infix search is used
+
+.DESCRIPTION
+This function only selects exact matches based on 
+
+.EXAMPLE
+$result = Select-ExactMatch -Parameter Name -Value $Name -Result $Result
+
+Filters based on the Name parameter and the 
+#>
     [CmdletBinding()]
     param (
         [parameter(Mandatory)]
         [string] $Parameter,
         [parameter(Mandatory)]
-        [string] $Value,
-        [parameter(Mandatory)]
         $Result
     )
+
+    begin {
+        $Value = (Get-Variable -Name $Parameter).Value
+    }
 
     process {
         $OldCount = @($Result).count
 
+        $result = $result | Where-Object {$Value -eq $_.$Parameter}
+
         Write-Verbose ('Excluded results not matching -{0} ''{1}'' {2} object(s) filtered, {3} object(s) remaining' -f $Parameter,$Value,($OldCount-@($Result).count),@($Result).count)
 
-        return $result | Where-Object {$Value -eq $_.$Parameter}
+        return $result
     }
 }

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -178,12 +178,10 @@ function Get-RubrikFileset
 
     # This block of code will filter results if -Name or -Hostname are used, probably should move to a private function
     if ('Query' -eq $PSCmdlet.ParameterSetName) {
-      if ($null -ne $PSBoundParameters.Name) {
-        $result = Select-ExactMatch -Parameter Name -Result $Result
-      }
-
-      if ($null -ne $PSBoundParameters.HostName) {
-        $result = Select-ExactMatch -Parameter HostName -Result $Result
+      'Name','HostName' | ForEach-Object {
+        if ($null -ne $PSBoundParameters.$_) {
+          $result = Select-ExactMatch -Parameter $_ -Result $Result
+        }
       }
     }
 

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -183,7 +183,7 @@ function Get-RubrikFileset
       }
 
       if ($null -ne $PSBoundParameters.HostName) {
-        $result = Select-ExactMatch -Parameter Name -Value $Name -Result $Result
+        $result = Select-ExactMatch -Parameter HostName -Value $HostName -Result $Result
       }
     }
 

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -179,15 +179,11 @@ function Get-RubrikFileset
     # This block of code will filter results if -Name or -Hostname are used, probably should move to a private function
     if ('Query' -eq $PSCmdlet.ParameterSetName) {
       if ($null -ne $PSBoundParameters.Name) {
-        $Result | Select-ExactMatch -
+        $result = Select-ExactMatch -Parameter Name -Value $Name -Result $Result
       }
 
       if ($null -ne $PSBoundParameters.HostName) {
-        $OldCount = @($Result).count
-
-        $result = $result | Where-Object {$HostName -eq $_.hostName}
-
-        Write-Verbose ('Excluded results not matching -HostName ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $HostName,($OldCount-@($Result).count),@($Result).count)
+        $result = Select-ExactMatch -Parameter Name -Value $Name -Result $Result
       }
     }
 

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -179,11 +179,7 @@ function Get-RubrikFileset
     # This block of code will filter results if -Name or -Hostname are used, probably should move to a private function
     if ('Query' -eq $PSCmdlet.ParameterSetName) {
       if ($null -ne $PSBoundParameters.Name) {
-        $OldCount = @($Result).count
-
-        $result = $result | Where-Object {$Name -eq $_.name}
-
-        Write-Verbose ('Excluded results not matching -Name ''{0}'' {1} object(s) filtered, {2} object(s) remaining' -f $Name,($OldCount-@($Result).count),@($Result).count)
+        $Result | Select-ExactMatch -
       }
 
       if ($null -ne $PSBoundParameters.HostName) {

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -179,11 +179,11 @@ function Get-RubrikFileset
     # This block of code will filter results if -Name or -Hostname are used, probably should move to a private function
     if ('Query' -eq $PSCmdlet.ParameterSetName) {
       if ($null -ne $PSBoundParameters.Name) {
-        $result = Select-ExactMatch -Parameter Name -Value $Name -Result $Result
+        $result = Select-ExactMatch -Parameter Name -Result $Result
       }
 
       if ($null -ne $PSBoundParameters.HostName) {
-        $result = Select-ExactMatch -Parameter HostName -Value $HostName -Result $Result
+        $result = Select-ExactMatch -Parameter HostName -Result $Result
       }
     }
 

--- a/Tests/Get-RubrikSnapshot.Tests.ps1
+++ b/Tests/Get-RubrikSnapshot.Tests.ps1
@@ -104,7 +104,7 @@ Describe -Name 'Public/Get-RubrikSnapshot' -Tag 'Public', 'Get-RubrikSnapshot' -
               Should -BeExactly "b42ed6ba-760e-425f-a35d-c7dc5636b55d"
         }
         It -Name 'Get specific snapshot' -Test {
-          ( Get-RubrikSnapshot -id 'VirtualMachine:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-vm-12345' -Date (Get-Date -Day 3 -Month 8 -Year 2019) ).id |
+          ( Get-RubrikSnapshot -id 'VirtualMachine:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-vm-12345' -Date (Get-Date -Day 3 -Month 8 -Year 2019).Date ).id |
               Should -BeExactly "ca214725-6dcd-49b4-88ae-45780b16879a"
         }
         It -Name 'Get on demand snapshots' -Test {


### PR DESCRIPTION
# Description

Currently some API endpoints provide 'in fix' searching which can give counter intuitive results, such is seen in issue #384.

## Related Issue

Resolve #419

## Motivation and Context

Why is this change required? What problem does it solve?

## How Has This Been Tested?

Ran the existing unit tests and tested command against the TME Cluster

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
