### PR TITLE
Issue 563 - Additional endpoint support for Get-RubrikRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Added Object TypeNames for VCD Servers and vCD vApps as specified in [Issue 462](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/462)
 * Added DirectArchive switch parameter and associated code to New-RubrikFileSet allowing the isPassthrough attribute to be set to enable NAS Direct Archive. Addresses [Issue 358](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/358)  Updated Unit tests for cmdlets to reflect new parametersets.
 * Added Get-RubrikHostVolume and Protect-RubrikHostVolumeGroup.  This addresses cmdlets requested within [Issue 512](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/512).
+* Added support to Get-RubrikRequest for VolumeGroup, Nutanix VMs, EC2 instances, Oracle Databases and VCD vApps as outlined in [Issue 563 ](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/563)
 
 
 ### Changed

--- a/Rubrik/Public/Get-RubrikRequest.ps1
+++ b/Rubrik/Public/Get-RubrikRequest.ps1
@@ -32,7 +32,7 @@ function Get-RubrikRequest {
     [String]$id,
     # The type of request
     [Parameter(Mandatory = $true)]
-    [ValidateSet('fileset', 'mssql', 'vmware/vm', 'hyperv/vm', 'managed_volume','volume_group')]
+    [ValidateSet('fileset', 'mssql', 'vmware/vm', 'hyperv/vm', 'managed_volume','volume_group','nutanix/vm','aws/ec2_instance','oracle','vcd/vapp')]
     [String]$Type,    
     # Wait for Request to Complete
     [Switch]$WaitForCompletion,
@@ -69,7 +69,7 @@ function Get-RubrikRequest {
     #region one-off
     $uri = $uri -replace '{type}', $Type
     #Place any internal API request calls into this collection, the replace will fix the URI
-    $internaltypes = @('managed_volume','volume_group')
+    $internaltypes = @('managed_volume','volume_group','nutanix/vm','aws/ec2_instance','oracle','vcd/vapp')
     if ($internaltypes -contains $Type) {
       $uri = $uri -replace 'v1', 'internal'
     }

--- a/Rubrik/Public/Get-RubrikRequest.ps1
+++ b/Rubrik/Public/Get-RubrikRequest.ps1
@@ -32,7 +32,7 @@ function Get-RubrikRequest {
     [String]$id,
     # The type of request
     [Parameter(Mandatory = $true)]
-    [ValidateSet('fileset', 'mssql', 'vmware/vm', 'hyperv/vm', 'managed_volume')]
+    [ValidateSet('fileset', 'mssql', 'vmware/vm', 'hyperv/vm', 'managed_volume','volume_group')]
     [String]$Type,    
     # Wait for Request to Complete
     [Switch]$WaitForCompletion,
@@ -69,7 +69,7 @@ function Get-RubrikRequest {
     #region one-off
     $uri = $uri -replace '{type}', $Type
     #Place any internal API request calls into this collection, the replace will fix the URI
-    $internaltypes = @('managed_volume')
+    $internaltypes = @('managed_volume','volume_group')
     if ($internaltypes -contains $Type) {
       $uri = $uri -replace 'v1', 'internal'
     }

--- a/Tests/Get-RubrikRequest.Tests.ps1
+++ b/Tests/Get-RubrikRequest.Tests.ps1
@@ -46,7 +46,7 @@ Describe -Name 'Public/Get-RubrikRequest' -Tag 'Public', 'Get-RubrikRequest' -Fi
         }      
         It -Name 'Type Validate Set' -Test {
             { Get-RubrikRequest -id '1111' -Type 'nonexistant' } |
-                Should -Throw "Cannot validate argument on parameter 'Type'. The argument `"nonexistant`" does not belong to the set `"fileset,mssql,vmware/vm,hyperv/vm,managed_volume`" specified by the ValidateSet attribute."
+                Should -Throw "Cannot validate argument on parameter 'Type'."
         }
     }
 }


### PR DESCRIPTION
# Description

Added additional endpoint support to Get-RubrikRequest for Nutanix VMs, Oracle Databases, Windows Volume Groups, VCD vApps and EC2 instances

## Related Issue

#563 

## Motivation and Context

Allows customers to query requests based off of those endpoints

## How Has This Been Tested?

Tested within the TM Lab

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
