### PR TITLE
Fix for RubrikOrgAuthorization API endpoint changed in 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * **Fixed** for any bug fixes.
 * **Security** in case of vulnerabilities.
 
+## [Unreleased] - 2019-03-04
+
+### Fixed 
+* Fix for RubrikOrgAuthorization API endpoint changed in 5.1 [570](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/568)
+
 ## [Unreleased] - 2019-02-21
 
 ### Fixed

--- a/Rubrik/ObjectDefinitions/Rubrik.OrgAuthorization.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.OrgAuthorization.ps1xml
@@ -37,7 +37,7 @@
                                 <ScriptBlock>$_.useSla.count</ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <ScriptBlock>$_.manageResource.count</ScriptBlock>
+                                <ScriptBlock>$_.manageResource.count+$_.privileges.manageRestoreSource.count</ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <ScriptBlock>$_.manageSla.count</ScriptBlock>

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -927,21 +927,6 @@ function Get-RubrikAPIData($endpoint) {
                 }
                 Success     = '200'
             }
-            '5.1' = @{
-                Description = 'Get summary of all Rubrik organizations'
-                URI         = '/api/v1/organization'
-                Method      = 'Get'
-                Body        = ''
-                Query       = @{
-                    is_global                = 'is_global'
-                    name                     = 'name'
-                }
-                Result      = 'data'
-                Filter      = @{
-                    'name' = 'name'
-                }
-                Success     = '200'
-            }
         }
         'Get-RubrikOrgAuthorization'         = @{
             '1.0' = @{
@@ -2668,6 +2653,26 @@ function Get-RubrikAPIData($endpoint) {
                     privileges = @{
                         manageCluster = [System.Collections.ArrayList]@()
                         manageResource = [System.Collections.ArrayList]@()
+                        useSla = [System.Collections.ArrayList]@()
+                        manageSla = [System.Collections.ArrayList]@()
+                    }
+                }
+                Query       = ''
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+            '5.1' = @{
+                Description = 'Grants an organization authorization for principal(s)'
+                URI         = '/api/internal/authorization/role/organization'
+                Method      = 'Post'
+                Body        = @{
+                    principals = [System.Collections.ArrayList]@()
+                    organizationId = 'organization_id'
+                    privileges = @{
+                        manageCluster = [System.Collections.ArrayList]@()
+                        manageResource = [System.Collections.ArrayList]@()
+                        manageRestoreSource = [System.Collections.ArrayList]@()
                         useSla = [System.Collections.ArrayList]@()
                         manageSla = [System.Collections.ArrayList]@()
                     }

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -2342,6 +2342,26 @@ function Get-RubrikAPIData($endpoint) {
                 Result      = 'data'
                 Filter      = ''
                 Success     = '200'
+            } 
+            '5.1' = @{
+                Description = 'Revokes an organization authorization for principal(s)'
+                URI         = '/api/internal/authorization/role/organization'
+                Method      = 'Delete'
+                Body        = @{
+                    principals = [System.Collections.ArrayList]@()
+                    organizationId = 'organization_id'
+                    privileges = @{
+                        manageCluster = [System.Collections.ArrayList]@()
+                        manageResource = [System.Collections.ArrayList]@()
+                        manageRestoreSource = [System.Collections.ArrayList]@()
+                        useSla = [System.Collections.ArrayList]@()
+                        manageSla = [System.Collections.ArrayList]@()
+                    }
+                }
+                Query       = ''
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
             }
         }
         'Remove-RubrikReport'          = @{

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -927,6 +927,21 @@ function Get-RubrikAPIData($endpoint) {
                 }
                 Success     = '200'
             }
+            '5.1' = @{
+                Description = 'Get summary of all Rubrik organizations'
+                URI         = '/api/v1/organization'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    is_global                = 'is_global'
+                    name                     = 'name'
+                }
+                Result      = 'data'
+                Filter      = @{
+                    'name' = 'name'
+                }
+                Success     = '200'
+            }
         }
         'Get-RubrikOrgAuthorization'         = @{
             '1.0' = @{

--- a/Rubrik/Public/Remove-RubrikOrgAuthorization.ps1
+++ b/Rubrik/Public/Remove-RubrikOrgAuthorization.ps1
@@ -95,7 +95,14 @@ function Remove-RubrikOrgAuthorization
 
     # Build REST Body
     if($UseSLA.Length -gt 0) { $resources.Body.privileges.useSla.AddRange($UseSLA) }
-    if($ManageResource.Length -gt 0) { $resources.Body.privileges.ManageResource.AddRange($ManageResource) }
+    if($ManageResource.Length -gt 0) { 
+      # Added changed body for 5.1, as ManageResource seems to be no longer used
+      if ([float]$rubrikConnection.version.substring(0,3) -gt [float]'5.0') {
+        $resources.Body.privileges.manageRestoreSource.AddRange($ManageResource)
+      } else {
+        $resources.Body.privileges.ManageResource.AddRange($ManageResource)
+      }
+    }
     if($ManageSLA.Length -gt 0) { $resources.Body.privileges.ManageSLA.AddRange($ManageSLA) }
     $resources.Body.principals.Add($id) | Out-Null
     $resources.Body.organizationId = $OrgID

--- a/Rubrik/Public/Set-RubrikOrgAuthorization.ps1
+++ b/Rubrik/Public/Set-RubrikOrgAuthorization.ps1
@@ -95,7 +95,14 @@ function Set-RubrikOrgAuthorization
 
     # Build REST Body
     if($UseSLA.Length -gt 0) { $resources.Body.privileges.useSla.AddRange($UseSLA) }
-    if($ManageResource.Length -gt 0) { $resources.Body.privileges.ManageResource.AddRange($ManageResource) }
+    if($ManageResource.Length -gt 0) { 
+      # Added changed body for 5.1, as ManageResource seems to be no longer used
+      if ([float]$rubrikConnection.version.substring(0,3) -gt [float]'5.0') {
+        $resources.Body.privileges.manageRestoreSource.AddRange($ManageResource)
+      } else {
+        $resources.Body.privileges.ManageResource.AddRange($ManageResource)
+      }
+    }
     if($ManageSLA.Length -gt 0) { $resources.Body.privileges.ManageSLA.AddRange($ManageSLA) }
     $resources.Body.principals.Add($id) | Out-Null
     $resources.Body.organizationId = $OrgID


### PR DESCRIPTION
# Description

Body of API Endpoints changed for Rubrik Org Authorization

## Related Issue

Resolve #570 

## Motivation and Context

API change in 5.1

Datamodel:

old body:
{"principals":["Organization:::2ca15cae-7f1a-4691-88e0-5140eea744b8"],"organizationId":"Organization:::2ca15cae-7f1a-4691-88e0-5140eea744b8","privileges":{"manageCluster":[],"manageAccess":[],"manageResource":["VirtualMachine:::de4beaa1-5abc-478c-aa0d-167054d4d17c-vm-2113"],"manageRestoreDestination":[],"useSla":[],"manageSla":[]}}

correct body:
{"principals":["Organization:::2ca15cae-7f1a-4691-88e0-5140eea744b8"],"organizationId":"Organization:::2ca15cae-7f1a-4691-88e0-5140eea744b8","privileges":{"manageCluster":[],"manageAccess":[],"manageResource":[],"manageRestoreSource":["VirtualMachine:::de4beaa1-5abc-478c-aa0d-167054d4d17c-vm-2113"],"manageRestoreDestination":[],"useSla":[],"manageSla":[]}}

## How Has This Been Tested?

The following code has been run on both 5.0 and 5.1 to validate there are no bugs when connecting to either version of a Rubrik Cluster.

```
New-RubrikOrganization -Name Test-Jaap-Issue570
Get-RubrikOrganization -Name Test-Jaap-Issue570 | Get-RubrikOrgAuthorization 
get-rubrikorganization -name test-jaap-issue570 | Set-RubrikOrgAuthorization -ManageResource VirtualMachine:::4c0f0c71-1390-4017-9206-f8b16bd7ca8c-vm-102 -verbose
Get-RubrikOrganization -Name Test-Jaap-Issue570 | Get-RubrikOrgAuthorization 
get-rubrikorganization -name test-jaap-issue570 | Remove-RubrikOrgAuthorization -ManageResource VirtualMachine:::4c0f0c71-1390-4017-9206-f8b16bd7ca8c-vm-102 -verbose
Get-RubrikOrganization -Name Test-Jaap-Issue570 | Get-RubrikOrgAuthorization 
Get-RubrikOrganization -Name Test-Jaap-Issue570 | Remove-RubrikOrganization
```

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
