### PR TITLE
Get-RubrikDatabaseFiles not returning correct data - Issue 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-08-23
+
+### Fixed [Get-RubrikDatabaseFiles]
+
+* Updated Api information for function in `Get-RubrikApiData` [Issue 430](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/430)
+
 ## 2019-08-14
 
 ### Changed [Test-ReturnFormat] private function

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -189,7 +189,7 @@ function Get-RubrikAPIData($endpoint) {
                 Query       = @{
                     time = 'time'
                 }
-                Result      = 'data'
+                Result      = ''
                 Filter      = ''
                 Success     = '200'
             }

--- a/Tests/Get-RubrikDatabaseFiles.Tests.ps1
+++ b/Tests/Get-RubrikDatabaseFiles.Tests.ps1
@@ -40,14 +40,14 @@ Describe -Name 'Public/Get-RubrikDatabaseFiles' -Tag 'Public', 'Get-RubrikDataba
               ]'
             return ConvertFrom-Json $response
         }
-        Mock -CommandName Test-ReturnFormat -Verifiable -ModuleName 'Rubrik' -MockWith {
-            param(
-                $api,
-                $result,
-                $localtion
-            )
-            $result  
-        }
+        #Mock -CommandName Test-ReturnFormat -Verifiable -ModuleName 'Rubrik' -MockWith {
+        #    param(
+        #        $api,
+        #        $result,
+        #        $localtion
+        #    )
+        #    $result  
+        #}
         
         It -Name 'Should return two results' -Test {
             ( Get-RubrikDatabaseFiles -id 'MssqlDatabase:::12345678-1234-abcd-8910-1234567890ab' -time '2010-01-01T00:00:00.000Z').Count |
@@ -69,7 +69,7 @@ Describe -Name 'Public/Get-RubrikDatabaseFiles' -Tag 'Public', 'Get-RubrikDataba
         Assert-VerifiableMock
         Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 2
         Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 2
-        Assert-MockCalled -CommandName Test-ReturnFormat -ModuleName 'Rubrik' -Exactly 2
+        #Assert-MockCalled -CommandName Test-ReturnFormat -ModuleName 'Rubrik' -Exactly 2
     }
 
     Context -Name 'Parameter Validation' {

--- a/Tests/Get-RubrikDatabaseFiles.Tests.ps1
+++ b/Tests/Get-RubrikDatabaseFiles.Tests.ps1
@@ -40,14 +40,6 @@ Describe -Name 'Public/Get-RubrikDatabaseFiles' -Tag 'Public', 'Get-RubrikDataba
               ]'
             return ConvertFrom-Json $response
         }
-        #Mock -CommandName Test-ReturnFormat -Verifiable -ModuleName 'Rubrik' -MockWith {
-        #    param(
-        #        $api,
-        #        $result,
-        #        $localtion
-        #    )
-        #    $result  
-        #}
         
         It -Name 'Should return two results' -Test {
             ( Get-RubrikDatabaseFiles -id 'MssqlDatabase:::12345678-1234-abcd-8910-1234567890ab' -time '2010-01-01T00:00:00.000Z').Count |
@@ -69,7 +61,6 @@ Describe -Name 'Public/Get-RubrikDatabaseFiles' -Tag 'Public', 'Get-RubrikDataba
         Assert-VerifiableMock
         Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 2
         Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 2
-        #Assert-MockCalled -CommandName Test-ReturnFormat -ModuleName 'Rubrik' -Exactly 2
     }
 
     Context -Name 'Parameter Validation' {


### PR DESCRIPTION
# Description

Get-RubrikDatabaseFiles will normally return back a list of files that make up a database at the time of the backup. At this time, the file information is being filtered out and returning back NULL values

Provide information about the failure by issuing the command using the -Verbose command.

## Related Issue

Resolve #430 

## Motivation and Context

Incorrect API data was entered for this function, causing results to get filtered

## How Has This Been Tested?

Ran against TME test clusters and verified with unit tests

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
