### PR TITLE
Issue 556 - Null filter on Get-RubrikSCVMM -DetailedObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 * Documentation links in comment-based help updated to lower case
+* Null filter on Get-RubrikSCVMM when using -DetailedObject as per [Issue 556](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/556)
 
 ## [5.0.0](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/5.0.0) - 2019-11-24
 

--- a/Rubrik/Public/Get-RubrikScvmm.ps1
+++ b/Rubrik/Public/Get-RubrikScvmm.ps1
@@ -122,7 +122,7 @@ function Get-RubrikScvmm
 
     # if detailed object is passed, loop through to get more information
 
-    if (($DetailedObject) -and (-not $PSBoundParameters.containskey('id')) -and ($null -ne $result))  {
+    if (($DetailedObject) -and (-not $PSBoundParameters.containskey('id')) -and ($result.total -ne 0) -and ($null -ne $result))  {
         for ($i = 0; $i -lt @($result).Count; $i++) {
           $Percentage = [int]($i/@($result).count*100)
           Write-Progress -Activity "DetailedObject queries in Progress, $($i+1) out of $(@($result).count)" -Status "$Percentage% Complete:" -PercentComplete $Percentage


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

fixes the zero results error when calling -DetailedObject on Get-RubrikSCVMM

## Related Issue

[Issue 556](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/556)

## Motivation and Context

Why is this change required? What problem does it solve?

Cmdlet won't fail when calling -DetailedObject with no results.

## How Has This Been Tested?

Tested in the TM lab

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
