### PR TITLE
Case sensitivity for PrimaryClusterId, Issue #469

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-10-29
+
+### Fixed behavior of -primary_cluster_id
+
+* Removed the case-sensitivity issues as listed in [Issue 469](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/469)
+* Updated behavior of New-QueryString, stop adding ?limit to non-Get calls
+
 ## 2019-10-28
 
 ### Added [Function property to Get-RubrikAPIData]

--- a/Rubrik/Private/Test-QueryObject.ps1
+++ b/Rubrik/Private/Test-QueryObject.ps1
@@ -21,6 +21,9 @@
   if ((-not [string]::IsNullOrWhiteSpace($object)) -and ($location)) {
     # This builds the individual query item for the endpoint
     # Example: /vmware/vm?search_value=SE-CWAHL-WIN&limit=9999 contains 2 queries - search_value and limit
+    if (($location -eq 'primary_cluster_id') -and ($object -in ('local','me'))) { 
+      $object = $object.toLower() 
+    }
     return "$location=$object"
   }
 }

--- a/Rubrik/Private/Test-QueryParam.ps1
+++ b/Rubrik/Private/Test-QueryParam.ps1
@@ -90,8 +90,9 @@
   
   if ($parameters.name -contains 'limit') {
     $uri = New-QueryString -query $querystring -uri $uri
-  }
-  else {  
+  } elseif ($resource.method -ne 'Get') {
+    $uri = New-QueryString -query $querystring -uri $uri
+  } else {  
     $uri = New-QueryString -query $querystring -uri $uri -nolimit $true
   }
   Write-Verbose -Message "URI = $uri"


### PR DESCRIPTION
# Description

When trying to filter on PrimaryClusterId using local, the text must be entered in lowercase. Entering any uppercase text (IE Local) causes the API to return nothing

Describe the solution you'd like

Would like to see this support uppercase to fall more inline with how PowerShell handles case.

Can be done by adding code similar to the following to the Test-QueryObject private function

## Related Issue

Resolve #469

## Motivation and Context

Inconsistent and unexpected behavior

## How Has This Been Tested?

Ran unit tests 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
