### PR TITLE
Added new private function, updated Get-RubrikEvent output - Issue 426

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -17,7 +17,7 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 
 **Describe the solution you'd like**
 
-A clear and concise description of what you want to happen.
+A clear and concise description of what you want to happen
 
 **Describe alternatives you've considered**
 

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -17,7 +17,7 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 
 **Describe the solution you'd like**
 
-A clear and concise description of what you want to happen
+A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-08-13
+
+### Added [Convert-ApiDateTime] private function
+
+* Function is used to convert API time strings to date time objects
+* Created associated unit tests to validate behavior of function
+
+### Changed [Get-RubrikEvent]
+
+* Added new `date` property to output, uses new Convert-APIDateTime function for conversion [Issue 426](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/426)
+* Added additional unit tests to validate proper date time conversion
+
 ## 2019-08-12
 
 ### Added [Select-ExactMatch] private function

--- a/Rubrik/Private/Convert-APIDateTime.ps1
+++ b/Rubrik/Private/Convert-APIDateTime.ps1
@@ -1,0 +1,46 @@
+function Convert-APIDateTime {
+<#
+.SYNOPSIS
+Function to convert specific date time format from API endpoint to a datetime object
+
+.EXAMPLE
+Convert-APIDateTime "Thu Aug 08 20:31:36 UTC 2019" 
+
+Thursday, August 8, 2019 8:31:36 PM
+#>
+    [cmdletbinding()]
+    param(
+        [parameter(
+            Position = 0,
+            Mandatory = $true,
+            ValueFromPipeline = $true
+        )]
+        [ValidateNotNullOrEmpty()]
+        [string] $DateTimeString
+    )
+
+    begin {
+        [System.Globalization.DateTimeFormatInfo]::InvariantInfo.get_abbreviatedmonthnames() | ForEach-Object -Begin {
+            $MonthHash = @{}
+            $Count = 0
+        } -Process {
+            $Count++
+            if ($_) {
+                $MonthHash.$_ = $Count.ToString().Padleft(2,'0')
+            }
+        }
+    }
+
+    process {
+        $NewDateTimeString = $DateTimeString.Substring(4) -replace 'UTC '
+        $MonthHash.GetEnumerator() | ForEach-Object {
+            $NewDateTimeString = $NewDateTimeString -replace $_.Key,$_.Value
+        }
+
+        try {
+            [DateTime]::ParseExact($NewDateTimeString,'MM dd HH:mm:ss yyyy',$null)
+        } catch {
+            Write-Error $_
+        }
+    }
+}

--- a/Rubrik/Private/Convert-APIDateTime.ps1
+++ b/Rubrik/Private/Convert-APIDateTime.ps1
@@ -40,7 +40,6 @@ Thursday, August 8, 2019 8:31:36 PM
         try {
             [DateTime]::ParseExact($NewDateTimeString,'MM dd HH:mm:ss yyyy',$null)
         } catch {
-            Write-Error $_
         }
     }
 }

--- a/Rubrik/Public/Get-RubrikEvent.ps1
+++ b/Rubrik/Public/Get-RubrikEvent.ps1
@@ -119,6 +119,14 @@ function Get-RubrikEvent
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
     $result = Test-FilterObject -filter ($resources.Filter) -result $result
 
+    # Add 'date' property to the output by converting 'time' property to datetime object
+    $result = $result | ForEach-Object {
+      Select-Object -InputObject $_ -Property *,@{
+        name = 'date'
+        expression = {Convert-APIDateTime -DateTimeString $_.time}
+      }
+    }
+    
     return $result
 
   } # End of process

--- a/Tests/Convert-APIDateTime.Tests.ps1
+++ b/Tests/Convert-APIDateTime.Tests.ps1
@@ -6,7 +6,7 @@ foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' |
 }
 
 Describe -Name 'Private/Convert-APIDateTime' -Tag 'Private', 'Convert-APIDateTime' -Fixture {
-    Context -Name 'Results Filtering' {
+    Context -Name 'Convert different date time objects' -Fixture {
       
         $cases = 'Mon Jan 10 17:12:14 UTC 2019',
         'Mon Mar 11 09:12:14 UTC 2017',
@@ -20,6 +20,13 @@ Describe -Name 'Private/Convert-APIDateTime' -Tag 'Private', 'Convert-APIDateTim
             param($DateTimeString)
             Convert-APIDateTime -DateTimeString $DateTimeString.ToString() |
                 Should -BeOfType DateTime
+        }
+    }
+    
+    Context -Name 'Error handling' -Fixture {
+        It -Name 'February 30' -Test {
+            Convert-APIDateTime -DateTimeString 'Mon Mar 11 09:12:14 UTC 2017' |
+                Should -BeExactly $null
         }
     }
 }

