### PR TITLE
Address issues 535, 536, and 537

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * **Fixed** for any bug fixes.
 * **Security** in case of vulnerabilities.
 
+## [Unreleased] - 2019-12-19
+
+### Changed
+* Get-RubrikSnapshot has been changed to convert the current date/time to UTC. This addresses Issue [535](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/535)
+* Restore-RubrikVApp and Export-RubrikVApp has been updated to properly deal with -PowerOn being changed to a switch-type parameter. This addresses issue [536](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/536)
+* Export-RubrikVApp has been changed so that it does not request vCD to restore vApp networks if the NICs are removed or unmapped. This addresses issue [537](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/537)
+
 ## [Unreleased] - 2019-12-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - 2019-12-19
 
 ### Changed
-* Get-RubrikSnapshot has been changed to convert the current date/time to UTC. This addresses Issue [535](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/535)
+* Get-RubrikSnapshot has been changed to convert the current date/time to UTC when using the -Latest parameter. This addresses Issue [535](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/535)
 * Restore-RubrikVApp and Export-RubrikVApp has been updated to properly deal with -PowerOn being changed to a switch-type parameter. This addresses issue [536](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/536)
 * Export-RubrikVApp has been changed so that it does not request vCD to restore vApp networks if the NICs are removed or unmapped. This addresses issue [537](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/537)
 

--- a/Rubrik/Public/Get-RubrikSnapshot.ps1
+++ b/Rubrik/Public/Get-RubrikSnapshot.ps1
@@ -128,7 +128,7 @@ function Get-RubrikSnapshot
         $result = Test-ReturnFilter -Object $datesearch -Location 'date' -result $result
       }
     } elseif ($Latest) {
-      $datesearch = Test-DateDifference -Date $($result.date) -Compare (Get-Date) -Range 999999999
+      $datesearch = Test-DateDifference -Date $($result.date) -Compare (Get-Date).ToUniversalTime() -Range 999999999
       # If $datesearch is $null, a matching date was not found, so return $null
       if($null -eq $datesearch) {
         $result = $null


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

* Get-RubrikSnapshot has been changed to convert the current date/time to UTC when using the -Latest parameter. This addresses Issue #535 
* Restore-RubrikVApp and Export-RubrikVApp has been updated to properly deal with -PowerOn being changed to a switch-type parameter. This addresses issue #536 
* Export-RubrikVApp has been changed so that it does not request vCD to restore vApp networks if the NICs are removed or unmapped. This addresses issue #537 

## Related Issue

Resolves #535 
Resolves #536 
Resolves #537 

## How Has This Been Tested?

Tested via manual tests and unit tests

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
