### PR TITLE
Revert "Issue 562 - Test-ReturnFormat"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,14 +42,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Modified New-RubrikSLA in order to support creation of SLAs when used with the pipeline from Get-RubrikSLA as per [Issue 484](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/484)
 * Modified ParameterSets on Set-RubrikDatabase to align with logic outlined in [Issue 438](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/438)
 * Added more object support to `Get-RubrikObject` as per defined in [Issue 545](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/545) and [Issue 462](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/462)
-* Removed check for null on results.location within the Test-ReturnFormat private function as it was returning the default data/hasmore/total stanza and causing incorrect counts of returned objects as outlined in [Issue 562](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/562) Updated Unit tests to respect this change.
-* Fixed issue around Get-RubrikDatabase and parent 'data' encapsulation
 
 ### Fixed
 
 * Documentation links in comment-based help updated to lower case
 * Null filter on Get-RubrikSCVMM when using -DetailedObject as per [Issue 556](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/556)
-* Fixed example for Get-RubrikDatabaseMount as per [Issue 550](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/550)
 
 ## [5.0.0](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/5.0.0) - 2019-11-24
 

--- a/Rubrik/Private/Test-ReturnFormat.ps1
+++ b/Rubrik/Private/Test-ReturnFormat.ps1
@@ -17,7 +17,7 @@
   #>
 
   Write-Verbose -Message 'Formatting return value'
-  if ($location) {
+  if ($location -and ($null -ne ($result).$location)) {
     # The $location check assumes that not all endpoints will require findng (and removing) a parent key
     # If one does exist, this extracts the value so that the $result data is consistent across API versions
     return ($result).$location

--- a/Rubrik/Public/Get-RubrikDatabase.ps1
+++ b/Rubrik/Public/Get-RubrikDatabase.ps1
@@ -171,10 +171,7 @@ function Get-RubrikDatabase
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
     $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)    
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
-    if (-not $id) {
-      Write-Verbose "No id passed, running filter"
-      $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
-    }
+    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
     $result = Test-FilterObject -filter ($resources.Filter) -result $result
     $result = Set-ObjectTypeName -TypeName $resources.ObjectTName -result $result
     # If the Get-RubrikDatabase function has been called with the -DetailedObject parameter a separate API query will be performed if the initial query was not based on ID

--- a/Rubrik/Public/New-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/New-RubrikDatabaseMount.ps1
@@ -17,12 +17,10 @@ function New-RubrikDatabaseMount
       https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/new-rubrikdatabasemount
 
       .EXAMPLE
-      $db=Get-RubrikDatabase -HostName FOO -Instance MSSQLSERVER -Database BAR -DetailedObject
-
-      New-RubrikDatabaseMount -id $db.id -targetInstanceId $db.instanceId -mountedDatabaseName 'BAR-LM' -recoveryDateTime (Get-date $db.latestRecoveryPoint)
+      New-RubrikDatabaseMount -id $db.id -targetInstanceId $db.instanceId -mountedDatabaseName 'BAR-LM' -recoveryDateTime (Get-date (Get-RubrikDatabase -id $db.id).latestRecoveryPoint)
       Creates a new database mount named BAR on the same instance as the source database, using the most recent recovery time for the database. 
       
-      
+      $db=Get-RubrikDatabase -HostName FOO -Instance MSSQLSERVER -Database BAR
 
   #>
 

--- a/Tests/Export-RubrikReport.Tests.ps1
+++ b/Tests/Export-RubrikReport.Tests.ps1
@@ -23,11 +23,7 @@ Describe -Name 'Public/Export-RubrikReport' -Tag 'Public', 'Export-RubrikReport'
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             @{
-                'data' = @{
-                    'url' = 'https://192.168.150.121/report_dir/reportid.csv'
-                }
-                'hasmore' = 'false'
-                'total' = '1'
+                'url' = 'https://192.168.150.121/report_dir/reportid.csv'
             }
         }
 

--- a/Tests/Get-RubrikAPIToken.Tests.ps1
+++ b/Tests/Get-RubrikAPIToken.Tests.ps1
@@ -22,36 +22,30 @@ Describe -Name 'Public/Get-RubrikAPIToken' -Tag 'Public', 'Get-RubrikAPIToken' -
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'data' =          
-                    @{ 
-                        'id'                     = '11111'
-                        'userId'                 = '12345'
-                        'tag'                    = 'roxie'
-                        'organizationId'         = 'org1'
-                    },
-                    @{ 
-                        'id'                     = '22222'
-                        'userId'                 = '56789'
-                        'tag'                    = 'powershell'
-                        'organizationId'         = 'org1'
-                    },
-                    @{ 
-                        'id'                     = '33333'
-                        'userId'                 = '12345'
-                        'tag'                    = 'python'
-                        'organizationId'         = 'org1'
-                    },
-                    @{ 
-                        'id'                     = '44444'
-                        'userId'                 = '12345'
-                        'tag'                    = 'ruby'
-                        'organizationId'         = 'org2'
-                    }
-                    'hasmore' = 'false'
-                    'total'   = '4'
+            @{ 
+                'id'                     = '11111'
+                'userId'                 = '12345'
+                'tag'                    = 'roxie'
+                'organizationId'         = 'org1'
+            },
+            @{ 
+                'id'                     = '22222'
+                'userId'                 = '56789'
+                'tag'                    = 'powershell'
+                'organizationId'         = 'org1'
+            },
+            @{ 
+                'id'                     = '33333'
+                'userId'                 = '12345'
+                'tag'                    = 'python'
+                'organizationId'         = 'org1'
+            },
+            @{ 
+                'id'                     = '44444'
+                'userId'                 = '12345'
+                'tag'                    = 'ruby'
+                'organizationId'         = 'org2'
             }
