### PR TITLE
Issue 554 - Invoke-RubrikRestCall and Single Item Array in body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Modified New-RubrikSLA in order to support creation of SLAs when used with the pipeline from Get-RubrikSLA as per [Issue 484](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/484)
 * Modified ParameterSets on Set-RubrikDatabase to align with logic outlined in [Issue 438](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/438)
 * Added more object support to `Get-RubrikObject` as per defined in [Issue 545](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/545) and [Issue 462](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/462)
+* Modified Invoke-RubrikRestCall to support the forcing of the body to be a single item array as per defined in [Issue 554](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/554)
 
 ### Fixed
 

--- a/Rubrik/Public/Invoke-RubrikRESTCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikRESTCall.ps1
@@ -26,7 +26,6 @@ function Invoke-RubrikRESTCall {
 
       .EXAMPLE
       Invoke-RubrikRESTCall -Endpoint 'vmware/vm' -Method GET -Query @{'name'='msf-sql2016'}
-
       Retrieve the raw output for the VMWare VM msf-sql2016 using a query parameter.
 
       .EXAMPLE
@@ -34,6 +33,12 @@ function Invoke-RubrikRESTCall {
       Invoke-RubrikRESTCall -Endpoint 'vmware/vm/VirtualMachine:::fbcb1f51-9520-4227-a68c-6fe145982f48-vm-649/snapshot' -Method POST -Body $body
 
       Execute an on-demand snapshot for the VMWare VM where the id is part of the endpoint.
+
+      .EXAMPLE
+      $body = New-Object -TypeName PSObject -Property @{'isPassthrough'=$true;'shareId'='HostShare:::11111';'templateId'='FilesetTemplate:::22222'}
+      Invoke-RubrikRESTCall -Endpoint 'fileset_template/bulk' -Method POST -Body $body -BodyAsArray
+
+      Creates a new fileset from the given fileset template and the given host id supporting Direct Archive.  Since fileset_template/bulk expects an array, we force the single item array with the BodyAsArray parameter.
   #>
 
   [cmdletbinding()]
@@ -54,6 +59,9 @@ function Invoke-RubrikRESTCall {
       [Parameter(Mandatory = $false,HelpMessage = 'REST Content')]
       [ValidateNotNullorEmpty()]
       [psobject]$Body,
+      #Force the body as an array (For endpoints requiring single item arrays)
+      [Parameter(Mandatory = $false, HelpMessage = 'Force Body to be an array')]
+      [Switch]$BodyAsArray,
       # Rubrik server IP or FQDN
       [String]$Server = $global:RubrikConnection.server,
       # API version
@@ -92,10 +100,15 @@ function Invoke-RubrikRESTCall {
 
         #If Method is not a GET call and a REST Body is passed, build the JSON body
         if($Method -ne 'GET' -and $body){
-            [string]$JsonBody = $Body | ConvertTo-Json -Depth 10
+            if ($BodyAsArray) {
+                [string]$JsonBody = ConvertTo-Json -inputobject @($Body) -Depth 10
+            }
+            else {
+                [string]$JsonBody = $Body | ConvertTo-Json -Depth 10
+            }
         }
         Write-Verbose "URI string: $uri"
-
+        Write-Verbose "Body string: $JsonBody"
         $result = Submit-Request -uri $uri -header $Header -method $Method -body $JsonBody
     }
     catch {


### PR DESCRIPTION
# Description

Modified Invoke-RubrikRestCall to allow end users to forcibly specify the body parameter should be treated as an array, even if just a single item.

## Related Issue

Addresses #554 

## Motivation and Context

Currently unless an array of hashtables was passed to the function, the body variable would convert to a simple string.  Some Rubrik endpoints require an array - This allows end-users to specify that they want to send a single item array to the endpoint.

## How Has This Been Tested?

Tested in the TM lab.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
