### PR TITLE
Updated link to relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2019-11-20
+
+### Changed [Made link to quick-start.md relative]
+
+* The link to `quick-start.md` in the readme.md has been updated to a relative link
+
 ## 2019-11-18
 
 ### Fixed [Issue with retrieving FileSet snapshots with Get-RubrikSnapshot]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Get-RubrikVersion
 
 Here are some resources to get you started! If you find any challenges from this project are not properly documented or are unclear, please [raise an issue](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/new/choose) and let us know! This is a fun, safe environment - don't worry if you're a GitHub newbie! :heart:
 
-* [Quick Start Guide](https://github.com/rubrikinc/rubrik-sdk-for-powershell/blob/master/docs/quick-start.md)
+* [Quick Start Guide](/docs/quick-start.md)
 * [Rubrik SDK for PowerShell Documentation](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/)
 * [Rubrik API Documentation](https://github.com/rubrikinc/api-documentation)
 


### PR DESCRIPTION
Updated documentation link to be relative, the quick start guide was the only link in readme.md that pointed to a specific branch, `master`. This has been corrected in this PR.

This PR resolves issue 519

Resolve #519 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
