### PR TITLE
Issue 487 - Expose volume letter in "Get-RubrikVolumeGroup"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-10-30
+
+### Added [-DetailedObject parameter in Get-RubrikVolumeGroup]
+
+* Changed default display
+* Added `-DetailedObject` parameter to `Get-RubrikVolumeGroup`
+* Addresses [Issue 487](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/487)
+
 ## 2019-10-29
 
 ### Changed [-Limit parameter in Get-RubrikReportData]

--- a/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
@@ -37,7 +37,7 @@
                                 <PropertyName>effectiveSlaDomainName</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <ScriptBlock>if ($_.volumes) {$.volumes.mountPoints}</ScriptBlock>
+                                <ScriptBlock>if ($null -ne $_.volumes) {$.volumes.mountPoints}</ScriptBlock>
                             </TableColumnItem>                            
                             <TableColumnItem>
                                 <PropertyName>id</PropertyName>

--- a/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
@@ -37,7 +37,7 @@
                                 <PropertyName>effectiveSlaDomainName</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <ScriptBlock>if ($null -ne $_.volumes) {$_.volumes.mountPoints}</ScriptBlock>
+                                <PropertyName>includes</PropertyName>
                             </TableColumnItem>                            
                             <TableColumnItem>
                                 <PropertyName>id</PropertyName>

--- a/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
@@ -37,7 +37,7 @@
                                 <PropertyName>effectiveSlaDomainName</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <ScriptBlock>if ($_.volumes) {$.volumes.mountPoints} else {(Get-RubrikVolumeGroup -Id $_.id).volumes.mountPoints}</ScriptBlock>
+                                <ScriptBlock>if ($_.volumes) {$.volumes.mountPoints}</ScriptBlock>
                             </TableColumnItem>                            
                             <TableColumnItem>
                                 <PropertyName>id</PropertyName>

--- a/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
@@ -19,7 +19,7 @@
                     </TableColumnHeader>
                     <TableColumnHeader>
                         <Label>ID</Label>
-                    </TableColumnHeader>                    
+                    </TableColumnHeader>
                 </TableHeaders>
                 <TableRowEntries>
                     <TableRowEntry>
@@ -35,7 +35,7 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>id</PropertyName>
-                            </TableColumnItem>                            
+                            </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>
                 </TableRowEntries>

--- a/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
@@ -37,7 +37,7 @@
                                 <PropertyName>effectiveSlaDomainName</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <ScriptBlock>if ($null -ne $_.volumes) {$.volumes.mountPoints}</ScriptBlock>
+                                <ScriptBlock>if ($null -ne $_.volumes) {$_.volumes.mountPoints}</ScriptBlock>
                             </TableColumnItem>                            
                             <TableColumnItem>
                                 <PropertyName>id</PropertyName>

--- a/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.VolumeGroup.ps1xml
@@ -18,6 +18,9 @@
                         <Label>SLA Domain</Label>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <Label>Includes</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Label>ID</Label>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -33,6 +36,9 @@
                             <TableColumnItem>
                                 <PropertyName>effectiveSlaDomainName</PropertyName>
                             </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>if ($_.volumes) {$.volumes.mountPoints} else {(Get-RubrikVolumeGroup -Id $_.id).volumes.mountPoints}</ScriptBlock>
+                            </TableColumnItem>                            
                             <TableColumnItem>
                                 <PropertyName>id</PropertyName>
                             </TableColumnItem>

--- a/Rubrik/Public/Get-RubrikVolumeGroup.ps1
+++ b/Rubrik/Public/Get-RubrikVolumeGroup.ps1
@@ -114,6 +114,15 @@ function Get-RubrikVolumeGroup
         }
         Set-ObjectTypeName -TypeName $resources.ObjectTName -result $updatedresult
       }