-
         }
         It -Name 'Should Return count of 4' -Test {
             ( Get-RubrikAPIToken).Count |

--- a/Tests/Get-RubrikAPIVersion.Tests.ps1
+++ b/Tests/Get-RubrikAPIVersion.Tests.ps1
@@ -20,9 +20,7 @@ Describe -Name 'Public/Get-RubrikAPIVersion' -Tag 'Public', 'Get-RubrikAPIVersio
     #endregion
 
     Context -Name 'Results Filtering' {
-        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{ 'apiversion' = '1'}
-        }
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith { return 1}
         It -Name 'Should return 1' -Test {
             ( Get-RubrikAPIVersion -Server 'server') |
                 Should -BeExactly 1

--- a/Tests/Get-RubrikArchive.Tests.ps1
+++ b/Tests/Get-RubrikArchive.Tests.ps1
@@ -22,10 +22,7 @@ Describe -Name 'Public/Get-RubrikArchive' -Tag 'Public', 'Get-RubrikArchive' -Fi
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-        @{
-            'total' = '3'
-            'hasmore' = 'false'
-            'data' = @{ 
+            @{ 
                 'id'                = '3333-2222-3333'
                 'name'              = 'S302'
                 'rawName'           = 'S302'
@@ -34,8 +31,8 @@ Describe -Name 'Public/Get-RubrikArchive' -Tag 'Public', 'Get-RubrikArchive' -Fi
                 'ownershipStats'    = 'OwnerActive'
                 'currentState'      = 'TemporarilyDisconnected'
                 'locationType'      = 'S3'   
-                },
-                @{ 
+            },
+            @{ 
                 'id'                = '2222-2222-3333'
                 'name'              = 'S301'
                 'rawName'           = 'S301'
@@ -44,8 +41,8 @@ Describe -Name 'Public/Get-RubrikArchive' -Tag 'Public', 'Get-RubrikArchive' -Fi
                 'ownershipStats'    = 'OwnerActive'
                 'currentState'      = 'Connected'
                 'locationType'      = 'S3'   
-                },
-                @{ 
+            },
+            @{ 
                 'id'                = '1111-2222-3333'
                 'name'              = 'Azure01'
                 'rawName'           = 'Azure01'
@@ -54,7 +51,6 @@ Describe -Name 'Public/Get-RubrikArchive' -Tag 'Public', 'Get-RubrikArchive' -Fi
                 'ownershipStats'    = 'OwnerActive'
                 'currentState'      = 'Connected'
                 'locationType'      = 'Azure'   
-                }
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikAvailabilityGroup.Tests.ps1
+++ b/Tests/Get-RubrikAvailabilityGroup.Tests.ps1
@@ -22,25 +22,21 @@ Describe -Name 'Public/Get-RubrikAvailabilityGroup' -Tag 'Public', 'Get-RubrikAv
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total' = '2'
-                'hasMore' = 'false'
-                'data' = @{ 
-                    'name'                   = 'AG1'
-                    'id'                     = '11111:22222:33333'
-                    'copyOnly'               = 'true'
-                    'configuredSLADomainId'  = '111111'
-                    'configuredSLADomainName'= 'Gold'
-                    'logRetentionHours'      = '1'   
-                },
-                @{ 
-                    'name'                   = 'AG2'
-                    'id'                     = '11111:22222:44444'
-                    'copyOnly'               = 'true'
-                    'configuredSLADomainId'  = '111111'
-                    'configuredSLADomainName'= 'Gold'
-                    'logRetentionHours'      = '1'   
-                }
+            @{ 
+                'name'                   = 'AG1'
+                'id'                     = '11111:22222:33333'
+                'copyOnly'               = 'true'
+                'configuredSLADomainId'  = '111111'
+                'configuredSLADomainName'= 'Gold'
+                'logRetentionHours'      = '1'   
+            },
+            @{ 
+                'name'                   = 'AG2'
+                'id'                     = '11111:22222:44444'
+                'copyOnly'               = 'true'
+                'configuredSLADomainId'  = '111111'
+                'configuredSLADomainName'= 'Gold'
+                'logRetentionHours'      = '1'   
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikClusterNetworkInterface.Tests.ps1
+++ b/Tests/Get-RubrikClusterNetworkInterface.Tests.ps1
@@ -22,37 +22,33 @@ Describe -Name 'Public/Get-RubrikClusterNetworkInterface' -Tag 'Public', 'Get-Ru
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total' = '4'
-                'hasMore' = 'false'
-                'data' = @{ 
-                    'node'          = 'RVM11111'
-                    'interfaceType' = 'Management'
-                    'ipAddress'     = '10.10.10.101'
-                    'interfaceName' = 'bond0'
-                    'netmask'       = '255.255.255.0'   
-                },
-                @{ 
-                    'node'          = 'RVM22222'
-                    'interfaceType' = 'Management'
-                    'ipAddress'     = '10.10.10.102'
-                    'interfaceName' = 'bond0'
-                    'netmask'       = '255.255.255.0'   
-                },
-                @{ 
-                    'node'          = 'RVM33333'
-                    'interfaceType' = 'Management'
-                    'ipAddress'     = '10.10.10.103'
-                    'interfaceName' = 'bond0'
-                    'netmask'       = '255.255.255.0'   
-                },
-                @{ 
-                    'node'          = 'RVM44444'
-                    'interfaceType' = 'Management'
-                    'ipAddress'     = '10.10.10.104'
-                    'interfaceName' = 'bond0'
-                    'netmask'       = '255.255.255.0'   
-                }
+            @{ 
+                'node'          = 'RVM11111'
+                'interfaceType' = 'Management'
+                'ipAddress'     = '10.10.10.101'
+                'interfaceName' = 'bond0'
+                'netmask'       = '255.255.255.0'   
+            },
+            @{ 
+                'node'          = 'RVM22222'
+                'interfaceType' = 'Management'
+                'ipAddress'     = '10.10.10.102'
+                'interfaceName' = 'bond0'
+                'netmask'       = '255.255.255.0'   
+            },
+            @{ 
+                'node'          = 'RVM33333'
+                'interfaceType' = 'Management'
+                'ipAddress'     = '10.10.10.103'
+                'interfaceName' = 'bond0'
+                'netmask'       = '255.255.255.0'   
+            },
+            @{ 
+                'node'          = 'RVM44444'
+                'interfaceType' = 'Management'
+                'ipAddress'     = '10.10.10.104'
+                'interfaceName' = 'bond0'
+                'netmask'       = '255.255.255.0'   
             }
 
         }

--- a/Tests/Get-RubrikDatabase.Tests.ps1
+++ b/Tests/Get-RubrikDatabase.Tests.ps1
@@ -15,7 +15,7 @@ Describe -Name 'Public/Get-RubrikDatabase' -Tag 'Public', 'Get-RubrikDatabase' -
         header  = @{ 'Authorization' = 'Bearer test-authorization' }
         time    = (Get-Date)
         api     = 'v1'
-        version = '1.0'
+        version = '4.0.5'
     }
     #endregion
 
@@ -145,7 +145,9 @@ Describe -Name 'Public/Get-RubrikDatabase' -Tag 'Public', 'Get-RubrikDatabase' -
     Context -Name 'Single Result' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            $response = ' 
+            $response = '{  
+                "hasMore":false,
+                "data":[  
                     {
                         "effectiveSlaDomainId": "12345678-1234-abcd-8910-1234567890ab",
                         "primaryClusterId": "12345678-1234-abcd-8910-1234567890ab",
@@ -170,7 +172,10 @@ Describe -Name 'Public/Get-RubrikDatabase' -Tag 'Public', 'Get-RubrikDatabase' -
                         "isRelic": false,
                         "name": "ExampleDB1",
                         "logBackupFrequencyInSeconds": 300
-                    }'
+                    }
+                ],
+                "total":1
+            }'
             return ConvertFrom-Json $response
         }
         It -Name 'one result returned' -Test {

--- a/Tests/Get-RubrikEmailSetting.Tests.ps1
+++ b/Tests/Get-RubrikEmailSetting.Tests.ps1
@@ -22,18 +22,13 @@ Describe -Name 'Public/Get-RubrikEmailSetting' -Tag 'Public', 'Get-RubrikEmailSe
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '1'
-                'hasMore'   = 'false'
-                'data' =            
-                @{ 
-                    'fromEmailId'  = 'rubrikCluster@test.com'
-                    'smtpUsername' = 'emailuser'
-                    'smtpHostname' = 'smtp.test.com'
-                    'smtpPort'     = '25'
-                    'smtpSecurity' = 'NONE'
-                    'id'           = '1111-2222-33333'   
-                }
+            @{ 
+                'fromEmailId'  = 'rubrikCluster@test.com'
+                'smtpUsername' = 'emailuser'
+                'smtpHostname' = 'smtp.test.com'
+                'smtpPort'     = '25'
+                'smtpSecurity' = 'NONE'
+                'id'           = '1111-2222-33333'   
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikEvent.Tests.ps1
+++ b/Tests/Get-RubrikEvent.Tests.ps1
@@ -22,40 +22,35 @@ Describe -Name 'Public/Get-RubrikEvent' -Tag 'Public', 'Get-RubrikEvent' -Fixtur
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '5'
-                'hasMore'   = 'false'
-                'data' =  
-                    @{ 
-                        'name'                   = 'VirtualMachine01'
-                        'id'                     = 'VirtualMachine:::11111'
-                        'eventType'              = 'Replication'
-                        'time'                   = 'Mon Aug 10 07:12:14 UTC 2019'
-                    },
-                    @{ 
-                        'name'                   = 'VirtualMachine02'
-                        'id'                     = 'VirtualMachine:::22222'
-                        'eventType'              = 'Backup'
-                        'time'                   = 'Mon Aug 11 07:12:14 UTC 2019'
-                    },
-                    @{ 
-                        'name'                   = 'VirtualMachine03'
-                        'id'                     = 'VirtualMachine:::33333'
-                        'eventType'              = 'CloudNativeSource'
-                        'time'                   = 'Mon Aug 12 07:12:14 UTC 2019'
-                    },
-                    @{ 
-                        'name'                   = 'VirtualMachine04'
-                        'id'                     = 'VirtualMachine:::44444'
-                        'eventType'              = 'Replication'
-                        'time'                   = 'Mon Aug 13 07:12:14 UTC 2019'
-                    },
-                    @{ 
-                        'name'                   = 'VirtualMachine05'
-                        'id'                     = 'VirtualMachine:::55555'
-                        'eventType'              = 'Replication'
-                        'time'                   = 'Mon Aug 14 07:12:14 UTC 2019'
-                    }
+            @{ 
+                'name'                   = 'VirtualMachine01'
+                'id'                     = 'VirtualMachine:::11111'
+                'eventType'              = 'Replication'
+                'time'                   = 'Mon Aug 10 07:12:14 UTC 2019'
+            },
+            @{ 
+                'name'                   = 'VirtualMachine02'
+                'id'                     = 'VirtualMachine:::22222'
+                'eventType'              = 'Backup'
+                'time'                   = 'Mon Aug 11 07:12:14 UTC 2019'
+            },
+            @{ 
+                'name'                   = 'VirtualMachine03'
+                'id'                     = 'VirtualMachine:::33333'
+                'eventType'              = 'CloudNativeSource'
+                'time'                   = 'Mon Aug 12 07:12:14 UTC 2019'
+            },
+            @{ 
+                'name'                   = 'VirtualMachine04'
+                'id'                     = 'VirtualMachine:::44444'
+                'eventType'              = 'Replication'
+                'time'                   = 'Mon Aug 13 07:12:14 UTC 2019'
+            },
+            @{ 
+                'name'                   = 'VirtualMachine05'
+                'id'                     = 'VirtualMachine:::55555'
+                'eventType'              = 'Replication'
+                'time'                   = 'Mon Aug 14 07:12:14 UTC 2019'
             }
         }
         It -Name 'Should Return count of 5' -Test {

--- a/Tests/Get-RubrikFileset.Tests.ps1
+++ b/Tests/Get-RubrikFileset.Tests.ps1
@@ -25,37 +25,32 @@ Describe -Name 'Public/Get-RubrikFileset' -Tag 'Public', 'Get-RubrikFileset' -Fi
             @{ 'id' = 'sla_id' }
         }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '3'
-                'hasMore'   = 'false'
-                'data' =  
-                @{ 
-                    'name'                   = 'Fileset'
-                    'hostname'               = 'Server'
-                    'id'                     = 'Fileset:::111111-2222-3333-4444-555555555555'
-                    'isRelic'                = 'False'
-                    'effectiveSlaDomainName' = 'sla_name'
-                    'effectiveSlaDomainId'   = 'sla_id'
-                    'primaryClusterId'       = 'cluster_id1'   
-                },
-                @{ 
-                    'name'                   = 'Fileset2'
-                    'hostname'               = 'Server2'
-                    'id'                     = 'Fileset:::111111-2222-3333-4444-6666666666666'
-                    'isRelic'                = 'False'
-                    'effectiveSlaDomainName' = 'sla_name2'
-                    'effectiveSlaDomainId'   = 'sla_id2'
-                    'primaryClusterId'       = 'cluster_id2'   
-                },
-                @{ 
-                    'name'                   = 'Fileset20'
-                    'hostname'               = 'Server20'
-                    'id'                     = 'Fileset:::111111-2222-3333-4444-7777777777777'
-                    'isRelic'                = 'False'
-                    'effectiveSlaDomainName' = 'sla_name2'
-                    'effectiveSlaDomainId'   = 'sla_id2'
-                    'primaryClusterId'       = 'cluster_id2'   
-                }
+            @{ 
+                'name'                   = 'Fileset'
+                'hostname'               = 'Server'
+                'id'                     = 'Fileset:::111111-2222-3333-4444-555555555555'
+                'isRelic'                = 'False'
+                'effectiveSlaDomainName' = 'sla_name'
+                'effectiveSlaDomainId'   = 'sla_id'
+                'primaryClusterId'       = 'cluster_id1'   
+            },
+            @{ 
+                'name'                   = 'Fileset2'
+                'hostname'               = 'Server2'
+                'id'                     = 'Fileset:::111111-2222-3333-4444-6666666666666'
+                'isRelic'                = 'False'
+                'effectiveSlaDomainName' = 'sla_name2'
+                'effectiveSlaDomainId'   = 'sla_id2'
+                'primaryClusterId'       = 'cluster_id2'   
+            },
+            @{ 
+                'name'                   = 'Fileset20'
+                'hostname'               = 'Server20'
+                'id'                     = 'Fileset:::111111-2222-3333-4444-7777777777777'
+                'isRelic'                = 'False'
+                'effectiveSlaDomainName' = 'sla_name2'
+                'effectiveSlaDomainId'   = 'sla_id2'
+                'primaryClusterId'       = 'cluster_id2'   
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikFilesetTemplate.Tests.ps1
+++ b/Tests/Get-RubrikFilesetTemplate.Tests.ps1
@@ -22,26 +22,21 @@ Describe -Name 'Public/Get-RubrikFilesetTemplate' -Tag 'Public', 'Get-RubrikFile
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '2'
-                'hasMore'   = 'false'
-                'data' =  
-                @{ 
-                    'name'                   = 'C-Drive'
-                    'id'                     = 'FilesetTemplate:::111111-2222-3333-4444-555555555555'
-                    'includes'               = 'C:'
-                    'useWindowsVss'          = 'True'
-                    'excludes'               = ''
-                    'primaryClusterId'       = 'cluster_id1'   
-                },
-                @{ 
-                    'name'                   = 'D-Drive'
-                    'id'                     = 'FilesetTemplate:::111111-2222-3333-4444-6666666666666'
-                    'includes'               = 'D:'
-                    'useWindowsVss'          = 'True'
-                    'excludes'               = ''
-                    'primaryClusterId'       = 'cluster_id2'   
-                }
+            @{ 
+                'name'                   = 'C-Drive'
+                'id'                     = 'FilesetTemplate:::111111-2222-3333-4444-555555555555'
+                'includes'               = 'C:'
+                'useWindowsVss'          = 'True'
+                'excludes'               = ''
+                'primaryClusterId'       = 'cluster_id1'   
+            },
+            @{ 
+                'name'                   = 'D-Drive'
+                'id'                     = 'FilesetTemplate:::111111-2222-3333-4444-6666666666666'
+                'includes'               = 'D:'
+                'useWindowsVss'          = 'True'
+                'excludes'               = ''
+                'primaryClusterId'       = 'cluster_id2'   
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikGuestOsCredential.Tests.ps1
+++ b/Tests/Get-RubrikGuestOsCredential.Tests.ps1
@@ -22,29 +22,24 @@ Describe -Name 'Public/Get-RubrikGuestOSCredential' -Tag 'Public', 'Get-RubrikGu
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '4'
-                'hasMore'   = 'false'
-                'data' =  
-                @{ 
-                    'username'  = 'user1'
-                    'id'        = '11111-22222-33333-44444-55555'
-                    'domain'    = 'domain.local'
-                },
-                @{ 
-                    'username'  = 'user2'
-                    'id'        = '11111-22222-33333-11111-55555'
-                    'domain'    = 'domain.local'
-                },
-                @{ 
-                    'username'  = 'user3'
-                    'id'        = '11111-11111-33333-44444-55555'
-                    'domain'    = 'anotherdomain.local'
-                },
-                @{ 
-                    'username'  = 'root'
-                    'id'        = '11111-22222-11111-44444-55555'
-                }
+            @{ 
+                'username'  = 'user1'
+                'id'        = '11111-22222-33333-44444-55555'
+                'domain'    = 'domain.local'
+            },
+            @{ 
+                'username'  = 'user2'
+                'id'        = '11111-22222-33333-11111-55555'
+                'domain'    = 'domain.local'
+            },
+            @{ 
+                'username'  = 'user3'
+                'id'        = '11111-11111-33333-44444-55555'
+                'domain'    = 'anotherdomain.local'
+            },
+            @{ 
+                'username'  = 'root'
+                'id'        = '11111-22222-11111-44444-55555'
             }
         }
         It -Name 'Should Return count of 4' -Test {

--- a/Tests/Get-RubrikHost.Tests.ps1
+++ b/Tests/Get-RubrikHost.Tests.ps1
@@ -22,35 +22,30 @@ Describe -Name 'Public/Get-RubrikHost' -Tag 'Public', 'Get-RubrikHost' -Fixture 
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '5'
-                'hasMore'   = 'false'
-                'data' =  
-                @{ 
-                    'name'                   = 'host01'
-                    'id'                     = 'Host:::11111'
-                    'operatingSystemType'    = 'Windows'
-                },
-                @{ 
-                    'name'                   = 'host02'
-                    'id'                     = 'Host:::22222'
-                    'operatingSystemType'    = 'Windows'
-                },
-                @{ 
-                    'name'                   = 'host03'
-                    'id'                     = 'Host:::33333'
-                    'operatingSystemType'    = 'Linux'
-                },
-                @{ 
-                    'name'                   = 'host04'
-                    'id'                     = 'Host:::44444'
-                    'operating_system_type'  = 'Windows'
-                },
-                @{ 
-                    'name'                   = 'host05'
-                    'id'                     = 'Host:::55555'
-                    'operating_system_type'  = 'Linux'
-                }
+            @{ 
+                'name'                   = 'host01'
+                'id'                     = 'Host:::11111'
+                'operatingSystemType'    = 'Windows'
+            },
+            @{ 
+                'name'                   = 'host02'
+                'id'                     = 'Host:::22222'
+                'operatingSystemType'    = 'Windows'
+            },
+            @{ 
+                'name'                   = 'host03'
+                'id'                     = 'Host:::33333'
+                'operatingSystemType'    = 'Linux'
+            },
+            @{ 
+                'name'                   = 'host04'
+                'id'                     = 'Host:::44444'
+                'operating_system_type'  = 'Windows'
+            },
+            @{ 
+                'name'                   = 'host05'
+                'id'                     = 'Host:::55555'
+                'operating_system_type'  = 'Linux'
             }
         }
         It -Name 'Should Return count of 5' -Test {

--- a/Tests/Get-RubrikHostVolume.Tests.ps1
+++ b/Tests/Get-RubrikHostVolume.Tests.ps1
@@ -22,31 +22,26 @@ Describe -Name 'Public/Get-RubrikHostVolume' -Tag 'Public', 'Get-RubrikHostVolum
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '3'
-                'hasMore'   = 'false'
-                'data' =  
-                @{ 
-                    'size'                   = '31558552'
-                    'mountPoints'            = 'C:\'
-                    'fileSystemType'         = 'NTFS'
-                    'id'                     = '1111-2222-3333'
-                    'isCurrentlyPresentOnSystem' = 'true'
-                },
-                @{ 
-                    'size'                   = '1233131558552'
-                    'mountPoints'            = 'D:\'
-                    'fileSystemType'         = 'NTFS'
-                    'id'                     = '2222-3333-4444'
-                    'isCurrentlyPresentOnSystem' = 'true'
-                },
-                @{ 
-                    'size'                   = '14534531558552'
-                    'mountPoints'            = 'E:\'
-                    'fileSystemType'         = 'NTFS'
-                    'id'                     = '4444-5555-666'
-                    'isCurrentlyPresentOnSystem' = 'true'
-                }
+            @{ 
+                'size'                   = '31558552'
+                'mountPoints'            = 'C:\'
+                'fileSystemType'         = 'NTFS'
+                'id'                     = '1111-2222-3333'
+                'isCurrentlyPresentOnSystem' = 'true'
+            },
+            @{ 
+                'size'                   = '1233131558552'
+                'mountPoints'            = 'D:\'
+                'fileSystemType'         = 'NTFS'
+                'id'                     = '2222-3333-4444'
+                'isCurrentlyPresentOnSystem' = 'true'
+            },
+            @{ 
+                'size'                   = '14534531558552'
+                'mountPoints'            = 'E:\'
+                'fileSystemType'         = 'NTFS'
+                'id'                     = '4444-5555-666'
+                'isCurrentlyPresentOnSystem' = 'true'
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikHyperVHost.Tests.ps1
+++ b/Tests/Get-RubrikHyperVHost.Tests.ps1
@@ -22,25 +22,20 @@ Describe -Name 'Public/Get-RubrikHyperVHost' -Tag 'Public', 'Get-RubrikHyperVHos
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '3'
-                'hasMore'   = 'false'
-                'data' =  
-                @{ 
-                    'name'                   = 'hyperv52'
-                    'id'                     = 'HypervServer:::11111'
-                    'primaryClusterId'       = '1'
-                },
-                @{ 
-                    'name'                   = 'hyperv51'
-                    'id'                     = 'HypervServer:::22222'
-                    'primaryClusterId'       = '1'
-                },
-                @{ 
-                    'name'                   = 'hyperv53'
-                    'id'                     = 'HypervServer:::33333'
-                    'primaryClusterId'       = '2'
-                }
+            @{ 
+                'name'                   = 'hyperv52'
+                'id'                     = 'HypervServer:::11111'
+                'primaryClusterId'       = '1'
+            },
+            @{ 
+                'name'                   = 'hyperv51'
+                'id'                     = 'HypervServer:::22222'
+                'primaryClusterId'       = '1'
+            },
+            @{ 
+                'name'                   = 'hyperv53'
+                'id'                     = 'HypervServer:::33333'
+                'primaryClusterId'       = '2'
             }
         }
         It -Name 'Should Return hyperv52' -Test {

--- a/Tests/Get-RubrikHyperVMount.Tests.ps1
+++ b/Tests/Get-RubrikHyperVMount.Tests.ps1
@@ -22,34 +22,29 @@ Describe -Name 'Public/Get-RubrikHyperVMount' -Tag 'Public', 'Get-RubrikHyperVMo
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '4'
-                'hasMore'   = 'false'
-                'data' =  
-                @{ 
-                    'id'                    = '11-22-33'
-                    'vmId'                  = 'HypervVirtualMachine:::111'
-                    'isReady'               = 'True'
-                    'hostId'                = 'HypervServer:::111'
-                },
-                @{ 
-                    'id'                    = '11-22-44'
-                    'vmId'                  = 'HypervVirtualMachine:::111'
-                    'isReady'               = 'True'
-                    'hostId'                = 'HypervServer:::222'
-                },
-                @{ 
-                    'id'                    = '11-22-55'
-                    'vmId'                  = 'HypervVirtualMachine:::222'
-                    'isReady'               = 'True'
-                    'hostId'                = 'HypervServer:::111'
-                },
-                @{ 
-                    'id'                    = '11-22-66'
-                    'vmId'                  = 'HypervVirtualMachine:::333'
-                    'isReady'               = 'True'
-                    'hostId'                = 'HypervServer:::111'
-                }
+            @{ 
+                'id'                    = '11-22-33'
+                'vmId'                  = 'HypervVirtualMachine:::111'
+                'isReady'               = 'True'
+                'hostId'                = 'HypervServer:::111'
+            },
+            @{ 
+                'id'                    = '11-22-44'
+                'vmId'                  = 'HypervVirtualMachine:::111'
+                'isReady'               = 'True'
+                'hostId'                = 'HypervServer:::222'
+            },
+            @{ 
+                'id'                    = '11-22-55'
+                'vmId'                  = 'HypervVirtualMachine:::222'
+                'isReady'               = 'True'
+                'hostId'                = 'HypervServer:::111'
+            },
+            @{ 
+                'id'                    = '11-22-66'
+                'vmId'                  = 'HypervVirtualMachine:::333'
+                'isReady'               = 'True'
+                'hostId'                = 'HypervServer:::111'
             }
         }
         It -Name 'Filter should return count of 4' -Test {

--- a/Tests/Get-RubrikHyperVVM.Tests.ps1
+++ b/Tests/Get-RubrikHyperVVM.Tests.ps1
@@ -25,18 +25,13 @@ Describe -Name 'Public/Get-RubrikHyperVVM' -Tag 'Public', 'Get-RubrikHyperVVM' -
             @{ 'id' = 'test-sla_id' }
         }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '1'
-                'hasMore'   = 'false'
-                'data' =  
-                @{ 
-                    'name'                   = 'test-vm1'
-                    'effectiveSlaDomainName' = 'test-valid_sla_name'
-                },
-                @{ # The server-side filter should not return this record, but this record will validate the response filter logic
-                    'name'                   = 'test-vm2'
-                    'effectiveSlaDomainName' = 'test-invalid_sla_name'
-                }
+            @{ 
+                'name'                   = 'test-vm1'
+                'effectiveSlaDomainName' = 'test-valid_sla_name'
+            },
+            @{ # The server-side filter should not return this record, but this record will validate the response filter logic
+                'name'                   = 'test-vm2'
+                'effectiveSlaDomainName' = 'test-invalid_sla_name'
             }
         }
         It -Name 'should overwrite $SLAID' -Test {
@@ -52,14 +47,9 @@ Describe -Name 'Public/Get-RubrikHyperVVM' -Tag 'Public', 'Get-RubrikHyperVVM' -
     Context -Name 'Parameter/SLAID' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '1'
-                'data'      =
-                @{ 
-                    'name'                   = 'test-vm1'
-                    'effectiveSlaDomainName' = 'test-valid_sla_name'
-                }
+            @{ 
+                'name'                   = 'test-vm1'
+                'effectiveSlaDomainName' = 'test-valid_sla_name'
             }
         }
         It -Name 'should not overwrite $SLAID' -Test {

--- a/Tests/Get-RubrikLogShipping.Tests.ps1
+++ b/Tests/Get-RubrikLogShipping.Tests.ps1
@@ -22,22 +22,17 @@ Describe -Name 'Public/Get-RubrikLogShipping' -Tag 'Public', 'Get-RubrikLogShipp
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '2'
-                'hasMore'   = 'false'
-                'data' =  
-                @{ 
-                    'id'                    = '11111'
-                    'location'              = 'test-server01'
-                    'primaryDatabaseName'   = 'AdventureWorks'
-                    'secondaryDatabaseName' = 'AdventureWorks_Replica'
-                },
-                @{ 
-                    'id'                    = '22222'
-                    'location'              = 'test-server02'
-                    'primaryDatabaseName'   = 'AdventureWorks2012'
-                    'secondaryDatabaseName' = 'AdventureWorks2012_Replica'
-                }
+            @{ 
+                'id'                    = '11111'
+                'location'              = 'test-server01'
+                'primaryDatabaseName'   = 'AdventureWorks'
+                'secondaryDatabaseName' = 'AdventureWorks_Replica'
+            },
+            @{ 
+                'id'                    = '22222'
+                'location'              = 'test-server02'
+                'primaryDatabaseName'   = 'AdventureWorks2012'
+                'secondaryDatabaseName' = 'AdventureWorks2012_Replica'
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikManagedVolume.Tests.ps1
+++ b/Tests/Get-RubrikManagedVolume.Tests.ps1
@@ -26,42 +26,37 @@ Describe -Name 'Public/Get-RubrikManagedVolume' -Tag 'Public', 'Get-RubrikManage
         }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             @{
-                'total'     = '3'
-                'hasMore'   = 'false'
-                'data' =  
-                @{
-                    'id'                        = 'ManagedVolume:::11111'
-                    'isDeleted'                 = 'False'
-                    'primaryClusterId'          = 'local'
-                    'name'                      = 'OracleMV'
-                    'isRelic'                   = 'False'
-                    'effectiveSlaDomainId'      = '12345678-1234-abcd-8910-1234567890cab'
-                    'configuredSlaDomainId'     = '12345678-1234-abcd-8910-1234567890cab'
-                    'effectiveSlaDomainName'    = 'Gold'
-                    'configuredSlaDomainName'   = 'Gold'
-                },
-                @{
-                    'id'                        = 'ManagedVolume:::22222'
-                    'isDeleted'                 = 'False'
-                    'primaryClusterId'          = 'local'
-                    'name'                      = 'SQLMV'
-                    'isRelic'                   = 'False'
-                    'effectiveSlaDomainId'      = '12345678-1234-abcd-8910-1234567890abc'
-                    'configuredSlaDomainId'     = '12345678-1234-abcd-8910-1234567890abc'
-                    'effectiveSlaDomainName'    = 'Bronze'
-                    'configuredSlaDomainName'   = 'Bronze'
-                },
-                @{
-                    'id'                        = 'ManagedVolume:::33333'
-                    'isDeleted'                 = 'False'
-                    'primaryClusterId'          = 'local'
-                    'name'                      = 'LinMV'
-                    'isRelic'                   = 'True'
-                    'effectiveSlaDomainId'      = '12345678-1234-abcd-8910-1234567890bac'
-                    'configuredSlaDomainId'     = '12345678-1234-abcd-8910-1234567890bac'
-                    'effectiveSlaDomainName'    = 'Silver'
-                    'configuredSlaDomainName'   = 'Silver'
-                }
+                'id'                        = 'ManagedVolume:::11111'
+                'isDeleted'                 = 'False'
+                'primaryClusterId'          = 'local'
+                'name'                      = 'OracleMV'
+                'isRelic'                   = 'False'
+                'effectiveSlaDomainId'      = '12345678-1234-abcd-8910-1234567890cab'
+                'configuredSlaDomainId'     = '12345678-1234-abcd-8910-1234567890cab'
+                'effectiveSlaDomainName'    = 'Gold'
+                'configuredSlaDomainName'   = 'Gold'
+            },
+            @{
+                'id'                        = 'ManagedVolume:::22222'
+                'isDeleted'                 = 'False'
+                'primaryClusterId'          = 'local'
+                'name'                      = 'SQLMV'
+                'isRelic'                   = 'False'
+                'effectiveSlaDomainId'      = '12345678-1234-abcd-8910-1234567890abc'
+                'configuredSlaDomainId'     = '12345678-1234-abcd-8910-1234567890abc'
+                'effectiveSlaDomainName'    = 'Bronze'
+                'configuredSlaDomainName'   = 'Bronze'
+            },
+            @{
+                'id'                        = 'ManagedVolume:::33333'
+                'isDeleted'                 = 'False'
+                'primaryClusterId'          = 'local'
+                'name'                      = 'LinMV'
+                'isRelic'                   = 'True'
+                'effectiveSlaDomainId'      = '12345678-1234-abcd-8910-1234567890bac'
+                'configuredSlaDomainId'     = '12345678-1234-abcd-8910-1234567890bac'
+                'effectiveSlaDomainName'    = 'Silver'
+                'configuredSlaDomainName'   = 'Silver'
             }
         }
         

--- a/Tests/Get-RubrikManagedVolumeExport.Tests.ps1
+++ b/Tests/Get-RubrikManagedVolumeExport.Tests.ps1
@@ -24,30 +24,25 @@ Describe -Name 'Public/Get-RubrikManagedVolumeExport' -Tag 'Public', 'Get-Rubrik
 
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             @{
-                'total'     = '3'
-                'hasMore'   = 'false'
-                'data' =  
-                @{
-                    'id'                        = '11111-22222-33333'
-                    'isActive'                  = 'True'
-                    'primaryClusterId'          = 'local'
-                    'sourceManagedVolumeName'   = 'OracleMV1'
-                    'sourceManagedVolumeID'     = 'ManagedVolume:::11111'
-                },
-                @{
-                    'id'                        = '22222-22222-33333'
-                    'isActive'                  = 'True'
-                    'primaryClusterId'          = 'local'
-                    'sourceManagedVolumeName'   = 'OracleMV2'
-                    'sourceManagedVolumeID'     = 'ManagedVolume:::11111'
-                },
-                @{
-                    'id'                        = '33333-22222-33333'
-                    'isActive'                  = 'True'
-                    'primaryClusterId'          = 'local'
-                    'sourceManagedVolumeName'   = 'SQLMV'
-                    'sourceManagedVolumeID'     = 'ManagedVolume:::22222'
-                }
+                'id'                        = '11111-22222-33333'
+                'isActive'                  = 'True'
+                'primaryClusterId'          = 'local'
+                'sourceManagedVolumeName'   = 'OracleMV1'
+                'sourceManagedVolumeID'     = 'ManagedVolume:::11111'
+            },
+            @{
+                'id'                        = '22222-22222-33333'
+                'isActive'                  = 'True'
+                'primaryClusterId'          = 'local'
+                'sourceManagedVolumeName'   = 'OracleMV2'
+                'sourceManagedVolumeID'     = 'ManagedVolume:::11111'
+            },
+            @{
+                'id'                        = '33333-22222-33333'
+                'isActive'                  = 'True'
+                'primaryClusterId'          = 'local'
+                'sourceManagedVolumeName'   = 'SQLMV'
+                'sourceManagedVolumeID'     = 'ManagedVolume:::22222'
             }
         }
         

--- a/Tests/Get-RubrikMount.Tests.ps1
+++ b/Tests/Get-RubrikMount.Tests.ps1
@@ -22,34 +22,29 @@ Describe -Name 'Public/Get-RubrikMount' -Tag 'Public', 'Get-RubrikMount' -Fixtur
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'total'     = '4'
-                'hasMore'   = 'false'
-                'data' =  
-                @{ 
-                    'id'                    = '11-22-33'
-                    'vmId'                  = 'VirtualMachine:::111'
-                    'isReady'               = 'True'
-                    'hostId'                = 'Host:::111'
-                },
-                @{ 
-                    'id'                    = '11-22-44'
-                    'vmId'                  = 'VirtualMachine:::111'
-                    'isReady'               = 'True'
-                    'hostId'                = 'Host:::222'
-                },
-                @{ 
-                    'id'                    = '11-22-55'
-                    'vmId'                  = 'VirtualMachine:::222'
-                    'isReady'               = 'True'
-                    'hostId'                = 'Host:::111'
-                },
-                @{ 
-                    'id'                    = '11-22-66'
-                    'vmId'                  = 'VirtualMachine:::333'
-                    'isReady'               = 'True'
-                    'hostId'                = 'Host:::111'
-                }
+            @{ 
+                'id'                    = '11-22-33'
+                'vmId'                  = 'VirtualMachine:::111'
+                'isReady'               = 'True'
+                'hostId'                = 'Host:::111'
+            },
+            @{ 
+                'id'                    = '11-22-44'
+                'vmId'                  = 'VirtualMachine:::111'
+                'isReady'               = 'True'
+                'hostId'                = 'Host:::222'
+            },
+            @{ 
+                'id'                    = '11-22-55'
+                'vmId'                  = 'VirtualMachine:::222'
+                'isReady'               = 'True'
+                'hostId'                = 'Host:::111'
+            },
+            @{ 
+                'id'                    = '11-22-66'
+                'vmId'                  = 'VirtualMachine:::333'
+                'isReady'               = 'True'
+                'hostId'                = 'Host:::111'
             }
         }
         It -Name 'Filter should return count of 4' -Test {

--- a/Tests/Get-RubrikNTPServer.Tests.ps1
+++ b/Tests/Get-RubrikNTPServer.Tests.ps1
@@ -22,13 +22,8 @@ Describe -Name 'Public/Get-RubrikNTPServer' -Tag 'Public', 'Get-RubrikNTPServer'
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '1'
-                'data'      =
-                @{ 
-                    'server' = 'ntp.server.com' 
-                }
+            @{ 
+                'server' = 'ntp.server.com' 
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikNetworkThrottle.Tests.ps1
+++ b/Tests/Get-RubrikNetworkThrottle.Tests.ps1
@@ -22,22 +22,17 @@ Describe -Name 'Public/Get-RubrikNetworkThrottle' -Tag 'Public', 'Get-RubrikNetw
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '2'
-                'data'      =
-                @{ 
-                    'resourceId'           = 'ArchivalEgress'
-                    'isEnabled'            = 'True'
-                    'defaultThrottleLimit' = '9223372036854'
-                    'scheduledThrottles'   = ''
-                },
-                @{ 
-                    'resourceId'           = 'ReplicationEgress'
-                    'isEnabled'            = 'False'
-                    'defaultThrottleLimit' = '9223372036854'
-                    'scheduledThrottles'   = ''
-                }
+            @{ 
+                'resourceId'           = 'ArchivalEgress'
+                'isEnabled'            = 'True'
+                'defaultThrottleLimit' = '9223372036854'
+                'scheduledThrottles'   = ''
+            },
+            @{ 
+                'resourceId'           = 'ReplicationEgress'
+                'isEnabled'            = 'False'
+                'defaultThrottleLimit' = '9223372036854'
+                'scheduledThrottles'   = ''
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikNode.Tests.ps1
+++ b/Tests/Get-RubrikNode.Tests.ps1
@@ -22,34 +22,29 @@ Describe -Name 'Public/Get-RubrikNode' -Tag 'Public', 'Get-RubrikNode' -Fixture 
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '4'
-                'data'      =
-                @{ 
-                    'brikId'    = 'ABC123'
-                    'id'        = 'RVM111'
-                    'ipAddress' = '10.0.0.101'
-                    'status'    = 'OK'
-                },
-                @{ 
-                    'brikId'    = 'ABC123'
-                    'id'        = 'RVM222'
-                    'ipAddress' = '10.0.0.102'
-                    'status'    = 'OK'
-                },
-                @{ 
-                    'brikId'    = 'ABC123'
-                    'id'        = 'RVM333'
-                    'ipAddress' = '10.0.0.103'
-                    'status'    = 'OK'
-                },
-                @{ 
-                    'brikId'    = 'ABC123'
-                    'id'        = 'RVM444'
-                    'ipAddress' = '10.0.0.104'
-                    'status'    = 'OK'
-                }
+            @{ 
+                'brikId'    = 'ABC123'
+                'id'        = 'RVM111'
+                'ipAddress' = '10.0.0.101'
+                'status'    = 'OK'
+            },
+            @{ 
+                'brikId'    = 'ABC123'
+                'id'        = 'RVM222'
+                'ipAddress' = '10.0.0.102'
+                'status'    = 'OK'
+            },
+            @{ 
+                'brikId'    = 'ABC123'
+                'id'        = 'RVM333'
+                'ipAddress' = '10.0.0.103'
+                'status'    = 'OK'
+            },
+            @{ 
+                'brikId'    = 'ABC123'
+                'id'        = 'RVM444'
+                'ipAddress' = '10.0.0.104'
+                'status'    = 'OK'
             }
         }
         It -Name 'Should Return count of 4' -Test {

--- a/Tests/Get-RubrikNotificationSetting.Tests.ps1
+++ b/Tests/Get-RubrikNotificationSetting.Tests.ps1
@@ -22,24 +22,19 @@ Describe -Name 'Public/Get-RubrikNotificationSetting' -Tag 'Public', 'Get-Rubrik
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '2'
-                'data'      =
-                @{ 
-                    'id'                 = '1111-2222'
-                    'eventTypes'         = '{Archive,AuthDomain}'
-                    'snmpAddresses'      = ''
-                    'shouldSendToSyslog' = 'False'
-                    'emailAddresses'     = 'testuser@test.com'   
-                },
-                @{ 
-                    'id'                 = '1111-3333'
-                    'eventTypes'         = '{Archive}'
-                    'snmpAddresses'      = ''
-                    'shouldSendToSyslog' = 'False'
-                    'emailAddresses'     = 'testuser2@test.com'   
-                }
+            @{ 
+                'id'                 = '1111-2222'
+                'eventTypes'         = '{Archive,AuthDomain}'
+                'snmpAddresses'      = ''
+                'shouldSendToSyslog' = 'False'
+                'emailAddresses'     = 'testuser@test.com'   
+            },
+            @{ 
+                'id'                 = '1111-3333'
+                'eventTypes'         = '{Archive}'
+                'snmpAddresses'      = ''
+                'shouldSendToSyslog' = 'False'
+                'emailAddresses'     = 'testuser2@test.com'   
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikNutanixCluster.Tests.ps1
+++ b/Tests/Get-RubrikNutanixCluster.Tests.ps1
@@ -22,24 +22,19 @@ Describe -Name 'Public/Get-RubrikNutanixCluster' -Tag 'Public', 'Get-RubrikNutan
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '2'
-                'data'      =
-                @{ 
-                    'name'                  = 'nutanix_cluster_1'
-                    'primary_cluster_id'    = '11111-22222-33333'
-                    'hostname'              = 'cluster1.domain.local'
-                    'username'              = 'administrator'
-                    'id'                    = 'NutanixCluster:::11111-222222'
-                },
-                @{ 
-                    'name'                  = 'nutanix_cluster_2'
-                    'primary_cluster_id'    = '11111-22222-33333'
-                    'hostname'              = 'cluster2.domain.local'
-                    'username'              = 'administrator'
-                    'id'                    = 'NutanixCluster:::11111-333333'
-                }
+            @{ 
+                'name'                  = 'nutanix_cluster_1'
+                'primary_cluster_id'    = '11111-22222-33333'
+                'hostname'              = 'cluster1.domain.local'
+                'username'              = 'administrator'
+                'id'                    = 'NutanixCluster:::11111-222222'
+            },
+            @{ 
+                'name'                  = 'nutanix_cluster_2'
+                'primary_cluster_id'    = '11111-22222-33333'
+                'hostname'              = 'cluster2.domain.local'
+                'username'              = 'administrator'
+                'id'                    = 'NutanixCluster:::11111-333333'
             }
         }
 

--- a/Tests/Get-RubrikNutanixVM.Tests.ps1
+++ b/Tests/Get-RubrikNutanixVM.Tests.ps1
@@ -25,18 +25,13 @@ Describe -Name 'Public/Get-RubrikNutanixVM' -Tag 'Public', 'Get-RubrikNutanixVM'
             @{ 'id' = 'test-sla_id' }
         }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '1'
-                'data'      =
-                @{ 
-                    'name'                   = 'test-vm1'
-                    'effectiveSlaDomainName' = 'test-valid_sla_name'
-                },
-                @{ # The server-side filter should not return this record, but this record will validate the response filter logic
-                    'name'                   = 'test-vm2'
-                    'effectiveSlaDomainName' = 'test-invalid_sla_name'
-                }
+            @{ 
+                'name'                   = 'test-vm1'
+                'effectiveSlaDomainName' = 'test-valid_sla_name'
+            },
+            @{ # The server-side filter should not return this record, but this record will validate the response filter logic
+                'name'                   = 'test-vm2'
+                'effectiveSlaDomainName' = 'test-invalid_sla_name'
             }
         }
         It -Name 'should overwrite $SLAID' -Test {
@@ -52,14 +47,9 @@ Describe -Name 'Public/Get-RubrikNutanixVM' -Tag 'Public', 'Get-RubrikNutanixVM'
     Context -Name 'Parameter/SLAID' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '1'
-                'data'      =
-                @{ 
-                    'name'                   = 'test-vm1'
-                    'effectiveSlaDomainName' = 'test-valid_sla_name'
-                }
+            @{ 
+                'name'                   = 'test-vm1'
+                'effectiveSlaDomainName' = 'test-valid_sla_name'
             }
         }
         It -Name 'should not overwrite $SLAID' -Test {

--- a/Tests/Get-RubrikOracleDB.Tests.ps1
+++ b/Tests/Get-RubrikOracleDB.Tests.ps1
@@ -25,18 +25,13 @@ Describe -Name 'Public/Get-RubrikOracleDB' -Tag 'Public', 'Get-RubrikOracleDB' -
             @{ 'id' = 'test-sla_id' }
         }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '1'
-                'data'      =
-                @{ 
-                    'name'                   = 'test-oracledb1'
-                    'effectiveSlaDomainName' = 'test-valid_sla_name'
-                },
-                @{ # The server-side filter should not return this record, but this record will validate the response filter logic
-                    'name'                   = 'test-oracledb2'
-                    'effectiveSlaDomainName' = 'test-invalid_sla_name'
-                }
+            @{ 
+                'name'                   = 'test-oracledb1'
+                'effectiveSlaDomainName' = 'test-valid_sla_name'
+            },
+            @{ # The server-side filter should not return this record, but this record will validate the response filter logic
+                'name'                   = 'test-oracledb2'
+                'effectiveSlaDomainName' = 'test-invalid_sla_name'
             }
         }
         It -Name 'should overwrite $SLAID' -Test {
@@ -52,14 +47,9 @@ Describe -Name 'Public/Get-RubrikOracleDB' -Tag 'Public', 'Get-RubrikOracleDB' -
     Context -Name 'Parameter/SLAID' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '1'
-                'data'      =
-                @{ 
-                    'name'                   = 'test-oracledb1'
-                    'effectiveSlaDomainName' = 'test-valid_sla_name'
-                }
+            @{ 
+                'name'                   = 'test-oracledb1'
+                'effectiveSlaDomainName' = 'test-valid_sla_name'
             }
         }
         It -Name 'SLAID Query should return OracleDB1 DB' -Test {

--- a/Tests/Get-RubrikOrganization.Tests.ps1
+++ b/Tests/Get-RubrikOrganization.Tests.ps1
@@ -22,35 +22,30 @@ Describe -Name 'Public/Get-RubrikOrganization' -Tag 'Public', 'Get-RubrikOrganiz
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '5'
-                'data'      =
-                @{ 
-                    'id'                     = 'Organization:1'
-                    'name'                   = 'org1'
-                    'isGlobal'               = 'False'
-                },
-                @{ 
-                    'id'                     = 'Organization:2'
-                    'name'                   = 'org2'
-                    'isGlobal'               = 'False'
-                },
-                @{ 
-                    'id'                     = 'Organization:3'
-                    'name'                   = 'org3'
-                    'isGlobal'               = 'False'
-                },
-                @{ 
-                    'id'                     = 'Organization:4'
-                    'name'                   = 'org4'
-                    'isGlobal'               = 'True'
-                },
-                @{ 
-                    'id'                     = 'Organization:5'
-                    'name'                   = 'org5'
-                    'isGlobal'               = 'False'
-                }
+            @{ 
+                'id'                     = 'Organization:1'
+                'name'                   = 'org1'
+                'isGlobal'               = 'False'
+            },
+            @{ 
+                'id'                     = 'Organization:2'
+                'name'                   = 'org2'
+                'isGlobal'               = 'False'
+            },
+            @{ 
+                'id'                     = 'Organization:3'
+                'name'                   = 'org3'
+                'isGlobal'               = 'False'
+            },
+            @{ 
+                'id'                     = 'Organization:4'
+                'name'                   = 'org4'
+                'isGlobal'               = 'True'
+            },
+            @{ 
+                'id'                     = 'Organization:5'
+                'name'                   = 'org5'
+                'isGlobal'               = 'False'
             }
         }
         It -Name 'Should Return count of 5' -Test {

--- a/Tests/Get-RubrikReplicationSource.Tests.ps1
+++ b/Tests/Get-RubrikReplicationSource.Tests.ps1
@@ -22,31 +22,26 @@ Describe -Name 'Public/Get-RubrikReplicationSource' -Tag 'Public', 'Get-RubrikRe
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '3'
-                'data'      =
-                @{ 
-                    'id'                        = 'DataLocation:::11111-22222-33333'
-                    'replicationSetup'          = 'Private Network'
-                    'sourceClusterAddress'      = '10.10.10.150'
-                    'sourceClusterName'         = 'Cluster_1'
-                    'sourceClusterUuid'         = '11111-22222-33333'
-                },
-                @{ 
-                    'id'                        = 'DataLocation:::22222-22222-33333'
-                    'replicationSetup'          = 'Private Network'
-                    'sourceClusterAddress'      = '10.10.15.150'
-                    'sourceClusterName'         = 'Cluster_2'
-                    'sourceClusterUuid'         = '22222-22222-33333'
-                },
-                @{ 
-                    'id'                        = 'DataLocation:::33333-22222-33333'
-                    'replicationSetup'          = 'Private Network'
-                    'sourceClusterAddress'      = '10.10.30.150'
-                    'sourceClusterName'         = 'Cluster_3'
-                    'sourceClusterUuid'         = '33333-22222-33333'
-                }
+            @{ 
+                'id'                        = 'DataLocation:::11111-22222-33333'
+                'replicationSetup'          = 'Private Network'
+                'sourceClusterAddress'      = '10.10.10.150'
+                'sourceClusterName'         = 'Cluster_1'
+                'sourceClusterUuid'         = '11111-22222-33333'
+            },
+            @{ 
+                'id'                        = 'DataLocation:::22222-22222-33333'
+                'replicationSetup'          = 'Private Network'
+                'sourceClusterAddress'      = '10.10.15.150'
+                'sourceClusterName'         = 'Cluster_2'
+                'sourceClusterUuid'         = '22222-22222-33333'
+            },
+            @{ 
+                'id'                        = 'DataLocation:::33333-22222-33333'
+                'replicationSetup'          = 'Private Network'
+                'sourceClusterAddress'      = '10.10.30.150'
+                'sourceClusterName'         = 'Cluster_3'
+                'sourceClusterUuid'         = '33333-22222-33333'
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikReplicationTarget.Tests.ps1
+++ b/Tests/Get-RubrikReplicationTarget.Tests.ps1
@@ -22,31 +22,26 @@ Describe -Name 'Public/Get-RubrikReplicationTarget' -Tag 'Public', 'Get-RubrikRe
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '3'
-                'data'      =
-                @{ 
-                    'id'                        = 'DataLocation:::11111-22222-33333'
-                    'replicationSetup'          = 'Private Network'
-                    'targetClusterAddress'      = '10.10.10.150'
-                    'targetClusterName'         = 'Cluster_1'
-                    'targetClusterUuid'         = '11111-22222-33333'
-                },
-                @{ 
-                    'id'                        = 'DataLocation:::22222-22222-33333'
-                    'replicationSetup'          = 'Private Network'
-                    'targetClusterAddress'      = '10.10.15.150'
-                    'targetClusterName'         = 'Cluster_2'
-                    'targetClusterUuid'         = '22222-22222-33333'
-                },
-                @{ 
-                    'id'                        = 'DataLocation:::33333-22222-33333'
-                    'replicationSetup'          = 'Private Network'
-                    'targetClusterAddress'      = '10.10.30.150'
-                    'targetClusterName'         = 'Cluster_3'
-                    'targetClusterUuid'         = '33333-22222-33333'
-                }
+            @{ 
+                'id'                        = 'DataLocation:::11111-22222-33333'
+                'replicationSetup'          = 'Private Network'
+                'targetClusterAddress'      = '10.10.10.150'
+                'targetClusterName'         = 'Cluster_1'
+                'targetClusterUuid'         = '11111-22222-33333'
+            },
+            @{ 
+                'id'                        = 'DataLocation:::22222-22222-33333'
+                'replicationSetup'          = 'Private Network'
+                'targetClusterAddress'      = '10.10.15.150'
+                'targetClusterName'         = 'Cluster_2'
+                'targetClusterUuid'         = '22222-22222-33333'
+            },
+            @{ 
+                'id'                        = 'DataLocation:::33333-22222-33333'
+                'replicationSetup'          = 'Private Network'
+                'targetClusterAddress'      = '10.10.30.150'
+                'targetClusterName'         = 'Cluster_3'
+                'targetClusterUuid'         = '33333-22222-33333'
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikReport.Tests.ps1
+++ b/Tests/Get-RubrikReport.Tests.ps1
@@ -22,22 +22,17 @@ Describe -Name 'Public/Get-RubrikReport' -Tag 'Public', 'Get-RubrikReport' -Fixt
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '2'
-                'data'      =
-                @{ 
-                    'name'                   = 'TestReport1'
-                    'updateStatus'           = 'Ready'
-                    'reportType'             = 'Custom'
-                    'id'                     = 'CustomReport:::11111'
-                },
-                @{ 
-                    'name'                   = 'TestReport2'
-                    'updateStatus'           = 'Ready'
-                    'reportType'             = 'Canned'
-                    'id'                     = 'CustomReport:::22222'
-                }
+            @{ 
+                'name'                   = 'TestReport1'
+                'updateStatus'           = 'Ready'
+                'reportType'             = 'Custom'
+                'id'                     = 'CustomReport:::11111'
+            },
+            @{ 
+                'name'                   = 'TestReport2'
+                'updateStatus'           = 'Ready'
+                'reportType'             = 'Canned'
+                'id'                     = 'CustomReport:::22222'
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikScvmm.Tests.ps1
+++ b/Tests/Get-RubrikScvmm.Tests.ps1
@@ -22,37 +22,32 @@ Describe -Name 'Public/Get-RubrikScvmm' -Tag 'Public', 'Get-RubrikScvmm' -Fixtur
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '3'
-                'data'      =
-                @{ 
-                    'name'                      = 'scvmm.domain.local'
-                    'primaryClusterId'          = '1111-2222-3333'
-                    'shouldDeployAgent'         = 'True'
-                    'runAsAccount'              = 'administrator@domain.local'
-                    'configuredSLADomainName'   = 'INHERIT'
-                    'id'                        = 'HypervScvmm:::1111-2222-3333'
-                    'status'                    = 'Connected'
-                },
-                @{ 
-                    'name'                      = 'scvmm02.domain.local'
-                    'primaryClusterId'          = '1111-2222-3333'
-                    'shouldDeployAgent'         = 'True'
-                    'runAsAccount'              = 'administrator@domain.local'
-                    'configuredSLADomainName'   = 'GOLD'
-                    'id'                        = 'HypervScvmm:::2222-2222-3333'
-                    'status'                    = 'Connected'
-                },
-                @{ 
-                    'name'                      = 'scvmm03.domain.local'
-                    'primaryClusterId'          = '2222-2222-3333'
-                    'shouldDeployAgent'         = 'True'
-                    'runAsAccount'              = 'administrator@domain.local'
-                    'configuredSLADomainName'   = 'INHERIT'
-                    'id'                        = 'HypervScvmm:::3333-2222-3333'
-                    'status'                    = 'Connected'
-                }
+            @{ 
+                'name'                      = 'scvmm.domain.local'
+                'primaryClusterId'          = '1111-2222-3333'
+                'shouldDeployAgent'         = 'True'
+                'runAsAccount'              = 'administrator@domain.local'
+                'configuredSLADomainName'   = 'INHERIT'
+                'id'                        = 'HypervScvmm:::1111-2222-3333'
+                'status'                    = 'Connected'
+            },
+            @{ 
+                'name'                      = 'scvmm02.domain.local'
+                'primaryClusterId'          = '1111-2222-3333'
+                'shouldDeployAgent'         = 'True'
+                'runAsAccount'              = 'administrator@domain.local'
+                'configuredSLADomainName'   = 'GOLD'
+                'id'                        = 'HypervScvmm:::2222-2222-3333'
+                'status'                    = 'Connected'
+            },
+            @{ 
+                'name'                      = 'scvmm03.domain.local'
+                'primaryClusterId'          = '2222-2222-3333'
+                'shouldDeployAgent'         = 'True'
+                'runAsAccount'              = 'administrator@domain.local'
+                'configuredSLADomainName'   = 'INHERIT'
+                'id'                        = 'HypervScvmm:::3333-2222-3333'
+                'status'                    = 'Connected'
             }
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikSmbDomain.Tests.ps1
+++ b/Tests/Get-RubrikSmbDomain.Tests.ps1
@@ -22,10 +22,6 @@ Describe -Name 'Public/Get-RubrikSmbDomain' -Tag 'Public', 'Get-RubrikSmbDomain'
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '2'
-                'data'      =
                 @{ 
                     'name'                  = 'domain.local'
                     'serviceAccount'        = 'serviceAccountUserName'
@@ -38,7 +34,6 @@ Describe -Name 'Public/Get-RubrikSmbDomain' -Tag 'Public', 'Get-RubrikSmbDomain'
                     'isStickySmbService'    = 'true'
                     'status'                = 'Configured'
                 }
-            }
 
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikSoftwareVersion.Tests.ps1
+++ b/Tests/Get-RubrikSoftwareVersion.Tests.ps1
@@ -20,7 +20,7 @@ Describe -Name 'Public/Get-RubrikSoftwareVersion' -Tag 'Public', 'Get-RubrikSoft
     #endregion
 
     Context -Name 'Results Filtering' {
-        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith { @{ 'version' = '5.0.1-p2-1592'}}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith { return '5.0.1-p2-1592'}
         It -Name 'Should return 1' -Test {
             ( Get-RubrikSoftwareVersion -Server 'server') |
                 Should -BeExactly '5.0.1-p2-1592'

--- a/Tests/Get-RubrikSyslogServer.Tests.ps1
+++ b/Tests/Get-RubrikSyslogServer.Tests.ps1
@@ -22,10 +22,6 @@ Describe -Name 'Public/Get-RubrikSyslogServer' -Tag 'Public', 'Get-RubrikSyslogS
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '2'
-                'data'      =
                 @{ 
                     'hostname'  = 'syslog1.domain.local'
                     'protocol'  = 'UDP'
@@ -38,7 +34,6 @@ Describe -Name 'Public/Get-RubrikSyslogServer' -Tag 'Public', 'Get-RubrikSyslogS
                     'port'      = '514'
                     'id'        = '1'                   
                 }
-            }
 
         }
         It -Name 'No parameters returns all results' -Test {

--- a/Tests/Get-RubrikUnmanagedObject.Tests.ps1
+++ b/Tests/Get-RubrikUnmanagedObject.Tests.ps1
@@ -22,34 +22,29 @@ Describe -Name 'Public/Get-RubrikUnmanagedObject' -Tag 'Public', 'Get-RubrikUnma
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '4'
-                'data'      =
-                @{ 
-                    'id'                    = 'VirtualMachine:11111'
-                    'name'                  = 'VM1'
-                    'unManagedStatus'       = 'Relic'
-                    'objectType'            = 'VirtualMachine'
-                },
-                @{ 
-                    'id'                    = 'MSSQLDatabase:11111'
-                    'name'                  = 'db1'
-                    'unManagedStatus'       = 'Unprotected'
-                    'objectType'            = 'MssqlDatabase'
-                },
-                @{ 
-                    'id'                    = 'VirtualMachine:22222'
-                    'name'                  = 'VM2'
-                    'unManagedStatus'       = 'Protected'
-                    'objectType'            = 'VirtualMachine'
-                },
-                @{ 
-                    'id'                    = 'VirtualMachine:33333'
-                    'name'                  = 'VM3'
-                    'unManagedStatus'       = 'Relic'
-                    'objectType'            = 'VirtualMachine'
-                }
+            @{ 
+                'id'                    = 'VirtualMachine:11111'
+                'name'                  = 'VM1'
+                'unManagedStatus'       = 'Relic'
+                'objectType'            = 'VirtualMachine'
+            },
+            @{ 
+                'id'                    = 'MSSQLDatabase:11111'
+                'name'                  = 'db1'
+                'unManagedStatus'       = 'Unprotected'
+                'objectType'            = 'MssqlDatabase'
+            },
+            @{ 
+                'id'                    = 'VirtualMachine:22222'
+                'name'                  = 'VM2'
+                'unManagedStatus'       = 'Protected'
+                'objectType'            = 'VirtualMachine'
+            },
+            @{ 
+                'id'                    = 'VirtualMachine:33333'
+                'name'                  = 'VM3'
+                'unManagedStatus'       = 'Relic'
+                'objectType'            = 'VirtualMachine'
             }
         }
         It -Name 'Should return count of 4' -Test {

--- a/Tests/Get-RubrikUserRole.Tests.ps1
+++ b/Tests/Get-RubrikUserRole.Tests.ps1
@@ -23,15 +23,10 @@ Describe -Name 'Public/Get-RubrikUserRole' -Tag 'Public', 'Get-RubrikUserRole' -
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             @{
-                'hasmore'   = 'false'
-                'total'     = '1'
-                'data'      =
-                @{
-                    'readOnlyAdmin'     = '@{basic=}'
-                    'admin'             = '@{fullAdmin=}'
-                    'principal'         = 'User:111-222-333'
-                    'endUser'           = '@{restore="VirtualMachine:111}'           
-                }
+                'readOnlyAdmin'     = '@{basic=}'
+                'admin'             = '@{fullAdmin=}'
+                'principal'         = 'User:111-222-333'
+                'endUser'           = '@{restore="VirtualMachine:111}'           
             }
         }
         It -Name 'Returns correct principal' -Test {

--- a/Tests/Get-RubrikVAppSnapshot.Tests.ps1
+++ b/Tests/Get-RubrikVAppSnapshot.Tests.ps1
@@ -22,7 +22,7 @@ Describe -Name 'Public/Get-RubrikVAppSnapshot' -Tag 'Public', 'Get-RubrikVAppSna
     Context -Name 'Parameters' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            $response = '{"data": {
+            $response = '{
                 "date": "2019-07-19T16:38:22.826Z",
                 "indexState": 1,
                 "slaName": "Silver",
@@ -66,7 +66,7 @@ Describe -Name 'Public/Get-RubrikVAppSnapshot' -Tag 'Public', 'Get-RubrikVAppSna
                   }
                 ],
                 "id": "01234567-8910-1abc-d435-0abc1234d567"
-              }}'
+              }'
             return ConvertFrom-Json $response
         }
 

