### PR TITLE
Issue 442 - Fix empty POST responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-11-05
+
+### Changed [Submit-Request]
+
+* Modified private function Submit-Request.ps1 to support adding in success/error information for empty POST responses
+* Modified status return code for Remove-RubrikManagedObject
+* Addresses [Issue 442](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/442)
+
 ## 2019-11-04
 
 ### Added [Set- & Remove-RubrikProxySetting functions]

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -1998,7 +1998,7 @@ function Get-RubrikAPIData($endpoint) {
                 Query       = ''
                 Result      = ''
                 Filter      = ''
-                Success     = '200'
+                Success     = '204'
             }
         }
         'Remove-RubrikVCenter'         = @{

--- a/Rubrik/Private/Submit-Request.ps1
+++ b/Rubrik/Private/Submit-Request.ps1
@@ -33,8 +33,8 @@ function Submit-Request {
     if ($PSCmdlet.ShouldProcess($id, $resources.Description)) {
         try {
             Write-Verbose -Message 'Submitting the request'
-            if ($resources.method -eq 'Delete') {
-                # Delete operations generally have no response body, skip JSON formatting and store the response from Invoke-WebRequest
+            if ($resources.method -in ('Delete','Post')) {
+                # Delete operations (and some post) generally have no response body, skip JSON formatting and store the response from Invoke-WebRequest
                 if (Test-PowerShellSix) {
                     # Uses the improved ConvertFrom-Json cmdlet as provided in PowerShell 6.1
                     $result = if ($null -ne ($WebResult = Invoke-RubrikWebRequest -Uri $uri -Headers $header -Method $method -Body $body)) {


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

This PR allows for a response stating either success or error to be displayed when a POST response contains no data.

Also modified the Remove-RubrikUnmanagedObject stanza in Get-RubrikAPIData to contain the proper success response code.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

Addresses [Issue 442](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/442)

## Motivation and Context

Why is this change required? What problem does it solve?


Allows for end users to see some sort of message rather than just an empty response.
## How Has This Been Tested?
Tested in TM Lab
* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