+    } elseif ($PSBoundParameters.containskey('id')) {
+      $result = $result | Select-Object -Property *,@{
+        name = 'includes'
+        expression = {
+          if ($null -ne $_.volumes) {$_.volumes.mountPoints}
+        }
+      }
+      $result = Set-ObjectTypeName -TypeName $resources.ObjectTName -result $result
+      return $result
     } else {
       $result = Set-ObjectTypeName -TypeName $resources.ObjectTName -result $result
       return $result

--- a/Rubrik/Public/Get-RubrikVolumeGroup.ps1
+++ b/Rubrik/Public/Get-RubrikVolumeGroup.ps1
@@ -104,17 +104,10 @@ function Get-RubrikVolumeGroup
       for ($i = 0; $i -lt @($result).Count; $i++) {
         $Percentage = [int]($i/@($result).count*100)
         Write-Progress -Activity "DetailedObject queries in Progress, $($i+1) out of $(@($result).count)" -Status "$Percentage% Complete:" -PercentComplete $Percentage
-        $updatedresult = Get-RubrikVolumeGroup -id $result[$i].id | ForEach-Object {
-          Select-Object -InputObject $_ -Property *,@{
-            name = 'includes'
-            expression = {
-              if ($null -ne $_.volumes) {$_.volumes.mountPoints}
-            }
-          }
-        }
+        $updatedresult = Get-RubrikVolumeGroup -id $result[$i].id
         Set-ObjectTypeName -TypeName $resources.ObjectTName -result $updatedresult
       }
-    } elseif ($PSBoundParameters.containskey('id')) {
+    } elseif ($PSBoundParameters.containskey('id') -and (-not $DetailedObject)) {
       $result = $result | Select-Object -Property *,@{
         name = 'includes'
         expression = {

--- a/Rubrik/Public/Get-RubrikVolumeGroup.ps1
+++ b/Rubrik/Public/Get-RubrikVolumeGroup.ps1
@@ -48,6 +48,8 @@ function Get-RubrikVolumeGroup
     # SLA id value
     [Alias('effective_sla_domain_id')]
     [String]$SLAID,    
+    # DetailedObject will retrieved the detailed VolumeGroup object, the default behavior of the API is to only retrieve a subset of the full VolumeGroup object unless we query directly by ID. Using this parameter does affect performance as more data will be retrieved and more API-queries will be performed.
+    [Switch]$DetailedObject,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
     # API version

--- a/Rubrik/Public/Get-RubrikVolumeGroup.ps1
+++ b/Rubrik/Public/Get-RubrikVolumeGroup.ps1
@@ -6,7 +6,7 @@ function Get-RubrikVolumeGroup
       Retrieves details on one or more volume groups known to a Rubrik cluster
 
       .DESCRIPTION
-      The Get-RubrikVolumeGroup cmdlet is used to pull a detailed data set from a Rubrik cluster on any number of volume groups
+      The Get-RubrikVolumeGroup cmdlet is used to pull a detailed data set from a Rubrik cluster on any number of volume groups. By default the 'Includes' property is not populated, unless when querying by ID or by using the -DetailedObject parameter
 
       .NOTES
       Written by Pierre Flammer for community usage
@@ -26,6 +26,14 @@ function Get-RubrikVolumeGroup
       .EXAMPLE
       Get-RubrikVolumeGroup -Relic
       This will return all removed volume groups that were formerly protected by Rubrik.
+
+      .EXAMPLE
+      Get-RubrikVolumeGroup -DetailedObject
+      This will return full details on all volume groups available on the Rubrik Cluster, this query will take longer as multiple API calls are required. The 'Includes' property will be populated
+
+      .EXAMPLE
+      Get-RubrikVolumeGroup -Id VolumeGroup:::205b0b65-b90c-48c5-9cab-66b95ed18c0f
+      This will return full details on for the specified VolumeGroup ID
   #>
 
   [CmdletBinding()]

--- a/Rubrik/Public/Get-RubrikVolumeGroup.ps1
+++ b/Rubrik/Public/Get-RubrikVolumeGroup.ps1
@@ -81,7 +81,6 @@ function Get-RubrikVolumeGroup
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
   }
 
   Process {
@@ -99,17 +98,32 @@ function Get-RubrikVolumeGroup
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
     $result = Test-FilterObject -filter ($resources.Filter) -result $result
-    $result = Set-ObjectTypeName -TypeName $resources.ObjectTName -result $result
-
+    
     # If the Get-RubrikVolumeGroup function has been called with the -DetailedObject parameter a separate API query will be performed if the initial query was not based on ID
     if (($DetailedObject) -and (-not $PSBoundParameters.containskey('id'))) {
-      for ($i = 0; $i -lt @($result).Count; $i++) {
+      $result = for ($i = 0; $i -lt @($result).Count; $i++) {
         $Percentage = [int]($i/@($result).count*100)
         Write-Progress -Activity "DetailedObject queries in Progress, $($i+1) out of $(@($result).count)" -Status "$Percentage% Complete:" -PercentComplete $Percentage
-        Get-RubrikVolumeGroup -id $result[$i].id
+        Get-RubrikVolumeGroup -id $result[$i].id | ForEach-Object {
+          Select-Object -InputObject $_ -Property *,@{
+            name = 'includes'
+            expression = {
+              if ($null -ne $_.volumes) {$_.volumes.mountPoints}
+            }
+          }
+        }
       }
     } else {
-      return $result
+      $selectsplat
+      $result = $result | Select-Object -Property *,@{
+        name = 'includes'
+        expression = {
+          if ($null -ne $_.volumes) {$_.volumes.mountPoints}
+        }
+      }
     }
+
+    $result = Set-ObjectTypeName -TypeName $resources.ObjectTName -result $result
+    return $result
   } # End of process
 } # End of function

--- a/Rubrik/Public/Get-RubrikVolumeGroup.ps1
+++ b/Rubrik/Public/Get-RubrikVolumeGroup.ps1
@@ -91,7 +91,15 @@ function Get-RubrikVolumeGroup
     $result = Test-FilterObject -filter ($resources.Filter) -result $result
     $result = Set-ObjectTypeName -TypeName $resources.ObjectTName -result $result
 
-    return $result
-
+    # If the Get-RubrikVolumeGroup function has been called with the -DetailedObject parameter a separate API query will be performed if the initial query was not based on ID
+    if (($DetailedObject) -and (-not $PSBoundParameters.containskey('id'))) {
+      for ($i = 0; $i -lt @($result).Count; $i++) {
+        $Percentage = [int]($i/@($result).count*100)
+        Write-Progress -Activity "DetailedObject queries in Progress, $($i+1) out of $(@($result).count)" -Status "$Percentage% Complete:" -PercentComplete $Percentage
+        Get-RubrikVolumeGroup -id $result[$i].id
+      }
+    } else {
+      return $result
+    }
   } # End of process
 } # End of function