--- a/Tests/Get-RubrikVM.Tests.ps1
+++ b/Tests/Get-RubrikVM.Tests.ps1
@@ -25,18 +25,13 @@ Describe -Name 'Public/Get-RubrikVM' -Tag 'Public', 'Get-RubrikVM' -Fixture {
             @{ 'id' = 'test-sla_id' }
         }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '1'
-                'data'      =
-                @{ 
-                    'name'                   = 'test-vm1'
-                    'effectiveSlaDomainName' = 'test-valid_sla_name'
-                },
-                @{ # The server-side filter should not return this record, but this record will validate the response filter logic
-                    'name'                   = 'test-vm2'
-                    'effectiveSlaDomainName' = 'test-invalid_sla_name'
-                }
+            @{ 
+                'name'                   = 'test-vm1'
+                'effectiveSlaDomainName' = 'test-valid_sla_name'
+            },
+            @{ # The server-side filter should not return this record, but this record will validate the response filter logic
+                'name'                   = 'test-vm2'
+                'effectiveSlaDomainName' = 'test-invalid_sla_name'
             }
         }
         It -Name 'should overwrite $SLAID' -Test {
@@ -52,14 +47,9 @@ Describe -Name 'Public/Get-RubrikVM' -Tag 'Public', 'Get-RubrikVM' -Fixture {
     Context -Name 'Parameter/SLAID' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '1'
-                'data'      =
-                @{ 
-                    'name'                   = 'test-vm1'
-                    'effectiveSlaDomainName' = 'test-valid_sla_name'
-                }
+            @{ 
+                'name'                   = 'test-vm1'
+                'effectiveSlaDomainName' = 'test-valid_sla_name'
             }
         }
         It -Name 'should not overwrite $SLAID' -Test {

--- a/Tests/Get-RubrikVMwareCluster.Tests.ps1
+++ b/Tests/Get-RubrikVMwareCluster.Tests.ps1
@@ -22,28 +22,23 @@ Describe -Name 'Public/Get-RubrikVMwareCluster' -Tag 'Public', 'Get-RubrikVMware
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '3'
-                'data'      =
-                @{ 
-                    'name'                   = 'Cluster01'
-                    'id'                     = 'Cluster:::11111'
-                    'dataCenterId'           = 'Datacenter:::11111'
-                    'primaryClusterId'       = '1'
-                },
-                @{ 
-                    'name'                   = 'Cluster02'
-                    'id'                     = 'Cluster:::22222'
-                    'DatacenterId'           = 'Datacenter:::11111'
-                    'primaryClusterId'       = '1'
-                },
-                @{ 
-                    'name'                   = 'Cluster01'
-                    'id'                     = 'Cluster:::33333'
-                    'DatacenterId'           = 'Datacenter:::22222'
-                    'primaryClusterId'       = '2'
-                }
+            @{ 
+                'name'                   = 'Cluster01'
+                'id'                     = 'Cluster:::11111'
+                'dataCenterId'           = 'Datacenter:::11111'
+                'primaryClusterId'       = '1'
+            },
+            @{ 
+                'name'                   = 'Cluster02'
+                'id'                     = 'Cluster:::22222'
+                'DatacenterId'           = 'Datacenter:::11111'
+                'primaryClusterId'       = '1'
+            },
+            @{ 
+                'name'                   = 'Cluster01'
+                'id'                     = 'Cluster:::33333'
+                'DatacenterId'           = 'Datacenter:::22222'
+                'primaryClusterId'       = '2'
             }
         }
         It -Name 'Should Return count of 2' -Test {

--- a/Tests/Get-RubrikVMwareDatacenter.Tests.ps1
+++ b/Tests/Get-RubrikVMwareDatacenter.Tests.ps1
@@ -22,28 +22,23 @@ Describe -Name 'Public/Get-RubrikVMwareDatacenter' -Tag 'Public', 'Get-RubrikVMw
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '3'
-                'data'      =
-                @{ 
-                    'name'                   = 'datacenter01'
-                    'id'                     = 'Datacenter:::11111'
-                    'vCenterId'              = 'vCenter:::11111'
-                    'primaryClusterId'       = '1'
-                },
-                @{ 
-                    'name'                   = 'datacenter02'
-                    'id'                     = 'Datacenter:::22222'
-                    'vCenterId'              = 'vCenter:::11111'
-                    'primaryClusterId'       = '1'
-                },
-                @{ 
-                    'name'                   = 'datacenter01'
-                    'id'                     = 'Datacenter:::33333'
-                    'vCenterId'              = 'vCenter:::22222'
-                    'primaryClusterId'       = '2'
-                }
+            @{ 
+                'name'                   = 'datacenter01'
+                'id'                     = 'Datacenter:::11111'
+                'vCenterId'              = 'vCenter:::11111'
+                'primaryClusterId'       = '1'
+            },
+            @{ 
+                'name'                   = 'datacenter02'
+                'id'                     = 'Datacenter:::22222'
+                'vCenterId'              = 'vCenter:::11111'
+                'primaryClusterId'       = '1'
+            },
+            @{ 
+                'name'                   = 'datacenter01'
+                'id'                     = 'Datacenter:::33333'
+                'vCenterId'              = 'vCenter:::22222'
+                'primaryClusterId'       = '2'
             }
         }
         It -Name 'Should Return count of 2' -Test {

--- a/Tests/Get-RubrikVMwareDatastore.Tests.ps1
+++ b/Tests/Get-RubrikVMwareDatastore.Tests.ps1
@@ -22,30 +22,26 @@ Describe -Name 'Public/Get-RubrikVMwareDatastore' -Tag 'Public', 'Get-RubrikVMwa
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasMore' = 'False'
-                'total' = '4'
-                'data' =
-                @{ 
-                    'name'                   = 'datastore01'
-                    'id'                     = 'Datastore:::11111'
-                    'dataStoreType'          = 'NFS'
-                },
-                @{ 
-                    'name'                   = 'datastore02'
-                    'id'                     = 'Datastore:::22222'
-                    'dataStoreType'          = 'VMFS'
-                },
-                @{ 
-                    'name'                   = 'datastore03'
-                    'id'                     = 'Datastore:::33333'
-                    'dataStoreType'          = 'VMFS'
-                },
-                @{ 
-                    'name'                   = 'VSAN'
-                    'id'                     = 'Datastore:::44444'
-                    'dataStoreType'          = 'vsan'
-                }
+            @{ 
+                'name'                   = 'datastore01'
+                'id'                     = 'Datastore:::11111'
+                'dataStoreType'          = 'NFS'
+            },
+            @{ 
+                'name'                   = 'datastore02'
+                'id'                     = 'Datastore:::22222'
+                'dataStoreType'          = 'VMFS'
+            },
+            @{ 
+                'name'                   = 'datastore03'
+                'id'                     = 'Datastore:::33333'
+                'dataStoreType'          = 'VMFS'
+            }
+            ,
+            @{ 
+                'name'                   = 'VSAN'
+                'id'                     = 'Datastore:::44444'
+                'dataStoreType'          = 'vsan'
             }
         }
         It -Name 'Should Return count of 4' -Test {

--- a/Tests/Get-RubrikVMwareHost.Tests.ps1
+++ b/Tests/Get-RubrikVMwareHost.Tests.ps1
@@ -22,34 +22,30 @@ Describe -Name 'Public/Get-RubrikVMwareHost' -Tag 'Public', 'Get-RubrikVMwareHos
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasMore' = 'false'
-                'total' = '4'
-                'data' =
-                @{ 
-                    'name'                   = 'esxi01.domain.local'
-                    'id'                     = 'VMwareHost:::11111'
-                    'datacenterId'           = 'Datacenter:::11111'
-                    'primaryClusterId'       = '1'
-                },
-                @{ 
-                    'name'                   = 'esxi02.domain.local'
-                    'id'                     = 'VMwareHost:::22222'
-                    'datacenterId'           = 'Datacenter:::11111'
-                    'primaryClusterId'       = '1'
-                },
-                @{ 
-                    'name'                   = 'esxi02.domain.local'
-                    'id'                     = 'VMwareHost:::33333'
-                    'datacenterId'           = 'Datacenter:::22222'
-                    'primaryClusterId'       = '2'
-                },
-                @{ 
-                    'name'                   = 'esxi04.domain.local'
-                    'id'                     = 'VMwareHost:::44444'
-                    'datacenterId'           = 'Datacenter:::22222'
-                    'primaryClusterId'       = '2'
-                }
+            @{ 
+                'name'                   = 'esxi01.domain.local'
+                'id'                     = 'VMwareHost:::11111'
+                'datacenterId'           = 'Datacenter:::11111'
+                'primaryClusterId'       = '1'
+            },
+            @{ 
+                'name'                   = 'esxi02.domain.local'
+                'id'                     = 'VMwareHost:::22222'
+                'datacenterId'           = 'Datacenter:::11111'
+                'primaryClusterId'       = '1'
+            },
+            @{ 
+                'name'                   = 'esxi02.domain.local'
+                'id'                     = 'VMwareHost:::33333'
+                'datacenterId'           = 'Datacenter:::22222'
+                'primaryClusterId'       = '2'
+            }
+            ,
+            @{ 
+                'name'                   = 'esxi04.domain.local'
+                'id'                     = 'VMwareHost:::44444'
+                'datacenterId'           = 'Datacenter:::22222'
+                'primaryClusterId'       = '2'
             }
         }
         It -Name 'Should Return count of 2' -Test {

--- a/Tests/Get-RubrikVolumeGroup.Tests.ps1
+++ b/Tests/Get-RubrikVolumeGroup.Tests.ps1
@@ -26,41 +26,36 @@ Describe -Name 'Public/Get-RubrikVolumeGroup' -Tag 'Public', 'Get-RubrikVolumeGr
         }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             @{
-                'hasmore'   = 'false'
-                'total'     = '1'
-                'data'      =
-                @{
-                    'name'                   = 'VG01'
-                    'id'                     = 'VolumeGroup:::11111'
-                    'hostname'               = 'VG01.domain.local'
-                    'effectiveSlaDomainName' = 'Gold'
-                    'effectiveSlaDomainId'   = 'SLA1'
-                    'hostId'                 = 'host01'
-                },
-                @{ 
-                    'name'                   = 'VG02'
-                    'id'                     = 'VolumeGroup:::22222'
-                    'hostname'               = 'VG02.domain.local'
-                    'effectiveSlaDomainName' = 'Gold'
-                    'effectiveSlaDomainId'   = 'SLA1'
-                    'hostId'                 = 'host02'
-                },
-                @{
-                    'name'                   = 'VG03'
-                    'id'                     = 'VolumeGroup:::33333'
-                    'hostname'               = 'VG03.domain.local'
-                    'effectiveSlaDomainName' = 'Silver'
-                    'effectiveSlaDomainId'   = 'SLA2'
-                    'hostId'                 = 'host03'
-                },
-                @{
-                    'name'                   = 'VG04'
-                    'id'                     = 'VolumeGroup:::44444'
-                    'hostname'               = 'VG04.domain.local'
-                    'effectiveSlaDomainName' = 'Gold'
-                    'effectiveSlaDomainId'   = 'SLA1'
-                    'hostId'                 = 'host04'
-                }
+                'name'                   = 'VG01'
+                'id'                     = 'VolumeGroup:::11111'
+                'hostname'               = 'VG01.domain.local'
+                'effectiveSlaDomainName' = 'Gold'
+                'effectiveSlaDomainId'   = 'SLA1'
+                'hostId'                 = 'host01'
+            },
+            @{ 
+                'name'                   = 'VG02'
+                'id'                     = 'VolumeGroup:::22222'
+                'hostname'               = 'VG02.domain.local'
+                'effectiveSlaDomainName' = 'Gold'
+                'effectiveSlaDomainId'   = 'SLA1'
+                'hostId'                 = 'host02'
+            },
+            @{
+                'name'                   = 'VG03'
+                'id'                     = 'VolumeGroup:::33333'
+                'hostname'               = 'VG03.domain.local'
+                'effectiveSlaDomainName' = 'Silver'
+                'effectiveSlaDomainId'   = 'SLA2'
+                'hostId'                 = 'host03'
+            },
+            @{
+                'name'                   = 'VG04'
+                'id'                     = 'VolumeGroup:::44444'
+                'hostname'               = 'VG04.domain.local'
+                'effectiveSlaDomainName' = 'Gold'
+                'effectiveSlaDomainId'   = 'SLA1'
+                'hostId'                 = 'host04'
             }
         }
         It -Name 'Requesting all should return count of 4' -Test {
@@ -91,20 +86,15 @@ Describe -Name 'Public/Get-RubrikVolumeGroup' -Tag 'Public', 'Get-RubrikVolumeGr
     Context -Name 'DetailedObject querying' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '1'
-                'data'      =
-                @{ 
-                    'name'                   = 'VG01'
-                    'id'                     = 'VolumeGroup:::11111'
-                    'hostname'               = 'VG01.domain.local'
-                    'effectiveSlaDomainName' = 'Gold'
-                    'effectiveSlaDomainId'   = 'SLA1'
-                    'hostId'                 = 'host01'
-                    'volumes'                = @{
-                        'mountPoints' = '/etc'
-                    }
+            @{ 
+                'name'                   = 'VG01'
+                'id'                     = 'VolumeGroup:::11111'
+                'hostname'               = 'VG01.domain.local'
+                'effectiveSlaDomainName' = 'Gold'
+                'effectiveSlaDomainId'   = 'SLA1'
+                'hostId'                 = 'host01'
+                'volumes'                = @{
+                    'mountPoints' = '/etc'
                 }
             }
         }

--- a/Tests/Get-RubrikVolumeGroupMount.Tests.ps1
+++ b/Tests/Get-RubrikVolumeGroupMount.Tests.ps1
@@ -22,38 +22,33 @@ Describe -Name 'Public/Get-RubrikVolumeGroupMount' -Tag 'Public', 'Get-RubrikVol
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore'   = 'false'
-                'total'     = '4'
-                'data'      =
-                @{ 
-                    'name'                   = 'mount01'
-                    'id'                     = '11111'
-                    'sourceVolumeGroupId'    = 'VolumeGroup:::11111'
-                    'sourceHostId'           = 'host:::11111'
-                    'sourceHostName'         = 'host01'
-                },
-                @{ 
-                    'name'                   = 'mount01'
-                    'id'                     = '22222'
-                    'sourceVolumeGroupId'    = 'VolumeGroup:::11111'
-                    'sourceHostId'           = 'host:::11111'
-                    'sourceHostName'         = 'host01'
-                },
-                @{ 
-                    'name'                   = 'mount02'
-                    'id'                     = '33333'
-                    'sourceVolumeGroupId'    = 'VolumeGroup:::22222'
-                    'sourceHostId'           = 'host:::22222'
-                    'sourceHostName'         = 'host02'
-                },
-                @{ 
-                    'name'                   = 'mount03'
-                    'id'                     = '44444'
-                    'sourceVolumeGroupId'    = 'VolumeGroup:::33333'
-                    'sourceHostId'           = 'host:::33333'
-                    'sourceHostName'         = 'host03'
-                }
+            @{ 
+                'name'                   = 'mount01'
+                'id'                     = '11111'
+                'sourceVolumeGroupId'    = 'VolumeGroup:::11111'
+                'sourceHostId'           = 'host:::11111'
+                'sourceHostName'         = 'host01'
+            },
+            @{ 
+                'name'                   = 'mount01'
+                'id'                     = '22222'
+                'sourceVolumeGroupId'    = 'VolumeGroup:::11111'
+                'sourceHostId'           = 'host:::11111'
+                'sourceHostName'         = 'host01'
+            },
+            @{ 
+                'name'                   = 'mount02'
+                'id'                     = '33333'
+                'sourceVolumeGroupId'    = 'VolumeGroup:::22222'
+                'sourceHostId'           = 'host:::22222'
+                'sourceHostName'         = 'host02'
+            },
+            @{ 
+                'name'                   = 'mount03'
+                'id'                     = '44444'
+                'sourceVolumeGroupId'    = 'VolumeGroup:::33333'
+                'sourceHostId'           = 'host:::33333'
+                'sourceHostName'         = 'host03'
             }
         }
         It -Name 'Requesting all should return count of 4' -Test {

--- a/Tests/New-RubrikFileset.Tests.ps1
+++ b/Tests/New-RubrikFileset.Tests.ps1
@@ -22,18 +22,13 @@ Describe -Name 'Public/New-RubrikFileset' -Tag 'Public', 'New-RubrikFileset' -Fi
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore' = 'false'
-                'total'   = '1'
-                'data'    =
-                @{ 
-                    'name'                   = 'Foo'
-                    'id'                     = 'Fileset::111111-2222-3333-4444-555555555555'
-                    'shareType'              = 'SMB'
-                    'useWindowsVss'          = 'False'
-                    'shareCount'             = '0'
-                    'primaryClusterId'       = 'cluster_id1'   
-                }
+            @{ 
+                'name'                   = 'Foo'
+                'id'                     = 'Fileset::111111-2222-3333-4444-555555555555'
+                'shareType'              = 'SMB'
+                'useWindowsVss'          = 'False'
+                'shareCount'             = '0'
+                'primaryClusterId'       = 'cluster_id1'   
             }
         }
         It -Name 'FilesetTemplate created' -Test {

--- a/Tests/Protect-RubrikDatabase.Tests.ps1
+++ b/Tests/Protect-RubrikDatabase.Tests.ps1
@@ -25,7 +25,7 @@ Describe -Name 'Public/Protect-RubrikDatabase' -Tag 'Public', 'Protect-RubrikDat
             @{ 'slaid' = '12345678-1234-abcd-8910-1234567890ab' }
         }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            $response = '{"data": {