--- a/Tests/Convert-APIDateTime.Tests.ps1
+++ b/Tests/Convert-APIDateTime.Tests.ps1
@@ -7,11 +7,7 @@ foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' |
 
 Describe -Name 'Private/Convert-APIDateTime' -Tag 'Private', 'Convert-APIDateTime' -Fixture {
     Context -Name 'Results Filtering' {
-        It -Name 'Should convert date correctly' -Test {
-            (Convert-APIDateTime).Count |
-                Should -BeExactly 5
-        }    
-        
+      
         $cases = 'Mon Jan 10 17:12:14 UTC 2019',
         'Mon Mar 11 09:12:14 UTC 2017',
         'Mon Sep 12 23:12:14 UTC 2018',
@@ -20,8 +16,10 @@ Describe -Name 'Private/Convert-APIDateTime' -Tag 'Private', 'Convert-APIDateTim
             
         }
 
-        It -Name "Get-RubrikAPIData - <f> test" -TestCases $cases {
-            
+        It -Name "Get-RubrikAPIData - <DateTimeString> test" -TestCases $cases {
+            param($DateTimeString)
+            Convert-APIDateTime -DateTimeString $DateTimeString.ToString() |
+                Should -BeOfType DateTime
         }
     }
 }

--- a/Tests/Convert-APIDateTime.Tests.ps1
+++ b/Tests/Convert-APIDateTime.Tests.ps1
@@ -5,73 +5,23 @@ foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' |
     . $privateFunctionFilePath
 }
 
-Describe -Name 'Public/Get-RubrikEvent' -Tag 'Public', 'Get-RubrikEvent' -Fixture {
-    #region init
-    $global:rubrikConnection = @{
-        id      = 'test-id'
-        userId  = 'test-userId'
-        token   = 'test-token'
-        server  = 'test-server'
-        header  = @{ 'Authorization' = 'Bearer test-authorization' }
-        time    = (Get-Date)
-        api     = 'v1'
-        version = '4.0.5'
-    }
-    #endregion
-
+Describe -Name 'Private/Convert-APIDateTime' -Tag 'Private', 'Convert-APIDateTime' -Fixture {
     Context -Name 'Results Filtering' {
-        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
-        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{ 
-                'name'                   = 'VirtualMachine01'
-                'id'                     = 'VirtualMachine:::11111'
-                'eventType'              = 'Replication'
-                'time'                   = 'Mon Aug 10 07:12:14 UTC 2019'
-            },
-            @{ 
-                'name'                   = 'VirtualMachine02'
-                'id'                     = 'VirtualMachine:::22222'
-                'eventType'              = 'Backup'
-                'time'                   = 'Mon Aug 11 07:12:14 UTC 2019'
-            },
-            @{ 
-                'name'                   = 'VirtualMachine03'
-                'id'                     = 'VirtualMachine:::33333'
-                'eventType'              = 'CloudNativeSource'
-                'time'                   = 'Mon Aug 12 07:12:14 UTC 2019'
-            },
-            @{ 
-                'name'                   = 'VirtualMachine04'
-                'id'                     = 'VirtualMachine:::44444'
-                'eventType'              = 'Replication'
-                'time'                   = 'Mon Aug 13 07:12:14 UTC 2019'
-            },
-            @{ 
-                'name'                   = 'VirtualMachine05'
-                'id'                     = 'VirtualMachine:::55555'
-                'eventType'              = 'Replication'
-                'time'                   = 'Mon Aug 14 07:12:14 UTC 2019'
-            }
-        }
-        It -Name 'Should Return count of 5' -Test {
-            (Get-RubrikEvent).Count |
+        It -Name 'Should convert date correctly' -Test {
+            (Convert-APIDateTime).Count |
                 Should -BeExactly 5
-        }
-        It -Name 'Should not run with Name parameter' -Test {
-            {Get-RubrikEvent -Name doesnotexist -ErrorAction Stop} |
-                Should -Throw
-        }
-        It -Name 'Time property should be a string' -Test {
-            (Get-RubrikEvent)[0].Time |
-                Should -BeOfType String
-        }
-        It -Name 'Date property should be a datetime object' -Test {
-            (Get-RubrikEvent)[0].Date |
-                Should -BeOfType DateTime
-        }
+        }    
         
-        Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 3
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 3
+        $cases = 'Mon Jan 10 17:12:14 UTC 2019',
+        'Mon Mar 11 09:12:14 UTC 2017',
+        'Mon Sep 12 23:12:14 UTC 2018',
+        'Mon Dec 13 14:12:14 UTC 2006' | ForEach-Object {
+            @{'DateTimeString' = $_}
+            
+        }
+
+        It -Name "Get-RubrikAPIData - <f> test" -TestCases $cases {
+            
+        }
     }
 }

