### PR TITLE
Add logic to pull from remote cluster ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-11-08
+
+### Changed [Changed the behavior of Test-RubrikSLA]
+
+* The private function `Test-RubrikSLA` had a hard coded local variable
+* Addresses [Issue 497](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/497)
+
 ## 2019-11-06
 
 ### Changed [Get-RubrikVcd & Get-RubrikVApp Options function names]

--- a/Rubrik/Private/Test-RubrikSLA.ps1
+++ b/Rubrik/Private/Test-RubrikSLA.ps1
@@ -1,4 +1,4 @@
-﻿Function Test-RubrikSLA($SLA, $Inherit, $DoNotProtect, $Mandatory, $PrimaryClusterID = 'local') {
+﻿Function Test-RubrikSLA($SLA, $Inherit, $DoNotProtect, $Mandatory, $PrimaryClusterID) {
   <#
     .SYNOPSIS
     Retrieves an ID for a given SLA
@@ -8,19 +8,27 @@
 
     .PARAMETER SLA
     The SLA Domain name to lookup
-    
+
     .PARAMETER Inherit
     Switch to set SLA to 'Inherit'
 
     .PARAMETER DoNotProtect
     Switch to set SLA to 'Unprotected'
-    
+
     .PARAMETER Mandatory
     Switch to ensure SLA information was inputted
-    
+
     .PARAMETER PrimaryClusterId
     The ID of the cluster to search
   #>
+
+  # Determine the state of $PrimaryClusterID
+  Write-Verbose -Message "Primary cluster ID currently set to: $PrimaryClusterID"
+  if (!$PrimaryClusterID) {
+    $PrimaryClusterID = 'local'
+    Write-Verbose -Message "Null value found. Setting primary cluster ID to $PrimaryClusterID"
+  }
+
   Write-Verbose -Message 'Determining the SLA Domain id'
   if ($SLA) {
     $slaid = (Get-RubrikSLA -SLA $SLA -PrimaryClusterID $PrimaryClusterID).id
@@ -39,4 +47,4 @@
     throw 'No SLA information was entered.'
   }
 }
-    
+

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -1,7 +1,7 @@
 ﻿#requires -Version 3
 function Get-RubrikVM
 {
-  <#  
+  <#
       .SYNOPSIS
       Retrieves details on one or more virtual machines known to a Rubrik cluster
 
@@ -30,7 +30,7 @@ function Get-RubrikVM
 
       .EXAMPLE
       Get-RubrikVM -Name myserver01 -DetailedObject
-      This will return the VM object with all properties, including additional details such as snapshots taken of the VM. Using this switch parameter negatively affects performance 
+      This will return the VM object with all properties, including additional details such as snapshots taken of the VM. Using this switch parameter negatively affects performance
   #>
 
   [CmdletBinding(DefaultParameterSetName = 'Query')]
@@ -53,7 +53,7 @@ function Get-RubrikVM
     [String]$id,
     # Filter results to include only relic (removed) virtual machines
     [Parameter(ParameterSetName='Query')]
-    [Alias('is_relic')]    
+    [Alias('is_relic')]
     [Switch]$Relic,
     # DetailedObject will retrieved the detailed VM object, the default behavior of the API is to only retrieve a subset of the full VM object unless we query directly by ID. Using this parameter does affect performance as more data will be retrieved and more API-queries will be performed.
     [Parameter(ParameterSetName='Query')]
@@ -61,23 +61,23 @@ function Get-RubrikVM
     # SLA Domain policy assigned to the virtual machine
     [Parameter(ParameterSetName='Query')]
     [ValidateNotNullOrEmpty()]
-    [String]$SLA, 
+    [String]$SLA,
     # Filter by SLA Domain assignment type
     [Parameter(ParameterSetName='Query')]
     [ValidateNotNullOrEmpty()]
     [ValidateSet('Derived', 'Direct','Unassigned')]
     [Alias('sla_assignment')]
-    [String]$SLAAssignment,     
+    [String]$SLAAssignment,
     # Filter the summary information based on the primarycluster_id of the primary Rubrik cluster. Use 'local' as the primary_cluster_id of the Rubrik cluster that is hosting the current REST API session.
     [Parameter(ParameterSetName='Query')]
     [ValidateNotNullOrEmpty()]
     [Alias('primary_cluster_id')]
-    [String]$PrimaryClusterID,        
+    [String]$PrimaryClusterID,
     # SLA id value
     [Parameter(ParameterSetName='Query')]
     [ValidateNotNullOrEmpty()]
     [Alias('effective_sla_domain_id')]
-    [String]$SLAID,    
+    [String]$SLAID,
     # Rubrik server IP or FQDN
     [Parameter(ParameterSetName='Query')]
     [Parameter(ParameterSetName='ID')]
@@ -92,7 +92,7 @@ function Get-RubrikVM
 
     # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
     # If a command needs to be run with each iteration or pipeline input, place it in the Process section
-    
+
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
 
@@ -105,20 +105,20 @@ function Get-RubrikVM
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
+
   }
 
   Process {
 
     #region One-off
     if ($SLAID.Length -eq 0 -and $SLA.Length -gt 0) {
-      $SLAID = Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect
+      $SLAID = Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect -PrimaryClusterID $PrimaryClusterID
     }
     #endregion
 
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
-    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)    
+    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
     $result = Test-FilterObject -filter ($resources.Filter) -result $result

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Rubrik.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.0.0.514'
+ModuleVersion = '4.0.0.515'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Signed-off-by: Chris Wahl <github@wahlnetwork.com>

<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

The private function `Test-RubrikSLA` had a hard coded `local` variable set for the primary cluster ID. This effectively blocks the user from being able to supply a remote cluster ID in a call. This PR specifically fixes two things:

* `Test-RubrikSLA` can now accept the `$PrimaryClusterID` value that is passed to it. If no value was passed, we assume the user wants the `local` cluster and supply that value with verbose logging.
* `Get-RubrikVM` will now pass the `$PrimaryClusterID` value that was set by the user in the param.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

Fixes #497 

## Motivation and Context

It solves the logical path for VM retrieval. If this ends up being successful and a desired change, we will need to find any other references to `Test-RubrikSLA` and ensure that those functions are also passing the `$PrimaryClusterID` to the test.

## How Has This Been Tested?

Tested on CDM 4.2 (Cluster A) replicating to CDM 5.0 (Cluster B)

```
Connect-Rubrik -Server 'cluster-b-rr.rubrik.us' -Credential $cred

get-rubrikvm -sla 'Prod-12H-R31-A60_AWS_USW1' -PrimaryClusterID '40fdb2a5-3591-40ee-a37a-50bce5240d62' -name 'DC01' -Verbose

VERBOSE: Validate the Rubrik token exists
VERBOSE: Found a Rubrik token for authentication
VERBOSE: Gather API Data for Get-RubrikVM
VERBOSE: Selected 1.0 API Data for Get-RubrikVM
VERBOSE: Load API data for Get-RubrikVM
VERBOSE: Description: Get summary of all the VMs
VERBOSE: Primary cluster ID currently set to: 40fdb2a5-3591-40ee-a37a-50bce5240d62
VERBOSE: Determining the SLA Domain id
VERBOSE: Validate the Rubrik token exists
VERBOSE: Found a Rubrik token for authentication
VERBOSE: Gather API Data for Get-RubrikSLA
VERBOSE: Selected 5.0 API Data for Get-RubrikSLA
VERBOSE: Load API data for Get-RubrikSLA
VERBOSE: Description: Retrieve summary information for all SLA Domains
VERBOSE: Build the URI
VERBOSE: URI = https://cluster-b-rr.rubrik.us/api/v2/sla_domain
VERBOSE: Build the query parameters for primary_cluster_id
VERBOSE: URI = https://cluster-b-rr.rubrik.us/api/v2/sla_domain?primary_cluster_id=40fdb2a5-3591-40ee-a37a-50bce5240d62
VERBOSE: Submitting the request
VERBOSE: GET https://cluster-b-rr.rubrik.us/api/v2/sla_domain?primary_cluster_id=40fdb2a5-3591-40ee-a37a-50bce5240d62 with 0-byte payload
VERBOSE: received 1035-byte response of content type application/json
VERBOSE: Received HTTP Status 200
VERBOSE: Formatting return value 
VERBOSE: Filter the results
VERBOSE: Filter match = Name
VERBOSE: Applying Rubrik.SLADomain TypeName to results
VERBOSE: Build the URI
VERBOSE: URI = https://cluster-b-rr.rubrik.us/api/v1/vmware/vm
VERBOSE: Build the query parameters for effective_sla_domain_id,name,is_relic,sla_assignment,primary_cluster_id
VERBOSE: URI = https://cluster-b-rr.rubrik.us/api/v1/vmware/vm?effective_sla_domain_id=0931056d-83c2-402e-8d67-0ade5f6a98c6&name=DC01&is_relic=False&primary_cluster_id=40fdb2a5-3591-40ee-a37a-50bce5240d62
VERBOSE: Submitting the request
VERBOSE: GET https://cluster-b-rr.rubrik.us/api/v1/vmware/vm?effective_sla_domain_id=0931056d-83c2-402e-8d67-0ade5f6a98c6&name=DC01&is_relic=False&primary_cluster_id=40fdb2a5-3591-40ee-a37a-50bce5240d62 with 0-byte payload
VERBOSE: received 2359-byte response of content type application/json
VERBOSE: Received HTTP Status 200
VERBOSE: Formatting return value 
VERBOSE: Filter the results      
VERBOSE: Filter match = SLA      
VERBOSE: Filter match = Name
VERBOSE: Applying Rubrik.VMwareVM TypeName to results

Name Operating System                       SLA Domain                RBS Status Id
---- ----------------                       ----------                ---------- --
DC01 Microsoft Windows Server 2016 (64-bit) Prod-12H-R31-A60_AWS_USW1            VirtualMachine:::2af8fe5f-5b64-44dd-a9e0-ec063753b823-vm-37
```


## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