+            $response = '{
                 "effectiveSlaDomainId": "12345678-1234-abcd-8910-1234567890ab",
                 "primaryClusterId": "12345678-1234-abcd-8910-1234567890ab",
                 "instanceName": "MSSQLSERVER",
@@ -49,7 +49,7 @@ Describe -Name 'Public/Protect-RubrikDatabase' -Tag 'Public', 'Protect-RubrikDat
                 "isRelic": false,
                 "name": "ExampleDB1",
                 "logBackupFrequencyInSeconds": 300
-            }}'
+            }'
             return ConvertFrom-Json $response
         }
         It -Name 'Verify results match expected values' -Test {

--- a/Tests/Protect-RubrikFileset.Tests.ps1
+++ b/Tests/Protect-RubrikFileset.Tests.ps1
@@ -25,18 +25,13 @@ Describe -Name 'Public/Protect-RubrikFileset' -Tag 'Public', 'Protect-RubrikFile
             @{ 'id' = 'sla_domain_id' }
         }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{
-                'hasmore' = 'false'
-                'total'   = '1'
-                'data'    =
-                @{ 
-                    'name'                   = 'Foo'
-                    'id'                     = 'Fileset::111111-2222-3333-4444-555555555555'
-                    'effectiveSlaDomainId'   = 'sla_domain_id'
-                    'useWindowsVss'          = 'False'
-                    'shareCount'             = '0'
-                    'primaryClusterId'       = 'cluster_id1' 
-                }
+            @{ 
+                'name'                   = 'Foo'
+                'id'                     = 'Fileset::111111-2222-3333-4444-555555555555'
+                'effectiveSlaDomainId'   = 'sla_domain_id'
+                'useWindowsVss'          = 'False'
+                'shareCount'             = '0'
+                'primaryClusterId'       = 'cluster_id1' 
             }
         }
         It -Name 'Fileset assigned to SLA Domain' -Test {

--- a/Tests/Remove-RubrikOrgAuthorization.Tests.ps1
+++ b/Tests/Remove-RubrikOrgAuthorization.Tests.ps1
@@ -22,12 +22,12 @@ Describe -Name 'Public/Remove-RubrikOrgAuthorization' -Tag 'Public', 'Remove-Rub
     Context -Name 'Results Validation' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Get-RubrikOrganization -Verifiable -ModuleName 'Rubrik' -MockWith {
-            $json = '{"data": {
+            $json = '{
                 "name": "SampleOrg",
                 "isGlobal": false,
                 "envoyStatus": false,
                 "id": "Organization:::01234567-8910-1abc-d435-0abc1234d567"
-              }}'
+              }'
             return ConvertFrom-Json $json
         } 
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
@@ -69,12 +69,12 @@ Describe -Name 'Public/Remove-RubrikOrgAuthorization' -Tag 'Public', 'Remove-Rub
     Context -Name 'Global Org' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            $json = '{"data": {
