### PR TITLE
Fix TLS version not working using powershell 5.1

### DIFF
--- a/Rubrik/Private/Unblock-SelfSignedCert.ps1
+++ b/Rubrik/Private/Unblock-SelfSignedCert.ps1
@@ -5,20 +5,23 @@
 function Unblock-SelfSignedCert() 
 {
   Write-Verbose -Message 'Allowing self-signed certificates'
-    
+  
   if ([System.Net.ServicePointManager]::CertificatePolicy -notlike 'TrustAllCertsPolicy') 
   {
     Add-Type -TypeDefinition @"
     using System.Net;
     using System.Security.Cryptography.X509Certificates;
     public class TrustAllCertsPolicy : ICertificatePolicy {
-	    public bool CheckValidationResult(
-	        ServicePoint srvPoint, X509Certificate certificate,
-	        WebRequest request, int certificateProblem) {
-	        return true;
-	    }
+        public bool CheckValidationResult(
+            ServicePoint srvPoint, X509Certificate certificate,
+            WebRequest request, int certificateProblem) {
+            return true;
+        }
     }
 "@
     [System.Net.ServicePointManager]::CertificatePolicy = New-Object -TypeName TrustAllCertsPolicy
   }
+  
+  [System.Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
+  
 }


### PR DESCRIPTION
# Description

Add tls12 in Unblock-SelfSignedCert

## Related Issue

https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/454

## Motivation and Context

Unusable module using Powershell 5.1

## How Has This Been Tested?

Being able to execute an existing working powershell script at customer site.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