--- a/Tests/Get-RubrikVolumeGroup.Tests.ps1
+++ b/Tests/Get-RubrikVolumeGroup.Tests.ps1
@@ -25,7 +25,7 @@ Describe -Name 'Public/Get-RubrikVolumeGroup' -Tag 'Public', 'Get-RubrikVolumeGr
             @{ 'slaid' = 'SLA1' }
         }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{ 
+            @{
                 'name'                   = 'VG01'
                 'id'                     = 'VolumeGroup:::11111'
                 'hostname'               = 'VG01.domain.local'
@@ -41,7 +41,7 @@ Describe -Name 'Public/Get-RubrikVolumeGroup' -Tag 'Public', 'Get-RubrikVolumeGr
                 'effectiveSlaDomainId'   = 'SLA1'
                 'hostId'                 = 'host02'
             },
-            @{ 
+            @{
                 'name'                   = 'VG03'
                 'id'                     = 'VolumeGroup:::33333'
                 'hostname'               = 'VG03.domain.local'
@@ -49,7 +49,7 @@ Describe -Name 'Public/Get-RubrikVolumeGroup' -Tag 'Public', 'Get-RubrikVolumeGr
                 'effectiveSlaDomainId'   = 'SLA2'
                 'hostId'                 = 'host03'
             },
-            @{ 
+            @{
                 'name'                   = 'VG04'
                 'id'                     = 'VolumeGroup:::44444'
                 'hostname'               = 'VG04.domain.local'
@@ -73,11 +73,11 @@ Describe -Name 'Public/Get-RubrikVolumeGroup' -Tag 'Public', 'Get-RubrikVolumeGr
         It -Name 'Missing ID Exception' -Test {
             { Get-RubrikVolumeGroup -id  } |
                 Should -Throw "Missing an argument for parameter 'id'. Specify a parameter of type 'System.String' and try again."
-        } 
+        }
         It -Name 'Missing Name Exception' -Test {
             { Get-RubrikVolumeGroup -name  } |
                 Should -Throw "Missing an argument for parameter 'name'. Specify a parameter of type 'System.String' and try again."
-        } 
+        }
         Assert-VerifiableMock
         Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 3
         Assert-MockCalled -CommandName Test-RubrikSLA -ModuleName 'Rubrik' -Exactly 1

--- a/Tests/Get-RubrikVolumeGroup.Tests.ps1
+++ b/Tests/Get-RubrikVolumeGroup.Tests.ps1
@@ -79,7 +79,8 @@ Describe -Name 'Public/Get-RubrikVolumeGroup' -Tag 'Public', 'Get-RubrikVolumeGr
                 Should -Throw "Missing an argument for parameter 'name'. Specify a parameter of type 'System.String' and try again."
         } 
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 3
+        Assert-MockCalled -CommandName Test-RubrikSLA -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 3
     }
 }

