### PR TITLE
Issue 347 - Various Unit Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-09-09
+
+### Added [Various Unit Tests]
+
+* Created unit tests for Get-RubrikAvailabilityGroup, Get-RubrikOrganization, Get-RubrikRequest, Get-RubrikUnmanagedObject, Remove-RubrikUnmanagedObject, Set-RubrikAvailabilityGroup, and Sync-RubrikTag.  Get-RubrikSnapshot was already present.
+* Resolves [Issue 347](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/347)
+
 ## 2019-09-02
 
 ### Added [-RubrikBootStrap] unit tests

--- a/Tests/Get-RubrikAvailabilityGroup.Tests.ps1
+++ b/Tests/Get-RubrikAvailabilityGroup.Tests.ps1
@@ -1,0 +1,60 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikAvailabilityGroup' -Tag 'Public', 'Get-RubrikAvailabilityGroup' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Returned Results' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'name'                   = 'AG1'
+                'id'                     = '11111:22222:33333'
+                'copyOnly'               = 'true'
+                'configuredSLADomainId'  = '111111'
+                'configuredSLADomainName'= 'Gold'
+                'logRetentionHours'      = '1'   
+            },
+            @{ 
+                'name'                   = 'AG2'
+                'id'                     = '11111:22222:44444'
+                'copyOnly'               = 'true'
+                'configuredSLADomainId'  = '111111'
+                'configuredSLADomainName'= 'Gold'
+                'logRetentionHours'      = '1'   
+            }
+        }
+        It -Name 'No parameters returns all results' -Test {
+            ( Get-RubrikAvailabilityGroup).Count |
+                Should -BeExactly 2
+        } 
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+    Context -Name 'Parameter Validation' {
+        It -Name 'ID Missing' -Test {
+            { Get-RubrikAvailabilityGroup -id } |
+                Should -Throw "Missing an argument for parameter 'id'. Specify a parameter of type 'System.String' and try again."
+        }      
+        It -Name 'Name missing' -Test {
+            { Get-RubrikAvailabilityGroup -Name } |
+                Should -Throw "Missing an argument for parameter 'GroupName'. Specify a parameter of type 'System.String' and try again."
+        }
+    }
+}

--- a/Tests/Get-RubrikOrganization.Tests.ps1
+++ b/Tests/Get-RubrikOrganization.Tests.ps1
@@ -1,0 +1,85 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikOrganization' -Tag 'Public', 'Get-RubrikOrganization' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'id'                     = 'Organization:1'
+                'name'                   = 'org1'
+                'isGlobal'               = 'False'
+            },
+            @{ 
+                'id'                     = 'Organization:2'
+                'name'                   = 'org2'
+                'isGlobal'               = 'False'
+            },
+            @{ 
+                'id'                     = 'Organization:3'
+                'name'                   = 'org3'
+                'isGlobal'               = 'False'
+            },
+            @{ 
+                'id'                     = 'Organization:4'
+                'name'                   = 'org4'
+                'isGlobal'               = 'True'
+            },
+            @{ 
+                'id'                     = 'Organization:5'
+                'name'                   = 'org5'
+                'isGlobal'               = 'False'
+            }
+        }
+        It -Name 'Should Return count of 5' -Test {
+            ( Get-RubrikOrganization).Count |
+                Should -BeExactly 5
+        }
+        It -Name 'Should Return org1' -Test {
+            (Get-RubrikOrganization -Name 'org1').Name |
+                Should -BeExactly 'org1'
+        }
+        It -Name 'Should Return Organization:4' -Test {
+            ( Get-RubrikOrganization -name 'org4').id |
+                Should -BeExactly 'Organization:4'
+        }
+        It -Name 'Should return count of 0 ' -Test {
+            (Get-RubrikOrganization -Name 'nonexistant').count |
+                Should -BeExactly 0
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 4
+    }
+    Context -Name 'Parameter Validation' {
+        It -Name 'Name Missing' -Test {
+            { Get-RubrikOrganization -name } |
+                Should -Throw "Missing an argument for parameter 'Name'. Specify a parameter of type 'System.String' and try again."
+        }   
+        It -Name 'ID Missing' -Test {
+            { Get-RubrikOrganization -id } |
+                Should -Throw "Missing an argument for parameter 'ID'. Specify a parameter of type 'System.String' and try again."
+        }      
+        It -Name 'isGlobal must be Boolean' -Test {
+            { Get-RubrikOrganization -isGlobal 'notabool' } |
+                Should -Throw "Cannot process argument transformation on parameter 'isGlobal'. "
+        }
+    }
+}