--- a/Tests/Convert-APIDateTime.Tests.ps1
+++ b/Tests/Convert-APIDateTime.Tests.ps1
@@ -1,0 +1,77 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikEvent' -Tag 'Public', 'Get-RubrikEvent' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'name'                   = 'VirtualMachine01'
+                'id'                     = 'VirtualMachine:::11111'
+                'eventType'              = 'Replication'
+                'time'                   = 'Mon Aug 10 07:12:14 UTC 2019'
+            },
+            @{ 
+                'name'                   = 'VirtualMachine02'
+                'id'                     = 'VirtualMachine:::22222'
+                'eventType'              = 'Backup'
+                'time'                   = 'Mon Aug 11 07:12:14 UTC 2019'
+            },
+            @{ 
+                'name'                   = 'VirtualMachine03'
+                'id'                     = 'VirtualMachine:::33333'
+                'eventType'              = 'CloudNativeSource'
+                'time'                   = 'Mon Aug 12 07:12:14 UTC 2019'
+            },
+            @{ 
+                'name'                   = 'VirtualMachine04'
+                'id'                     = 'VirtualMachine:::44444'
+                'eventType'              = 'Replication'
+                'time'                   = 'Mon Aug 13 07:12:14 UTC 2019'
+            },
+            @{ 
+                'name'                   = 'VirtualMachine05'
+                'id'                     = 'VirtualMachine:::55555'
+                'eventType'              = 'Replication'
+                'time'                   = 'Mon Aug 14 07:12:14 UTC 2019'
+            }
+        }
+        It -Name 'Should Return count of 5' -Test {
+            (Get-RubrikEvent).Count |
+                Should -BeExactly 5
+        }
+        It -Name 'Should not run with Name parameter' -Test {
+            {Get-RubrikEvent -Name doesnotexist -ErrorAction Stop} |
+                Should -Throw
+        }
+        It -Name 'Time property should be a string' -Test {
+            (Get-RubrikEvent)[0].Time |
+                Should -BeOfType String
+        }
+        It -Name 'Date property should be a datetime object' -Test {
+            (Get-RubrikEvent)[0].Date |
+                Should -BeOfType DateTime
+        }
+        
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 3
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 3
+    }
+}

--- a/Tests/Convert-APIDateTime.Tests.ps1
+++ b/Tests/Convert-APIDateTime.Tests.ps1
@@ -24,8 +24,16 @@ Describe -Name 'Private/Convert-APIDateTime' -Tag 'Private', 'Convert-APIDateTim
     }
     
     Context -Name 'Error handling' -Fixture {
-        It -Name 'February 30' -Test {
-            Convert-APIDateTime -DateTimeString 'Mon Mar 11 09:12:14 UTC 2017' |
+        It -Name 'February 30 - Should not have output' -Test {
+            Convert-APIDateTime -DateTimeString 'Mon Feb 30 09:12:14 UTC 2017' |
+                Should -BeExactly $null
+        }
+        It -Name 'Movember - Should not have output' -Test {
+            Convert-APIDateTime -DateTimeString 'Mon Mov 30 09:12:14 UTC 2018' |
+                Should -BeExactly $null
+        }
+        It -Name '25th hour - Should not have output' -Test {
+            Convert-APIDateTime -DateTimeString 'Mon Sep 30 25:12:14 UTC 2018' |
                 Should -BeExactly $null
         }
     }

--- a/Tests/Get-RubrikEvent.Tests.ps1
+++ b/Tests/Get-RubrikEvent.Tests.ps1
@@ -67,7 +67,7 @@ Describe -Name 'Public/Get-RubrikEvent' -Tag 'Public', 'Get-RubrikEvent' -Fixtur
         }
         
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 3
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 3
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 2
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 2
     }
 }

