### PR TITLE
Issue 440/485 - Limit flag for unlimited results on Get-RubrikReportData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-10-29
+
+### Changed [-Limit parameter in Get-RubrikReportData]
+
+* Added checks within Get-RubrikReportData to detect a limit value of -1. If detected, the cmdlet will perform recursion until all paginations has occured.
+* Addresses [Issue 440](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/440) and [Issue 485](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/485) in getting around the maximum limit defined within the API of 10000.
+
 ## 2019-10-28
 
 ### Added [Function property to Get-RubrikAPIData]

--- a/Rubrik/Public/Get-RubrikReportData.ps1
+++ b/Rubrik/Public/Get-RubrikReportData.ps1
@@ -103,7 +103,7 @@ function Get-RubrikReportData {
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body 
 
     # if limit has been set to -1
-    if ($returnAll -and $result.hasMore -eq 'True') {
+    if ($returnAll -and $result.hasMore -eq 'true') {
       # duplicate response to save initial returned data
       $nextresult = $result
       $PSBoundParameters.Add('cursor',$nextresult.cursor)
@@ -116,9 +116,9 @@ function Get-RubrikReportData {
           $nextresult = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
           $nextresult.dataGrid
           Write-Verbose $nextresult.hasMore
-        } while ($nextresult.hasMore -eq 'True')
+        } while ($nextresult.hasMore -eq 'true')
     }
-    $result.hasMore = 'False'
+    $result.hasMore = 'false'
 
     return $result
 

--- a/Tests/Get-RubrikReportData.Tests.ps1
+++ b/Tests/Get-RubrikReportData.Tests.ps1
@@ -26,16 +26,20 @@ Describe -Name 'Public/Get-RubrikReportData' -Tag 'Public', 'Get-RubrikReportDat
                 'columns'               = @('TaskStatus','TaskType','ObjectId','ObjectName')
                 'cursor'                = '1111-2222-3333'
                 'reportTemplate'        = 'ProtectionTaskDetails'
-                'datagrid'              = @('OracleDatabase','Backup','11111','OracleHR')
+                'datagrid'              = @('OracleDatabase','Backup','11111','OracleHR')  
             }
         }
         It -Name 'Returns reportTemplate' -Test {
             ( Get-RubrikReportData -id 1111).reportTemplate |
                 Should -BeExactly 'ProtectionTaskDetails'
         } 
+        It -Name 'Sets hasMore to false' -Test {
+            (Get-RubrikReportData -id 1111 -limit -1).hasMore | 
+            Should -BeExactly 'False'
+        }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 2
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 2
     }
     Context -Name 'Parameter Validation' {
         It -Name 'ID Missing' -Test {

--- a/Tests/Get-RubrikReportData.Tests.ps1
+++ b/Tests/Get-RubrikReportData.Tests.ps1
@@ -35,7 +35,7 @@ Describe -Name 'Public/Get-RubrikReportData' -Tag 'Public', 'Get-RubrikReportDat
         } 
         It -Name 'Sets hasMore to false' -Test {
             (Get-RubrikReportData -id 1111 -limit -1).hasMore | 
-            Should -BeExactly 'False'
+            Should -BeExactly 'false'
         }
         Assert-VerifiableMock
         Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 2


### PR DESCRIPTION
# Description

The API response from Rubrik is limited to a maximum of 10,000 lines when returning data. In order to view more, pagination and the cursor attribute must be used.  This can become difficult for the end-user. 

Rather than require the end-user to use our pagination, we can simply build it into the cmdlet. Specifying a -Limit of -1 will now return all the results, ignoring the limit.

## Related Issue

Addresses [Issue 440](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/440) and [Issue 485](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/485) in getting around the maximum limit defined within the API of 10000.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce



## Motivation and Context

Why is this change required? What problem does it solve?

This further simplifies the usage of our PowerShell SDK for our customers.

## How Has This Been Tested?

Tested within the TM lab on a 5.0 cluster.

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
