### PR TITLE
Add null check to DetailedObject param on Get-RubrikSCVMM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 * ValidateSet on Set-RubrikNutanixVM was incorrect. Changed this to the desired values as outlined in [Issue 533](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/533)
+* Added null check to results when passing -DetailedObject to Get-RubrikSCVMM. Addresses [Issue 531](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/531)
 
 ### Fixed
 

--- a/Rubrik/Public/Get-RubrikScvmm.ps1
+++ b/Rubrik/Public/Get-RubrikScvmm.ps1
@@ -121,15 +121,16 @@ function Get-RubrikScvmm
     $result = Set-ObjectTypeName -TypeName $resources.ObjectTName -result $result
 
     # if detailed object is passed, loop through to get more information
-    if (($DetailedObject) -and (-not $PSBoundParameters.containskey('id'))) {
+
+    if (($DetailedObject) -and (-not $PSBoundParameters.containskey('id')) -and ($null -ne $result))  {
         for ($i = 0; $i -lt @($result).Count; $i++) {
           $Percentage = [int]($i/@($result).count*100)
           Write-Progress -Activity "DetailedObject queries in Progress, $($i+1) out of $(@($result).count)" -Status "$Percentage% Complete:" -PercentComplete $Percentage
           Get-RubrikScvmm -id $result[$i].id
         }
-      } else {
+    } else {
         return $result
-      }
+    }
 
   } # End of process
 } # End of function


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

Added null check to results when passing -DetailedObject to Get-RubrikSCVMM.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

Addresses [Issue 531](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/531)

## Motivation and Context

Why is this change required? What problem does it solve?

Module would throw error when no results were returned.

## How Has This Been Tested?

Tested in TM Lab

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