--- a/Tests/Get-RubrikRequest.Tests.ps1
+++ b/Tests/Get-RubrikRequest.Tests.ps1
@@ -1,0 +1,52 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikRequest' -Tag 'Public', 'Get-RubrikRequest' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'id'                    = 'RequestID:11111'
+                'nodeID'                = 'cluster:1111'
+                'status'                = 'Succeeded'
+                'starttime'             = '2019-09-09:12:20'
+                'endtime'               = '2019-09-09:12:24'
+            }
+        }
+        It -Name 'Should Return Succeeded' -Test {
+            (Get-RubrikRequest -id 'RequestID:11111' -type 'vmware/vm').status |
+                Should -BeExactly 'Succeeded'
+        }
+
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+    Context -Name 'Parameter Validation' {  
+        It -Name 'ID Missing' -Test {
+            { Get-RubrikRequest -id -Type 'vmware\vm' } |
+                Should -Throw "Missing an argument for parameter 'ID'. Specify a parameter of type 'System.String' and try again."
+        }      
+        It -Name 'Type Validate Set' -Test {
+            { Get-RubrikRequest -id '1111' -Type 'nonexistant' } |
+                Should -Throw "Cannot validate argument on parameter 'Type'. The argument `"nonexistant`" does not belong to the set `"fileset,mssql,vmware/vm,hyperv/vm,managed_volume`" specified by the ValidateSet attribute."
+        }
+    }
+}

--- a/Tests/Get-RubrikSnapshot.Tests.ps1
+++ b/Tests/Get-RubrikSnapshot.Tests.ps1
@@ -120,11 +120,11 @@ Describe -Name 'Public/Get-RubrikSnapshot' -Tag 'Public', 'Get-RubrikSnapshot' -
               Should -BeExactly $null
         }
         It -Name 'Test -Range' -Test {
-          ( Get-RubrikSnapshot -id 'VirtualMachine:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-vm-12345' -Date (Get-Date -Day 8 -Month 8 -Year 2019).Date -Range 3).id |
+          ( Get-RubrikSnapshot -id 'VirtualMachine:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-vm-12345' -Date (Get-Date -Day 8 -Month 8 -Year 2019).Date -Range 4).id |
               Should -BeExactly "b42ed6ba-760e-425f-a35d-c7dc5636b55d"
         }
         It -Name 'Test -Range and -ExactMatch' -Test {
-          ( Get-RubrikSnapshot -id 'VirtualMachine:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-vm-12345' -Date (Get-Date -Day 8 -Month 8 -Year 2019).Date -Range 3 -ExactMatch ).id |
+          ( Get-RubrikSnapshot -id 'VirtualMachine:::aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-vm-12345' -Date (Get-Date -Day 8 -Month 8 -Year 2019).Date -Range 4 -ExactMatch ).id |
               Should -BeExactly "b42ed6ba-760e-425f-a35d-c7dc5636b55d"
         }
         It -Name 'Test -Range with out of range date' -Test {

--- a/Tests/Get-RubrikUnmanagedObject.Tests.ps1
+++ b/Tests/Get-RubrikUnmanagedObject.Tests.ps1
@@ -1,0 +1,73 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikUnmanagedObject' -Tag 'Public', 'Get-RubrikUnmanagedObject' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'id'                    = 'VirtualMachine:11111'
+                'name'                  = 'VM1'
+                'unManagedStatus'       = 'Relic'
+                'objectType'            = 'VirtualMachine'
+            },
+            @{ 
+                'id'                    = 'MSSQLDatabase:11111'
+                'name'                  = 'db1'
+                'unManagedStatus'       = 'Unprotected'
+                'objectType'            = 'MssqlDatabase'
+            },
+            @{ 
+                'id'                    = 'VirtualMachine:22222'
+                'name'                  = 'VM2'
+                'unManagedStatus'       = 'Protected'
+                'objectType'            = 'VirtualMachine'
+            },
+            @{ 
+                'id'                    = 'VirtualMachine:33333'
+                'name'                  = 'VM3'
+                'unManagedStatus'       = 'Relic'
+                'objectType'            = 'VirtualMachine'
+            }
+        }
+        It -Name 'Should return count of 4' -Test {
+            (Get-RubrikUnmanagedObject).Count |
+                Should -BeExactly 4
+        }
+
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+    Context -Name 'Parameter Validation' {  
+        It -Name 'Name Missing' -Test {
+            { Get-RubrikUnmanagedObject -Name } |
+                Should -Throw "Missing an argument for parameter 'Name'. Specify a parameter of type 'System.String' and try again."
+        }      
+        It -Name 'Type - Validate Set' -Test {
+            { Get-RubrikUnmanagedObject -Type 'nonexistant' } |
+                Should -Throw "Cannot validate argument on parameter 'Type'. The argument `"nonexistant`" does not belong to the set `"VirtualMachine,MssqlDatabase,LinuxFileset,WindowsFileset`" specified by the ValidateSet attribute."
+        }
+        It -Name 'Status - Validate Set' -Test {
+            { Get-RubrikUnmanagedObject -Status 'nonexistant' } |
+                Should -Throw "Cannot validate argument on parameter 'Status'. The argument `"nonexistant`" does not belong to the set `"Protected,Relic,Unprotected`" specified by the ValidateSet attribute."
+        }
+    }
+}

