### PR TITLE
Changed output of user agent string to match Rubrik SDK for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Get-RubrikVersion
 
 Here are some resources to get you started! If you find any challenges from this project are not properly documented or are unclear, please [raise an issue](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/new/choose) and let us know! This is a fun, safe environment - don't worry if you're a GitHub newbie! :heart:
 
-* [Quick Start Guide](https://github.com/rubrikinc/rubrik-sdk-for-powershell/blob/master/docs/quick-start.md)
+* [Quick Start Guide](/docs/quick-start.md)
 * [Rubrik SDK for PowerShell Documentation](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/)
 * [Rubrik API Documentation](https://github.com/rubrikinc/api-documentation)
 

--- a/Rubrik/Private/New-UserAgentString.ps1
+++ b/Rubrik/Private/New-UserAgentString.ps1
@@ -31,9 +31,9 @@ function New-UserAgentString {
         } else {
             $psversiontable.platform
             if($psversiontable.os.Length -gt 64) { 
-                    $psversiontable.os.Substring(0,64) 
+                [uri]::EscapeDataString($psversiontable.os.Substring(0,64))
             } else {
-                $psversiontable.os.Trim()
+                [uri]::EscapeDataString($psversiontable.os.Trim())
             }
         }
         

--- a/Rubrik/Private/New-UserAgentString.ps1
+++ b/Rubrik/Private/New-UserAgentString.ps1
@@ -35,9 +35,9 @@ function New-UserAgentString {
         } else {
             $psversiontable.platform
             if($psversiontable.os.Length -gt 64) { 
-                [uri]::EscapeDataString($psversiontable.os.Substring(0,64))
+                $psversiontable.os.Substring(0,64) -replace ':','.'
             } else {
-                [uri]::EscapeDataString($psversiontable.os.Trim())
+                $psversiontable.os.Trim() -replace ':','.'
             }
         }
         

--- a/Rubrik/Private/New-UserAgentString.ps1
+++ b/Rubrik/Private/New-UserAgentString.ps1
@@ -35,10 +35,16 @@ function New-UserAgentString {
             
         }
         
-        $PlatformDetails = [convert]::ToBase64String("{""platform"": ""$OS"": ""platform_version"": ""$OSVersion""}".ToCharArray())
+        $PlatformDetails = "platform--$OS--platform_version--$OSVersion"
         
         $ModuleVersion = try {
-            $MyInvocation.MyCommand.ScriptBlock.Module.Version.ToString()
+            if (-not [string]::IsNullOrWhiteSpace($MyInvocation.MyCommand.ScriptBlock.Module.PrivateData.PSData.Prerelease)) {
+                $MyInvocation.MyCommand.ScriptBlock.Module.Version.ToString(),
+                $MyInvocation.MyCommand.ScriptBlock.Module.PrivateData.PSData.Prerelease.ToString() -join '.'
+
+            } else {
+                $MyInvocation.MyCommand.ScriptBlock.Module.Version.ToString()
+            }
         } catch {
             
         }

--- a/Rubrik/Private/New-UserAgentString.ps1
+++ b/Rubrik/Private/New-UserAgentString.ps1
@@ -16,6 +16,9 @@ function New-UserAgentString {
 
         Will generate a new user agent string containing the module name, version and OS / platform information
     #>
+    param(
+        [hashtable] $UserAgentHash
+    )
 
     process {
         $OS, $OSVersion = if ($psversiontable.PSVersion.Major -lt 6) {
@@ -32,7 +35,6 @@ function New-UserAgentString {
             } else {
                 $psversiontable.os.Trim()
             }
-            
         }
         
         $PlatformDetails = "platform--$OS--platform_version--$OSVersion"
@@ -53,7 +55,17 @@ function New-UserAgentString {
             $ModuleVersion,
             $psversiontable.psversion.tostring(),
             $PlatformDetails
+
+        if ($UserAgentHash) {
+            $UserAgentHash.keys | ForEach-Object -Begin {
+                [string]$StringBuilder = ''
+            } -Process {
+                $StringBuilder += "--$_--$($UserAgentHash[$_])"
+            } -End {
+                $UserAgent += $StringBuilder
+            }
+        }
             
-        return ($UserAgent -replace '{|}|"')
+        return $UserAgent
     }
 }


### PR DESCRIPTION
# Description

Changes the output of the user agent string to display platform information with double-dashed separated key-value pairs.
Added parameter to Connect-Rubrik that allows specifying additional user-agent information.

## Related Issue

Resolve #517 

## Motivation and Context

Why is this change required? What problem does it solve?

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12744735/69454548-bd2eaf00-0d66-11ea-939d-ea4ffcbf038f.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
