### PR TITLE
Issue 539 - Adding QUEUED to Get-RubrikEvent Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 * Added `Get-RubrikArchive`, `Get-RubrikBackupServiceDeployment`, `Get-RubrikGuestOsCredential`, `Get-RubrikIPMI`, `Get-RubrikNfsArchive`, `Get-RubrikNutanixCluster`, `Get-RubrikObjectStoreArchive`, `Get-RubrikQstarArchive`, `Get-RubrikReplicationSource`, `Get-RubrikReplicationTarget`, `Get-RubrikScvmm`, `Get-RubrikSecurityClassification`, `Get-RubrikSmbDomain`, `Get-RubrikSmbSecurity`, and `Get-RubrikSyslogServer` cmdlets to retrieve data from a Rubrik cluster for use in the As Built Report module.
+* Added QUEUED as a value in the status ValidateSet within Get-RubrikEvent and updated Unit Tests.  Addresses [Issue 539](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/539)
 
 ### Changed
 

--- a/Rubrik/Public/Get-RubrikEvent.ps1
+++ b/Rubrik/Public/Get-RubrikEvent.ps1
@@ -48,7 +48,7 @@ function Get-RubrikEvent
     [parameter()]
     [string]$EventSeriesId,
     # Filter by Status. Enter any of the following values: 'Failure', 'Warning', 'Running', 'Success', 'Canceled', 'Canceling’.
-    [ValidateSet('Failure', 'Warning', 'Running', 'Success', 'Canceled', 'Canceling', IgnoreCase = $false)]
+    [ValidateSet('Failure', 'Warning', 'Running', 'Success', 'Canceled', 'Canceling', 'Queued', IgnoreCase = $false)]
     [parameter()]
     [string]$Status,
     # Filter by Event Type.

--- a/Tests/Get-RubrikEvent.Tests.ps1
+++ b/Tests/Get-RubrikEvent.Tests.ps1
@@ -107,7 +107,10 @@ Describe -Name 'Public/Get-RubrikEvent' -Tag 'Public', 'Get-RubrikEvent' -Fixtur
             }
             (-join $Output) | Should -Not -BeLike '*filter_only_on_latest='
         }
-        
+        It -Name 'Verify Status ValidateSet' -Test {
+            { Get-RubrikEvent -Status 'NonExistant' } | 
+                Should -Throw "Cannot validate argument on parameter 'Status'."
+        }        
         Assert-VerifiableMock
         Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 8
         Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 8


### PR DESCRIPTION
# Description

Added QUEUED as a value in the status ValidateSet within Get-RubrikEvent and updated Unit Tests.  

## Related Issue

Addresses [Issue 539](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/539)

## Motivation and Context

Why is this change required? What problem does it solve?

Allows for filtering based on events which are QUEUED

## How Has This Been Tested?

Tested within the TM lab against Rubrik CDM 5.0

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