+            $json = '{
                 "name": "Global",
                 "isGlobal": true,
                 "envoyStatus": false,
                 "id": "Organization:::01234567-8910-1abc-d435-0abc1234d567"
-              }}'
+              }'
             return ConvertFrom-Json $json
         }
         It -Name 'Should throw an error on Global Org' -Test {

--- a/Tests/Set-RubrikOrgAuthorization.Tests.ps1
+++ b/Tests/Set-RubrikOrgAuthorization.Tests.ps1
@@ -22,12 +22,12 @@ Describe -Name 'Public/Set-RubrikOrgAuthorization' -Tag 'Public', 'Set-RubrikOrg
     Context -Name 'Results Validation' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Get-RubrikOrganization -Verifiable -ModuleName 'Rubrik' -MockWith {
-            $json = '{"data": {
+            $json = '{
                 "name": "SampleOrg",
                 "isGlobal": false,
                 "envoyStatus": false,
                 "id": "Organization:::01234567-8910-1abc-d435-0abc1234d567"
-              }}'
+              }'
             return ConvertFrom-Json $json
         } 
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
@@ -71,12 +71,12 @@ Describe -Name 'Public/Set-RubrikOrgAuthorization' -Tag 'Public', 'Set-RubrikOrg
     Context -Name 'Global Org' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            $json = '{"data": {
