### PR TITLE
Issue 470 - Setting variable scope to local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-10-22
+
+### Fixed [Scoped ID variable to local in New-RubrikHost]
+
+* Scoped the ID variable to local within the URI construction of New-RubrikHost as it was pulling ID variables set within the global scope and causing errors
+* Resolves [Issue 470](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/470)
+
 ## 2019-10-01
 
 ### Added [cmdlets to set and delete user roles and permissions]

--- a/Rubrik/Public/New-RubrikHost.ps1
+++ b/Rubrik/Public/New-RubrikHost.ps1
@@ -21,7 +21,7 @@ function New-RubrikHost
       This will register a host that resolves to the name "Server1.example.com"
 
       .EXAMPLE
-      New-RubrikHost -Name 'NAS.example.com' -HasAgent $false
+      New-RubrikHost -Name 'NAS.example.com' -HasAgent:$false
       This will register a host that resolves to the name "NAS.example.com" without using the Rubrik Backup Service
       In this case, the example host is a NAS share.
   #>
@@ -33,7 +33,7 @@ function New-RubrikHost
     [Alias('Hostname')]
     [String]$Name,
     # Set to $false to register a host that will be accessed through network shares
-    [Bool]$HasAgent,
+    [Switch]$HasAgent,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
     # API version
@@ -55,13 +55,14 @@ function New-RubrikHost
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
-    Write-Verbose -Message "Load API data for $Function"
+    Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   
   }
 
   Process {
-    
+    # If the switch parameter was not explicitly specified remove from query params 
+    if(-not $PSBoundParameters.ContainsKey('HasAgent')) { $Resources.Body.Remove('hasAgent') }
     $uri = New-URIString -server $Server -endpoint ($resources.URI)
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
     $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)

--- a/Rubrik/Public/New-RubrikHost.ps1
+++ b/Rubrik/Public/New-RubrikHost.ps1
@@ -62,7 +62,7 @@ function New-RubrikHost
 
   Process {
     
-    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $local:id
+    $uri = New-URIString -server $Server -endpoint ($resources.URI)
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
     $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body

--- a/Rubrik/Public/New-RubrikHost.ps1
+++ b/Rubrik/Public/New-RubrikHost.ps1
@@ -61,8 +61,8 @@ function New-RubrikHost
   }
 
   Process {
-
-    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+    
+    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $local:id
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
     $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body

--- a/Rubrik/Public/New-RubrikHost.ps1
+++ b/Rubrik/Public/New-RubrikHost.ps1
@@ -55,7 +55,7 @@ function New-RubrikHost
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
-    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Load API data for $($Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
   
   }

--- a/Rubrik/Public/New-RubrikHost.ps1
+++ b/Rubrik/Public/New-RubrikHost.ps1
@@ -55,7 +55,7 @@ function New-RubrikHost
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
-    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Load API data for $Function"
     Write-Verbose -Message "Description: $($resources.Description)"
   
   }

--- a/Rubrik/Public/New-RubrikHost.ps1
+++ b/Rubrik/Public/New-RubrikHost.ps1
@@ -55,7 +55,7 @@ function New-RubrikHost
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
-    Write-Verbose -Message "Load API data for $($Function)"
+    Write-Verbose -Message "Load API data for $Function"
     Write-Verbose -Message "Description: $($resources.Description)"
   
   }

--- a/Tests/New-RubrikHost.Tests.ps1
+++ b/Tests/New-RubrikHost.Tests.ps1
@@ -1,0 +1,44 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/New-RubrikHost' -Tag 'Public', 'New-RubrikHost' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Parameter Validation' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                id = "11111-11111-11111"
+                name = "MyNewServer"
+                hostname = "MyNewServer"
+                primaryClusterId = "22222-22222-22222"
+                operatingSystem = "MacOS"
+            }
+        }
+
+        It -Name 'Should create mount with QUEUED status' -Test {
+            ( New-RubrikHost -Id 'snapshotid').status |
+                Should -BeExactly 'QUEUED'
+        }
+        
+
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Exactly 1
+    }
+}

--- a/Tests/New-RubrikHost.Tests.ps1
+++ b/Tests/New-RubrikHost.Tests.ps1
@@ -19,26 +19,42 @@ Describe -Name 'Public/New-RubrikHost' -Tag 'Public', 'New-RubrikHost' -Fixture 
     }
     #endregion
 
-    Context -Name 'Parameter Validation' {
+    Context -Name 'Reponse Validation' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             @{
                 id = "11111-11111-11111"
-                name = "MyNewServer"
-                hostname = "MyNewServer"
+                name = "MyNewServer.Rubrik.com"
+                hostname = "MyNewServer.Rubrik.com"
                 primaryClusterId = "22222-22222-22222"
-                operatingSystem = "MacOS"
+                operatingSystem = "macOS"
             }
         }
 
-        It -Name 'Should create mount with QUEUED status' -Test {
-            ( New-RubrikHost -Id 'snapshotid').status |
-                Should -BeExactly 'QUEUED'
+        It -Name 'Should create new Rubrik host with correct name' -Test {
+            ( New-RubrikHost -Name 'MyNewServer.Rubrik.com').Name |
+                Should -BeExactly 'MyNewServer.Rubrik.com'
         }
         
+        It -Name 'Should create new Rubrik host with correct hostname' -Test {
+            ( New-RubrikHost -Name 'MyNewServer.Rubrik.com').hostname |
+                Should -BeExactly 'MyNewServer.Rubrik.com'
+        }
+        
+        It -Name 'Should create new Rubrik host with correct operating system' -Test {
+            ( New-RubrikHost -Name 'MyNewServer.Rubrik.com').operatingSystem |
+                Should -BeExactly 'macOS'
+        }
+        
+        It -Name 'Verify switch param - No PauseBackups - Switch Param' -Test {
+            $Output = & {
+                New-RubrikHost -Name 'MyNewServer.Rubrik.com' -Verbose 4>&1
+            }
+            (-join $Output) | Should -BeLike '*hostname*:*MyNewServer.Rubrik.com*'
+        }
 
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Exactly 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 4
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Exactly 4
     }
 }


### PR DESCRIPTION
# Description

This PR ensures that a globally scoped ID variable will not be used within the construction of the URI for New-RubrikHost.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

Resolves #470 

## Motivation and Context

Currently, if you set a value to a variable $id within a PS console, then run New-RubrikHost it will pull the global information for $id in.  By scoping the variable to $local:id we can avoid this.

## How Has This Been Tested?

Tested within the TM lab on CDM 5.0

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
