### PR TITLE
Issue 348 - Unit test for Invoke-RubrikRestCall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-09-10
+
+### Added [Unit test for Invoke-RubrikRestCall]
+
+* Created unit test for Invoke-RubrikRestCall
+* Addresses [Issue 348](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/348)
+
 ## 2019-09-09
 
 ### Added [Various Unit Tests]

--- a/Tests/Invoke-RubrikRestCall.Tests.ps1
+++ b/Tests/Invoke-RubrikRestCall.Tests.ps1
@@ -1,0 +1,71 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Invoke-RubrikRestCall' -Tag 'Public', 'Invoke-RubrikRestCall' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'total' = '3'
+                'data'  =   @{ 
+                                'Name'        = 'VM1'
+                                'ID'          = 'VirtualMachine:11111'
+                                'powerStatus' = 'poweredOn'
+                            },
+                            @{ 
+                                'Name'        = 'VM2'
+                                'ID'          = 'VirtualMachine:22222'
+                                'powerStatus' = 'poweredOn'
+                            },
+                            @{ 
+                                'Name'        = 'VM3'
+                                'ID'          = 'VirtualMachine:33333'
+                                'powerStatus' = 'poweredOff'
+                            }
+            }
+        }
+
+        It -Name 'Requesting all should return total of 3' -Test {
+            ( Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "Get"   ).Total |
+                Should -BeExactly '3'
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+    Context -Name 'Parameter Validation' { 
+        It -Name 'Endpoint cannot be null or empty' -Test {
+            { Invoke-RubrikRestCall -Endpoint $null -Method "GET" } |
+                Should -Throw "Cannot validate argument on parameter 'Endpoint'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+        It -Name 'ValidateSet - Method' -Test {
+            { Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "non-existant" } |
+                Should -Throw "Cannot validate argument on parameter 'Method'."
+        }  
+        It -Name 'Query cannot be null or empty' -Test {
+            { Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "POST" -Query $null } |
+                Should -Throw "Cannot validate argument on parameter 'Query'."
+        } 
+        It -Name 'Body cannot be null or empty' -Test {
+            { Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "POST" -Body $null } |
+                Should -Throw "Cannot validate argument on parameter 'Body'."
+        }        
+    }
+}


### PR DESCRIPTION
# Description

Addition of unit test for Invoke-RubrikRestCall

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

Addresses [Issue 348](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/348)

## Motivation and Context

Why is this change required? What problem does it solve?

Allows for more unit test coverage within the Powershell SDK

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

Tested in the TM lab

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