--- a/Tests/Remove-RubrikUnmanagedObject.Tests.ps1
+++ b/Tests/Remove-RubrikUnmanagedObject.Tests.ps1
@@ -1,0 +1,30 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Remove-RubrikUnmanagedObject' -Tag 'Public', 'Remove-RubrikUnmanagedObject' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Parameter Validation' {  
+
+        It -Name 'ID Missing' -Test {
+            { Remove-RubrikUnmanagedObject -ID -Type 'VirtualMachine' } |
+                Should -Throw "Missing an argument for parameter 'Id'. Specify a parameter of type 'System.String' and try again."
+        }      
+
+    }
+}

--- a/Tests/Set-RubrikAvailabilityGroup.Tests.ps1
+++ b/Tests/Set-RubrikAvailabilityGroup.Tests.ps1
@@ -1,0 +1,60 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Set-RubrikAvailabilityGroup' -Tag 'Public', 'Set-RubrikAvailabilityGroup' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+ 
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Test-RubrikSLA -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 'slaid' = 'SLA:1111' }
+        }
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                'id'                            = 'AG:1111'
+                'name'                          = 'AG1'
+                'configuredSlaDomainId'         = 'SLA:1111'
+                'configuredSlaDomainName'       = 'Gold'
+                'logBackupFrequencyinSeconds'   = '60'
+                'logRetentionHours'             = '1'
+                'copyOnly'                      = 'true'
+            }
+        }
+        It -Name 'Should return AG1' -Test {
+            (Set-RubrikAvailabilityGroup -SLA 'Gold' -id 'AG:1111' -CopyOnly -LogBackupFrequencyInSeconds 60 -LogRetentionHours 1).Name |
+                Should -BeExactly 'AG1'
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Exactly 1
+    }
+    Context -Name 'Parameter Validation' {
+        It -Name 'Parameter id missing' -Test {
+            { Set-RubrikAvailabilityGroup -id  } |
+                Should -Throw "Missing an argument for parameter 'id'. Specify a parameter of type 'System.String' and try again."
+        }
+        It -Name 'Parameter LogBackupFrequencyInSeconds is integer' -Test {
+            { Set-RubrikAvailabilityGroup -id 'AG1' -LogBackupFrequencyInSeconds 'sixty'  } |
+                Should -Throw "Cannot process argument transformation on parameter 'LogBackupFrequencyInSeconds'."
+        }
+        It -Name 'Parameter LogRetentionHours is integer' -Test {
+            { Set-RubrikAvailabilityGroup -id 'AG1' -LogRetentionHours 'one'  } |
+                Should -Throw "Cannot process argument transformation on parameter 'LogRetentionHours'."
+        }
+    }
+}

--- a/Tests/Sync-RubrikTag.Tests.ps1
+++ b/Tests/Sync-RubrikTag.Tests.ps1
@@ -1,0 +1,32 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Sync-RubrikTag' -Tag 'Public', 'Sync-RubrikTag' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+    Context -Name 'Parameter Validation' {
+        
+        It -Name 'Parameter category cannot be null or empty' -Test {
+            { Sync-RubrikTag -Category $null  } |
+                Should -Throw "Cannot validate argument on parameter 'Category'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+        It -Name 'Parameter category missing' -Test {
+            { Sync-RubrikTag -Category  } |
+                Should -Throw "Missing an argument for parameter 'Category'. Specify a parameter of type 'System.String' and try again."
+        }
+    }
+}


### PR DESCRIPTION
# Description

Created unit tests for Get-RubrikAvailabilityGroup, Get-RubrikOrganization, Get-RubrikRequest, Get-RubrikUnmanagedObject, Remove-RubrikUnmanagedObject, Set-RubrikAvailabilityGroup, and Sync-RubrikTag.  Get-RubrikSnapshot was already present.

## Related Issue

[Issue 347](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/347)

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

Brings more unit tests to the PS SDK

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

Pester test passing.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
