### PR TITLE
Added time property validation to Get-RubrikEvent - Issue #428

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-08-14
+
+### Changed [Test-ReturnFormat] private function
+
+* Improved detection of empty strings
+
+### Changed [Get-RubrikEvent]
+
+* Added validation for `time` field, if `time` field does not exist it will not add `date` property [Issue 428](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/428)
+
 ## 2019-08-13
 
 ### Added [Convert-ApiDateTime] private function

--- a/Rubrik/Private/Test-ReturnFormat.ps1
+++ b/Rubrik/Private/Test-ReturnFormat.ps1
@@ -6,7 +6,7 @@
   # $location = The key/value pair that contains the name of the key holding the response content's data
 
   Write-Verbose -Message 'Formatting return value'
-  if ($location -and ($result).$location -ne $null) 
+  if ($location -and ($null -ne ($result).$location))
   {
     # The $location check assumes that not all endpoints will require findng (and removing) a parent key
     # If one does exist, this extracts the value so that the $result data is consistent across API versions

--- a/Rubrik/Public/Get-RubrikEvent.ps1
+++ b/Rubrik/Public/Get-RubrikEvent.ps1
@@ -120,10 +120,12 @@ function Get-RubrikEvent
     $result = Test-FilterObject -filter ($resources.Filter) -result $result
 
     # Add 'date' property to the output by converting 'time' property to datetime object
-    $result = $result | ForEach-Object {
-      Select-Object -InputObject $_ -Property *,@{
-        name = 'date'
-        expression = {Convert-APIDateTime -DateTimeString $_.time}
+    if (($null -ne $result) -and ($null -ne ($result | Select-Object -ExpandProperty time))) {
+      $result = $result | ForEach-Object {
+        Select-Object -InputObject $_ -Property *,@{
+          name = 'date'
+          expression = {Convert-APIDateTime -DateTimeString $_.time}
+        }
       }
     }
     

--- a/Rubrik/Public/Get-RubrikEvent.ps1
+++ b/Rubrik/Public/Get-RubrikEvent.ps1
@@ -120,7 +120,7 @@ function Get-RubrikEvent
     $result = Test-FilterObject -filter ($resources.Filter) -result $result
 
     # Add 'date' property to the output by converting 'time' property to datetime object
-    if (($null -ne $result) -and ($null -ne ($result | Select-Object -ExpandProperty time))) {
+    if (($null -ne $result) -and ($null -ne ($result | Select-Object -First 1).time)) {
       $result = $result | ForEach-Object {
         Select-Object -InputObject $_ -Property *,@{
           name = 'date'

--- a/Tests/Get-RubrikDatabaseFiles.Tests.ps1
+++ b/Tests/Get-RubrikDatabaseFiles.Tests.ps1
@@ -67,8 +67,8 @@ Describe -Name 'Public/Get-RubrikDatabaseFiles' -Tag 'Public', 'Get-RubrikDataba
         }
 
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 2
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 2
     }
 
     Context -Name 'Parameter Validation' {

--- a/Tests/Get-RubrikDatabaseFiles.Tests.ps1
+++ b/Tests/Get-RubrikDatabaseFiles.Tests.ps1
@@ -40,6 +40,15 @@ Describe -Name 'Public/Get-RubrikDatabaseFiles' -Tag 'Public', 'Get-RubrikDataba
               ]'
             return ConvertFrom-Json $response
         }
+        Mock -CommandName Test-ReturnFormat -Verifiable -ModuleName 'Rubrik' -MockWith {
+            param(
+                $api,
+                $result,
+                $localtion
+            )
+            $result  
+        }
+        
         It -Name 'Should return two results' -Test {
             ( Get-RubrikDatabaseFiles -id 'MssqlDatabase:::12345678-1234-abcd-8910-1234567890ab' -time '2010-01-01T00:00:00.000Z').Count |
                 Should -BeExactly 2
@@ -58,7 +67,7 @@ Describe -Name 'Public/Get-RubrikDatabaseFiles' -Tag 'Public', 'Get-RubrikDataba
         }
 
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
         Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
     }
 

--- a/Tests/Get-RubrikDatabaseFiles.Tests.ps1
+++ b/Tests/Get-RubrikDatabaseFiles.Tests.ps1
@@ -69,6 +69,7 @@ Describe -Name 'Public/Get-RubrikDatabaseFiles' -Tag 'Public', 'Get-RubrikDataba
         Assert-VerifiableMock
         Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 2
         Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 2
+        Assert-MockCalled -CommandName Test-ReturnFormat -ModuleName 'Rubrik' -Exactly 2
     }
 
     Context -Name 'Parameter Validation' {


### PR DESCRIPTION
# Description

Cmdlet should display Event info as it does when not using -AfterDate parameter

## Related Issue

Resolves #428

## How Has This Been Tested?

Unit tests still run successfully, extensive unit tests are available for this. Ran commands against the test cluster.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
