### PR TITLE
Issue 358 - NAS Direct Archive support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Added QUEUED as a value in the status ValidateSet within Get-RubrikEvent and updated Unit Tests.  Addresses [Issue 539](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/539)
 * Added Get-RubrikVMwareDatacenter and Get-RubrikVMwareCluster along with associated Unit Tests. Addresses [Issue 463](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/463)
 * Added Object TypeNames for VCD Servers and vCD vApps as specified in [Issue 462](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/462)
+* Added DirectArchive switch parameter and associated code to New-RubrikFileSet allowing the isPassthrough attribute to be set to enable NAS Direct Archive. Addresses [Issue 358](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/358)  Updated Unit tests for cmdlets to reflect new parametersets.
 
 ### Changed
 

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -1673,7 +1673,7 @@ function Get-RubrikAPIData($endpoint) {
                     templateId = 'templateId'
                 }
                 Query       = ''
-                Result      = ''
+                Result      = 'data'
                 Filter      = ''
                 Success     = '202'
             }

--- a/Rubrik/Public/New-RubrikFileset.ps1
+++ b/Rubrik/Public/New-RubrikFileset.ps1
@@ -26,6 +26,11 @@ function New-RubrikFileset
       New-RubrikFileset -TemplateID (Get-RubrikFilesetTemplate -Name 'FOO').id -ShareID (Get-RubrikNASShare -name 'BAR').id
 
       Creates a new fileset for the BAR NAS, using the FOO template.
+
+      .EXAMPLE
+      New-RubrikFileset -TemplateID (Get-RubrikFilesetTemplate -Name 'FOO').id -ShareID (Get-RubrikNASShare -name 'BAR').id -DirectArchive
+
+      Creates a new fileset for the BAR NAS, using the FOO template. Enables the NAS Direct Archive functionality on the share.
   #>
 
   [CmdletBinding()]

--- a/Rubrik/Public/New-RubrikFileset.ps1
+++ b/Rubrik/Public/New-RubrikFileset.ps1
@@ -31,12 +31,16 @@ function New-RubrikFileset
   [CmdletBinding()]
   Param(
     #Fileset Template ID to use for the new fileset
-    [Parameter(Mandatory=$true)]
+    [Parameter(ParameterSetName='Host',Mandatory=$true)]
+    [Parameter(ParameterSetName='NAS',Mandatory=$true)]
     [String]$TemplateID,
     # HostID - Used for Windows or Linux Filesets
+    [Parameter(ParameterSetName='Host',Mandatory=$true)]
     [String]$HostID,
     # ShareID - used for NAS shares
+    [Parameter(ParameterSetName='NAS',Mandatory=$true)]
     [String]$ShareID, 
+    [Parameter(ParameterSetName='NAS')]
     # DirectArchive - used to specify if data should be directly sent to archive (bypassing Rubrik Cluster)
     [Alias('isPassThrough')]
     [Switch]$DirectArchive , 

--- a/Tests/New-RubrikFileset.Tests.ps1
+++ b/Tests/New-RubrikFileset.Tests.ps1
@@ -51,6 +51,10 @@ Describe -Name 'Public/New-RubrikFileset' -Tag 'Public', 'New-RubrikFileset' -Fi
         It -Name 'HostId missing' -Test {
             { New-RubrikFileset -TemplateID 'Foo' -HostId  } |
                 Should -Throw "Missing an argument for parameter 'HostId'."
-        }          
+        } 
+        It -Name 'Test ParameterSets' -Test {
+            { New-RubrikFileset -TemplateId 'Foo' -HostId 'bar1' -shareId 'bar2' } | 
+                Should -Throw "Parameter set cannot be resolved using the specified named parameters."
+        }         
     }
 }


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

Added DirectArchive switch parameter and associated code to New-RubrikFileSet allowing the isPassthrough attribute to be set to enable NAS Direct Archive.

## Related Issue

Addresses [Issue 358](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/358)

## Motivation and Context

Allows customers to configure NAS Direct Archive when setting up filesets.

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

Tested in the TM lab.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
