### PR TITLE
Issue 478 - fix primary_cluster_id documenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-10-30
+
+### Fixed [Documenation referencing _local]
+
+* Replaced occurances of _local with local within documenation around the primary_cluster_id.
+* Addresses [Issue 468](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/468)
+
 ## 2019-10-29
 
 ### Changed [-Limit parameter in Get-RubrikReportData]

--- a/Rubrik/Public/Get-RubrikAvailabilityGroup.ps1
+++ b/Rubrik/Public/Get-RubrikAvailabilityGroup.ps1
@@ -36,7 +36,7 @@ function Get-RubrikAvailabilityGroup
     [Alias('effectiveSlaDomainName')]
     [String]$SLA,
     
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,    
 

--- a/Rubrik/Public/Get-RubrikDatabase.ps1
+++ b/Rubrik/Public/Get-RubrikDatabase.ps1
@@ -96,7 +96,7 @@ function Get-RubrikDatabase
     # SQL AvailabilityGroupID, used as a unique identifier
     [Alias('availability_group_id')]
     [string]$AvailabilityGroupID,
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,    
     # SLA id value

--- a/Rubrik/Public/Get-RubrikFileset.ps1
+++ b/Rubrik/Public/Get-RubrikFileset.ps1
@@ -102,7 +102,7 @@ function Get-RubrikFileset
     [Alias('template_id')]
     [ValidateNotNullOrEmpty()]
     [String]$TemplateID,
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Parameter(ParameterSetName='Query')]
     [Parameter(ParameterSetName='Filter')]
     [Alias('primary_cluster_id')]

--- a/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
+++ b/Rubrik/Public/Get-RubrikFilesetTemplate.ps1
@@ -42,7 +42,7 @@ function Get-RubrikFilesetTemplate
     [ValidateSet('NFS', 'SMB')]
     [Alias('share_type')]
     [String]$shareType,
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,    
     # The ID of the fileset template

--- a/Rubrik/Public/Get-RubrikHost.ps1
+++ b/Rubrik/Public/Get-RubrikHost.ps1
@@ -47,7 +47,7 @@ function Get-RubrikHost
     [ValidateSet('Windows','Linux','Any','None')]
     [Alias('operating_system_type')]
     [String]$Type,
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,
     # ID of the registered host

--- a/Rubrik/Public/Get-RubrikHyperVVM.ps1
+++ b/Rubrik/Public/Get-RubrikHyperVVM.ps1
@@ -50,7 +50,7 @@ function Get-RubrikHyperVVM
     [Parameter(ParameterSetName='Query')]
     [ValidateSet('Derived', 'Direct','Unassigned')]
     [String]$SLAAssignment,     
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Parameter(ParameterSetName='Query')]    
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,        

--- a/Rubrik/Public/Get-RubrikManagedVolumeExport.ps1
+++ b/Rubrik/Public/Get-RubrikManagedVolumeExport.ps1
@@ -39,7 +39,7 @@ function Get-RubrikManagedVolumeExport
     #Name of the source managed volume
     [Alias('$source_managed_volume_name')]
     [String]$SourceManagedVolumeName,
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,
     # Rubrik server IP or FQDN

--- a/Rubrik/Public/Get-RubrikNASShare.ps1
+++ b/Rubrik/Public/Get-RubrikNASShare.ps1
@@ -45,7 +45,7 @@ function Get-RubrikNASShare
     [String]$exportPoint,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Parameter(ParameterSetName='Query')]
     [ValidateNotNullOrEmpty()]
     [Alias('primary_cluster_id')]

--- a/Rubrik/Public/Get-RubrikNutanixVM.ps1
+++ b/Rubrik/Public/Get-RubrikNutanixVM.ps1
@@ -50,7 +50,7 @@ function Get-RubrikNutanixVM
     [Parameter(ParameterSetName='Query')]
     [ValidateSet('Derived', 'Direct','Unassigned')]
     [String]$SLAAssignment,     
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Parameter(ParameterSetName='Query')]    
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,        

--- a/Rubrik/Public/Get-RubrikOracleDB.ps1
+++ b/Rubrik/Public/Get-RubrikOracleDB.ps1
@@ -51,7 +51,7 @@ function Get-RubrikOracleDB
     [Alias('sla_assignment')]
     [ValidateSet('Derived', 'Direct','Unassigned')]
     [String]$SLAAssignment,     
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,        
     # Oracle DB id

--- a/Rubrik/Public/Get-RubrikSLA.ps1
+++ b/Rubrik/Public/Get-RubrikSLA.ps1
@@ -36,7 +36,7 @@ function Get-RubrikSLA
     [ValidateNotNullOrEmpty()]
     [Alias('SLA')]
     [String]$Name,
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,    
     # SLA Domain id

--- a/Rubrik/Public/Get-RubrikVCenter.ps1
+++ b/Rubrik/Public/Get-RubrikVCenter.ps1
@@ -25,7 +25,7 @@ function Get-RubrikVCenter
     [String]$Name,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,  
     # API version

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -68,7 +68,7 @@ function Get-RubrikVM
     [ValidateSet('Derived', 'Direct','Unassigned')]
     [Alias('sla_assignment')]
     [String]$SLAAssignment,     
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Parameter(ParameterSetName='Query')]
     [ValidateNotNullOrEmpty()]
     [Alias('primary_cluster_id')]

--- a/Rubrik/Public/Get-RubrikVolumeGroup.ps1
+++ b/Rubrik/Public/Get-RubrikVolumeGroup.ps1
@@ -39,7 +39,7 @@ function Get-RubrikVolumeGroup
     [Switch]$Relic,
     # SLA Domain policy assigned to the volume group
     [String]$SLA, 
-    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use **_local** as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
+    # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Alias('primary_cluster_id')]
     [String]$PrimaryClusterID,        
     # Volume group id


### PR DESCRIPTION
# Description

This PR simply updates the documentation around the primary_cluster_id parameter to reference 'local' instead of '_local'

## Related Issue

Addresses [Issue 468](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/468)

## Motivation and Context

End users can now see the proper syntax for passing 'local' to the primary_cluster_id parameter

## How Has This Been Tested?

Tested within the TM lab.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