--- a/Tests/Get-RubrikVolumeGroup.Tests.ps1
+++ b/Tests/Get-RubrikVolumeGroup.Tests.ps1
@@ -105,12 +105,12 @@ Describe -Name 'Public/Get-RubrikVolumeGroup' -Tag 'Public', 'Get-RubrikVolumeGr
         }
 
         It -Name 'Requesting volumes property should be /etc when queried by id' -Test {
-            ( Get-RubrikVolumeGroup -id VolumeGroup:::11111).Volumes.mountPoints |
+            ( Get-RubrikVolumeGroup -id VolumeGroup:::11111).includes |
                 Should -BeExactly '/etc'
         }
 
         It -Name 'Requesting volumes property should be /etc when using -DetailedObject' -Test {
-            ( Get-RubrikVolumeGroup -DetailedObject).Volumes.mountPoints |
+            ( Get-RubrikVolumeGroup -Name VG01 -DetailedObject).includes |
                 Should -BeExactly '/etc'
         }
         Assert-VerifiableMock

--- a/Tests/Get-RubrikVolumeGroup.Tests.ps1
+++ b/Tests/Get-RubrikVolumeGroup.Tests.ps1
@@ -85,9 +85,6 @@ Describe -Name 'Public/Get-RubrikVolumeGroup' -Tag 'Public', 'Get-RubrikVolumeGr
     }
     Context -Name 'DetailedObject querying' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
-        Mock -CommandName Test-RubrikSLA -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{ 'slaid' = 'SLA1' }
-        }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             @{ 
                 'name'                   = 'VG01'
@@ -107,14 +104,17 @@ Describe -Name 'Public/Get-RubrikVolumeGroup' -Tag 'Public', 'Get-RubrikVolumeGr
                 Should -BeExactly 1
         }
 
-        It -Name 'Requesting volumes property should be empty by default' -Test {
+        It -Name 'Requesting volumes property should be /etc when queried by id' -Test {
             ( Get-RubrikVolumeGroup -id VolumeGroup:::11111).Volumes.mountPoints |
                 Should -BeExactly '/etc'
         }
 
-        It -Name 'Requesting volumes property should be empty by default' -Test {
+        It -Name 'Requesting volumes property should be /etc when using -DetailedObject' -Test {
             ( Get-RubrikVolumeGroup -DetailedObject).Volumes.mountPoints |
                 Should -BeExactly '/etc'
         }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 4
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 4
     }    
 }


### PR DESCRIPTION
# Description

Add the associated protected volume letter to a VolumeGroup ID in the Get-RubrikVolumeGroup CMDlet

## Related Issue

Resolve #487

## Motivation and Context

The default display does not display any associated volumes, this is the default in the GUI interface and would be interesting data to display. In order to resolve this I have done the following:

* Added -DetailedObject parameter, as is present in other Get-Rubrik* functions
* Updated documentation
* Updated default display to in the 'includes' field

## How Has This Been Tested?

Existing unit tests run, new unit tests have been created. Ran the code against the TME test clusters.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