+            $json = '{
                 "name": "Global",
                 "isGlobal": true,
                 "envoyStatus": false,
                 "id": "Organization:::01234567-8910-1abc-d435-0abc1234d567"
-              }}'
+              }'
             return ConvertFrom-Json $json
         }
         It -Name 'Should throw an error on Global Org' -Test {

--- a/Tests/Set-RubrikUserRole.Tests.ps1
+++ b/Tests/Set-RubrikUserRole.Tests.ps1
@@ -24,15 +24,10 @@ Describe -Name 'Public/Set-RubrikUserRole' -Tag 'Public', 'Set-RubrikUserRole' -
         Mock -CommandName Update-RubrikUserRole  -ModuleName 'Rubrik' -Mockwith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             @{
-                'hasmore' = 'false'
-                'total' = '1'
-                'data' = 
-                @{
-                    'readOnlyAdmin'     = '@{basic=}'
-                    'admin'             = '@{fullAdmin=}'
-                    'principal'         = 'User:111-222-333'
-                    'endUser'           = '@{restore="VirtualMachine:111}'           
-                }
+                'readOnlyAdmin'     = '@{basic=}'
+                'admin'             = '@{fullAdmin=}'
+                'principal'         = 'User:111-222-333'
+                'endUser'           = '@{restore="VirtualMachine:111}'           
             }
         }
         It -Name 'User is updated' -Test {


### PR DESCRIPTION
Reverts rubrikinc/rubrik-sdk-for-powershell#566

Endpoints which support ID within the URI no longer work when passing an ID - removing this work for now..