--- a/Tests/Get-RubrikEvent.Tests.ps1
+++ b/Tests/Get-RubrikEvent.Tests.ps1
@@ -71,7 +71,7 @@ Describe -Name 'Public/Get-RubrikEvent' -Tag 'Public', 'Get-RubrikEvent' -Fixtur
         }
         
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 3
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 3
     }
 }

--- a/Tests/Get-RubrikEvent.Tests.ps1
+++ b/Tests/Get-RubrikEvent.Tests.ps1
@@ -61,12 +61,8 @@ Describe -Name 'Public/Get-RubrikEvent' -Tag 'Public', 'Get-RubrikEvent' -Fixtur
             {Get-RubrikEvent -Name doesnotexist -ErrorAction Stop} |
                 Should -Throw
         }
-        It -Name 'Time property should be a string' -Test {
-            (Get-RubrikEvent)[0].Time |
-                Should -BeOfType String
-        }
         It -Name 'Date property should be a datetime object' -Test {
-            (Get-RubrikEvent)[0].Date |
+            (Get-RubrikEvent)[1].Date |
                 Should -BeOfType DateTime
         }
         

--- a/Tests/Get-RubrikEvent.Tests.ps1
+++ b/Tests/Get-RubrikEvent.Tests.ps1
@@ -26,26 +26,31 @@ Describe -Name 'Public/Get-RubrikEvent' -Tag 'Public', 'Get-RubrikEvent' -Fixtur
                 'name'                   = 'VirtualMachine01'
                 'id'                     = 'VirtualMachine:::11111'
                 'eventType'              = 'Replication'
+                'time'                   = 'Mon Aug 10 07:12:14 UTC 2019'
             },
             @{ 
                 'name'                   = 'VirtualMachine02'
                 'id'                     = 'VirtualMachine:::22222'
                 'eventType'              = 'Backup'
+                'time'                   = 'Mon Aug 11 07:12:14 UTC 2019'
             },
             @{ 
                 'name'                   = 'VirtualMachine03'
                 'id'                     = 'VirtualMachine:::33333'
                 'eventType'              = 'CloudNativeSource'
+                'time'                   = 'Mon Aug 12 07:12:14 UTC 2019'
             },
             @{ 
                 'name'                   = 'VirtualMachine04'
                 'id'                     = 'VirtualMachine:::44444'
                 'eventType'              = 'Replication'
+                'time'                   = 'Mon Aug 13 07:12:14 UTC 2019'
             },
             @{ 
                 'name'                   = 'VirtualMachine05'
                 'id'                     = 'VirtualMachine:::55555'
                 'eventType'              = 'Replication'
+                'time'                   = 'Mon Aug 14 07:12:14 UTC 2019'
             }
         }
         It -Name 'Should Return count of 5' -Test {
@@ -56,7 +61,11 @@ Describe -Name 'Public/Get-RubrikEvent' -Tag 'Public', 'Get-RubrikEvent' -Fixtur
             {Get-RubrikEvent -Name doesnotexist -ErrorAction Stop} |
                 Should -Throw
         }
-
+        It -Name 'Time property should be a string' -Test {
+            (Get-RubrikEvent)[0].Time |
+                Should -BeOfType String
+        }
+        
         Assert-VerifiableMock
         Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
         Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1

--- a/Tests/Get-RubrikEvent.Tests.ps1
+++ b/Tests/Get-RubrikEvent.Tests.ps1
@@ -65,6 +65,10 @@ Describe -Name 'Public/Get-RubrikEvent' -Tag 'Public', 'Get-RubrikEvent' -Fixtur
             (Get-RubrikEvent)[0].Time |
                 Should -BeOfType String
         }
+        It -Name 'Date property should be a datetime object' -Test {
+            (Get-RubrikEvent)[0].Date |
+                Should -BeOfType DateTime
+        }
         
         Assert-VerifiableMock
         Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1


### PR DESCRIPTION
# Description

The time field returned by Get-RubrikEvent is a string, this has been resolved in this pull request

## Related Issue

Time returned by Get-RubrikEvent is a string:
Resolve #426

## Motivation and Context

Other date time objects returned by the PowerShell module are proper date time objects, I have added an additional property: `date` to the output object that is a converted datetime object.

## How Has This Been Tested?

* Ran this against the TME test cluster
* Created new unit test for private function
* Updated existing unit tests for Get-RubrikEvent

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12744735/62932353-3b6ed300-bdc0-11e9-8cc0-b28ff5972368.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
