### PR TITLE
Added ability to search by AG name and ID

### DIFF
--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -217,6 +217,7 @@ function Get-RubrikAPIData($endpoint) {
         'Get-RubrikDatabase'           = @{
             '1.0' = @{
                 Description = 'Returns a list of summary information for Microsoft SQL databases.'
+                Function    = 'Get-RubrikDatabase'
                 URI         = '/api/v1/mssql/db'
                 Method      = 'Get'
                 Body        = ''
@@ -225,6 +226,7 @@ function Get-RubrikAPIData($endpoint) {
                     effective_sla_domain_id = 'effective_sla_domain_id'
                     primary_cluster_id      = 'primary_cluster_id'
                     is_relic                = 'is_relic'
+                    availability_group_id   = 'availability_group_id'
                 }
                 Result      = 'data'
                 Filter      = @{

--- a/Rubrik/Public/Get-RubrikDatabase.ps1
+++ b/Rubrik/Public/Get-RubrikDatabase.ps1
@@ -78,9 +78,14 @@ function Get-RubrikDatabase
     [String]$Hostname,
     #ServerInstance name (combined hostname\instancename)
     [String]$ServerInstance,
+    #Availability Group Name
+    [String]$AvailabilityGroupName,
     #SQL InstanceID, used as a unique identifier
     [Alias('instance_id')]
     [string]$InstanceID,
+    #SQL AvailabilityGroupID, used as a unique identifier
+    [Alias('availability_group_id')]
+    [string]$AvailabilityGroupID,
     # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,    
@@ -115,14 +120,18 @@ function Get-RubrikDatabase
 
     #region one-off
     if($ServerInstance){
-
       $SIobj = ConvertFrom-SqlServerInstance $ServerInstance
       $Hostname = $SIobj.hostname
       $Instance = $SIobj.instancename
     }
       
-   if($Hostname.Length -gt 0 -and $Instance.Length -gt 0 -and $InstanceID.Length -eq 0){
+    if($Hostname.Length -gt 0 -and $Instance.Length -gt 0 -and $InstanceID.Length -eq 0){
       $InstanceID = (Get-RubrikSQLInstance -Hostname $Hostname -Name $Instance).id
+    }
+
+    if($PSBoundParameters.ContainsKey('AvailabilityGroupName')){
+      $AvailabilityGroupID = (Get-RubrikAvailabilityGroup -GroupName $AvailabilityGroupName).id
+      if ($AvailabilGroupID.count -gt 1){$HostName = $AvailabilityGroupName}
     }
     #endregion
   }


### PR DESCRIPTION
# Description

Change will allow for Get-RubrikDatabase to search for databases in an Availability Group more efficiently. We are now allowing for search based AG name or ID

## Related Issue

https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/476

## Motivation and Context

Slow response times when working databases in an AG. A single database in an AG would be returned back in 4 min, with these changes, it will return back in less than 30 second. 

## How Has This Been Tested?

Testing has been conducted in the Gaia Lab with both non AG lookups and databases in an AG

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
