### PR TITLE
Issue 580 - Get-RubrikEventSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Updated `Get-RubrikAPIData` with formatted objecttypes for `New-RubrikSLA` and `Set-RubrikSLA`
 * Updated `New-RubrikSLA` and `Set-RubrikSLA` functions to add type names and decorate output similar to `Get-RubrikSLA`
 * Error handing in private function `Get-RubrikAPIData`, now displays error when no matching endpoint is found.
+* Changed `Get-RubrikEvent`, adding parametersets to isolate eventSeriesId. When cmdlet is called with eventSeriesId the `Get-RubrikEventSeries` cmdlet is now called rather than filtering through a giant, unindexed table. Details in [Issue 580](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/580)
 
 ### Added
 
 * Added `Suspend-RubrikSLA` and `Resume-RubrikSLA`
+* Added `Get-RubrikEventSeries` to now parse the event_series API rather than events as per [Issue 580](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/580)
 
 ## [5.0.1](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/5.0.1) - 2020-03-05
 
@@ -149,9 +151,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Changed the output of the user agent string to display platform information with double-dashed separated key-value pairs.
 * The link to `quick-start.md` in the `readme.md` has been updated to a relative link
 * The private function `Test-RubrikSLA` had a hard coded local variable
-* Renamed Get-RubrikVAppExportOptions to `Get-RubrikVAppExportOption` to use singular nouns 
-* Renamed Get-RubrikVAppRecoverOptions to `Get-RubrikVAppRecoverOption` to use singular nouns 
-* Renamed Get-RubrikVcdTemplateExportOptions to `Get-RubrikVcdTemplateExportOption` to use singular nouns 
+* Renamed Get-RubrikVAppExportOptions to `Get-RubrikVAppExportOption` to use singular nouns
+* Renamed Get-RubrikVAppRecoverOptions to `Get-RubrikVAppRecoverOption` to use singular nouns
+* Renamed Get-RubrikVcdTemplateExportOptions to `Get-RubrikVcdTemplateExportOption` to use singular nouns
 * Changed [parameter type from boolean to switch] for all functions
 * Modified private function Submit-Request.ps1 to support adding in success/error information for empty POST, PUT and PATCH responses
 * Modified status return code for Remove-RubrikManagedObject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Added `Suspend-RubrikSLA` and `Resume-RubrikSLA`
 * Added `Get-RubrikEventSeries` to now parse the event_series API rather than events as per [Issue 580](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/580)
+* Added unit tests to cover `Get-RubrikEventSeries` and changes to `Get-RubrikEvent`
 
 ## [5.0.1](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/5.0.1) - 2020-03-05
 

--- a/Rubrik/ObjectDefinitions/Rubrik.EventSeries.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.EventSeries.ps1xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+    <ViewDefinitions>
+        <View>
+            <Name>Default</Name>
+            <ViewSelectedBy>
+                <TypeName>Rubrik.EventSeries</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Label>Time</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Status</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Object Type</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Object Location</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>ID</Label>
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry> 
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>eventDate</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                               <PropertyName>status</PropertyName>
+                            </TableColumnItem>                            
+                            <TableColumnItem>
+                                <PropertyName>taskType</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>location</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>eventId</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+    </ViewDefinitions>
+</Configuration>

--- a/Rubrik/ObjectDefinitions/Rubrik.EventSeries.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.EventSeries.ps1xml
@@ -28,7 +28,7 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>eventDate</PropertyName>
+                                <PropertyName>endTime</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                <PropertyName>status</PropertyName>
@@ -47,7 +47,7 @@
                 </TableRowEntries>
             </TableControl>
         </View>
-                <View>
+        <View>
             <Name>Default</Name>
             <ViewSelectedBy>
                 <TypeName>Rubrik.EventSeries</TypeName>

--- a/Rubrik/ObjectDefinitions/Rubrik.EventSeries.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.EventSeries.ps1xml
@@ -4,6 +4,52 @@
         <View>
             <Name>Default</Name>
             <ViewSelectedBy>
+                <TypeName>Rubrik.EventSeriesById</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Label>Time</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Status</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Task Type</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Object Location</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Number of Events</Label>
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>eventDate</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                               <PropertyName>status</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>taskType</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>location</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>total</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+                <View>
+            <Name>Default</Name>
+            <ViewSelectedBy>
                 <TypeName>Rubrik.EventSeries</TypeName>
             </ViewSelectedBy>
             <TableControl>
@@ -21,18 +67,21 @@
                         <Label>Object Location</Label>
                     </TableColumnHeader>
                     <TableColumnHeader>
-                        <Label>ID</Label>
+                        <Label>Event Id</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Event Series Id</Label>
                     </TableColumnHeader>
                 </TableHeaders>
                 <TableRowEntries>
-                    <TableRowEntry> 
+                    <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
                                 <PropertyName>eventDate</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                <PropertyName>status</PropertyName>
-                            </TableColumnItem>                            
+                            </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>taskType</PropertyName>
                             </TableColumnItem>
@@ -41,6 +90,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>eventId</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>eventSeriesId</PropertyName>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -485,7 +485,7 @@ function Get-RubrikAPIData {
             }
         }
         'Get-RubrikEventSeries' = @{
-            '1.0' = @{
+            '5.0' = @{
                 Description = 'Retrieve information for event series within Rubrik.'
                 URI         = '/api/internal/event_series'
                 Method      = 'Get'

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -127,7 +127,7 @@ function Get-RubrikAPIData {
                 Body        = @{
                     exportMode  = 'exportMode'
                     networksToRestore = [System.Collections.ArrayList]@()
-                    vmsToExport = @( 
+                    vmsToExport = @(
                         @{
                             name   		= 'name'
                             vcdMoid     = 'vcdMoid'
@@ -186,7 +186,7 @@ function Get-RubrikAPIData {
                 Success     = '200'
                 ObjectTName = 'Rubrik.APIToken'
             }
-        }       
+        }
         'Get-RubrikAPIVersion'         = @{
             '1.0' = @{
                 Description = 'Retrieves software version of the Rubrik cluster'
@@ -206,7 +206,7 @@ function Get-RubrikAPIData {
                 Method      = 'Get'
                 Body        = ''
                 Query       = @{
-                    'ArchiveType'  = 'location_type' 
+                    'ArchiveType'  = 'location_type'
                 }
                 Result      = 'data'
                 Filter      = @{
@@ -484,6 +484,24 @@ function Get-RubrikAPIData {
                 ObjectTName = 'Rubrik.Event'
             }
         }
+        'Get-RubrikEventSeries' = @{
+            '1.0' = @{
+                Description = 'Retrieve information for event series within Rubrik.'
+                URI         = '/api/internal/event_series'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    status = 'status'
+                    event_type = 'event_type'
+                    object_ids = 'object_ids'
+                    object_name = 'object_name'
+                    object_type = 'object_type'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+        }
         'Get-RubrikFileset'            = @{
             '1.0' = @{
                 Description = 'Retrieve summary information for each fileset. Optionally, filter the retrieved information.'
@@ -595,7 +613,7 @@ function Get-RubrikAPIData {
                 Result      = 'data'
                 Filter      = @{
                     id = 'id'
-                    vmId = 'vmId'    
+                    vmId = 'vmId'
                 }
                 Success     = '200'
             }
@@ -746,7 +764,7 @@ function Get-RubrikAPIData {
                 Result      = 'data'
                 Filter      = @{
                     id = 'id'
-                    vmId = 'vmId'    
+                    vmId = 'vmId'
                 }
                 Success     = '200'
             }
@@ -1944,7 +1962,7 @@ function Get-RubrikAPIData {
                     replicationSpecs = @{
                         locationId     = 'locationId'
                         retentionLimit = 'retentionLimit'
-                    }    
+                    }
                 }
                 Query       = ''
                 Result      = ''
@@ -1991,7 +2009,7 @@ function Get-RubrikAPIData {
                     replicationSpecs = @{
                         locationId     = 'locationId'
                         retentionLimit = 'retentionLimit'
-                    }    
+                    }
                 }
                 Query       = ''
                 Result      = ''
@@ -2187,7 +2205,7 @@ function Get-RubrikAPIData {
                 Result      = ''
                 Filter      = ''
                 Success     = '204'
-            } 
+            }
         }
         'Remove-RubrikAPIToken'   = @{
             '5.0' = @{
@@ -2348,7 +2366,7 @@ function Get-RubrikAPIData {
                 Result      = 'data'
                 Filter      = ''
                 Success     = '200'
-            } 
+            }
             '5.1' = @{
                 Description = 'Revokes an organization authorization for principal(s)'
                 URI         = '/api/internal/authorization/role/organization'
@@ -3302,7 +3320,7 @@ function Get-RubrikAPIData {
     } else {
         Write-Verbose -Message "Selected $key API Data for $endpoint"
         # Add the function name to resolve issue #480
-        $api.$endpoint.$key.Add('Function',$endpoint) 
+        $api.$endpoint.$key.Add('Function',$endpoint)
         return $api.$endpoint.$key
     }
 } # End of function

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -500,6 +500,7 @@ function Get-RubrikAPIData {
                 Result      = 'data'
                 Filter      = ''
                 Success     = '200'
+                ObjectTName = 'Rubrik.EventSeries'
             }
         }
         'Get-RubrikFileset'            = @{

--- a/Rubrik/Public/Get-RubrikEvent.ps1
+++ b/Rubrik/Public/Get-RubrikEvent.ps1
@@ -32,6 +32,10 @@ function Get-RubrikEvent
       Get-RubrikHost -Name SQLFoo.demo.com | Get-RubrikEvent -EventType Archive
       This will feed any Archive events against the Rubrik Host object 'SQLFoo.demo.com' via a piped query.
 
+      .EXAMPLE
+      Get-RubrikEvent -EventSeriesId '1111-2222-3333'
+      This will retrieve all of the events belonging to the specified EventSeriesId. *Note - This will call Get-RubrikEventSeries*
+
   #>
 
   [CmdletBinding()]
@@ -126,7 +130,7 @@ function Get-RubrikEvent
     }
     else {
       # Adding property for TypeName support
-      $result = ((Get-RubrikEventSeries -id $EventSeriesId).eventDetailList) | Select *,@{N="eventStatus";E={$_.status}}
+      $result = ((Get-RubrikEventSeries -id $EventSeriesId).eventDetailList) | Select-Object *,@{N="eventStatus";E={$_.status}}
     }
     # Add 'date' property to the output by converting 'time' property to datetime object
     if (($null -ne $result) -and ($null -ne ($result | Select-Object -First 1).time)) {

--- a/Rubrik/Public/Get-RubrikEvent.ps1
+++ b/Rubrik/Public/Get-RubrikEvent.ps1
@@ -1,17 +1,17 @@
 #requires -Version 3
 function Get-RubrikEvent
 {
-  <#  
+  <#
       .SYNOPSIS
       Retrieve information for events that match the value specified in any of the following categories: type, status, or ID, and limit events by date.
 
       .DESCRIPTION
-      The Get-RubrikEvent cmdlet is used to pull a event data set from a Rubrik cluster. There are a vast number of arguments 
-      that can be supplied to narrow down the event query. 
+      The Get-RubrikEvent cmdlet is used to pull a event data set from a Rubrik cluster. There are a vast number of arguments
+      that can be supplied to narrow down the event query.
 
       .NOTES
       Written by J.R. Phillips for community usage
-      GitHub: JayAreP     
+      GitHub: JayAreP
 
       .LINK
       https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/get-rubrikevent
@@ -30,59 +30,59 @@ function Get-RubrikEvent
 
       .EXAMPLE
       Get-RubrikHost -Name SQLFoo.demo.com | Get-RubrikEvent -EventType Archive
-      This will feed any Archive events against the Rubrik Host object 'SQLFoo.demo.com' via a piped query. 
+      This will feed any Archive events against the Rubrik Host object 'SQLFoo.demo.com' via a piped query.
 
   #>
 
   [CmdletBinding()]
   Param(
     # Maximum number of events retrieved, default is to return 50 objects
-    [parameter()]
+    [Parameter(ParameterSetName="eventByID")]
     [int]$Limit = 50,
     # Earliest event retrieved
     [Alias('after_id')]
-    [parameter()]
+    [Parameter(ParameterSetName="eventByID")]
     [string]$AfterId,
-    # Filter by Event Series ID 
+    # Filter by Event Series ID
     [Alias('event_series_id')]
-    [parameter()]
+    [Parameter(ParameterSetName='EventSeries',Mandatory=$true)]
     [string]$EventSeriesId,
     # Filter by Status. Enter any of the following values: 'Failure', 'Warning', 'Running', 'Success', 'Canceled', 'Canceling’.
     [ValidateSet('Failure', 'Warning', 'Running', 'Success', 'Canceled', 'Canceling', 'Queued', IgnoreCase = $false)]
-    [parameter()]
+    [Parameter(ParameterSetName="eventByID")]
     [string]$Status,
     # Filter by Event Type.
     [ValidateSet('Archive', 'Audit', 'AuthDomain', 'Backup', 'CloudNativeSource', 'Configuration', 'Diagnostic', 'Discovery', 'Instantiate', 'Maintenance', 'NutanixCluster', 'Recovery', 'Replication', 'StorageArray', 'StormResource', 'System', 'Vcd', 'VCenter', IgnoreCase = $false)]
     [Alias('event_type')]
-    [parameter()]
+    [Parameter(ParameterSetName="eventByID")]
     [string]$EventType,
     # Filter by a comma separated list of object IDs.
     [Alias('object_ids')]
-    [Parameter(ValueFromPipelineByPropertyName = $true)]
+    [Parameter(ValueFromPipelineByPropertyName = $true,ParameterSetName="eventByID")]
     [array]$id,
-    # Filter all the events according to the provided name using infix search for resources and exact search for usernames. 
+    # Filter all the events according to the provided name using infix search for resources and exact search for usernames.
     [Alias('object_name')]
-    [parameter()]
+    [Parameter(ParameterSetName="eventByID")]
     [string]$ObjectName,
     # Filter all the events before a date.
     [Alias('before_date')]
-    [parameter()]
+    [Parameter(ParameterSetName="eventByID")]
     [System.DateTime]$BeforeDate,
     # Filter all the events after a date.
     [Alias('after_date')]
-    [parameter()]
+    [Parameter(ParameterSetName="eventByID")]
     [System.DateTime]$AfterDate,
     # Filter all the events by object type. Enter any of the following values: 'VmwareVm', 'Mssql', 'LinuxFileset', 'WindowsFileset', 'WindowsHost', 'LinuxHost', 'StorageArrayVolumeGroup', 'VolumeGroup', 'NutanixVm', 'Oracle', 'AwsAccount', and 'Ec2Instance'. WindowsHost maps to both WindowsFileset and VolumeGroup, while LinuxHost maps to LinuxFileset and StorageArrayVolumeGroup.
     [Alias('object_type')]
-    [parameter()]
+    [Parameter(ParameterSetName="eventByID")]
     [string]$ObjectType,
     # A switch value that determines whether to show only on the most recent event in the series. When 'true' only the most recent event in the series are shown. When 'false' all events in the series are shown. The default value is 'true'.
     [Alias('show_only_latest')]
-    [parameter()]
+    [Parameter(ParameterSetName="eventByID")]
     [Switch]$ShowOnlyLatest,
     # A Switch value that determines whether to filter only on the most recent event in the series. When 'true' only the most recent event in the series are filtered. When 'false' all events in the series are filtered. The default value is 'true'.
     [Alias('filter_only_on_latest')]
-    [parameter()]
+    [Parameter(ParameterSetName="eventByID")]
     [Switch]$FilterOnlyOnLatest,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
@@ -94,47 +94,52 @@ function Get-RubrikEvent
 
     # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
     # If a command needs to be run with each iteration or pipeline input, place it in the Process section
-    
+
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
-    
+
     # API data references the name of the function
     # For convenience, that name is saved here to $function
     $function = $MyInvocation.MyCommand.Name
-        
+
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
+
   }
 
   Process {
 
-    # If the switch parameter was not explicitly specified remove from query params 
-    if(-not $PSBoundParameters.ContainsKey('ShowOnlyLatest')) { $Resources.Query.Remove('show_only_latest') }
-    if(-not $PSBoundParameters.ContainsKey('FilterOnlyOnLatest')) { $Resources.Query.Remove('filter_only_on_latest') }
+    if (-not $EventSeriesId) {
+      # If the switch parameter was not explicitly specified remove from query params
+      if(-not $PSBoundParameters.ContainsKey('ShowOnlyLatest')) { $Resources.Query.Remove('show_only_latest') }
+      if(-not $PSBoundParameters.ContainsKey('FilterOnlyOnLatest')) { $Resources.Query.Remove('filter_only_on_latest') }
 
-    $uri = New-URIString -server $Server -endpoint ($resources.URI)
-    $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
-    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
-    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
-    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
-    $result = Test-FilterObject -filter ($resources.Filter) -result $result
-    
-    
+      $uri = New-URIString -server $Server -endpoint ($resources.URI)
+      $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+      $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+      $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+      $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+      $result = Test-FilterObject -filter ($resources.Filter) -result $result
+    }
+    else {
+      # Adding property for TypeName support
+      $result = ((Get-RubrikEventSeries -id $EventSeriesId).eventDetailList) | Select *,@{N="eventStatus";E={$_.status}}
+    }
     # Add 'date' property to the output by converting 'time' property to datetime object
     if (($null -ne $result) -and ($null -ne ($result | Select-Object -First 1).time)) {
       $result = $result | ForEach-Object {
         Select-Object -InputObject $_ -Property *,@{
           name = 'date'
           expression = {Convert-APIDateTime -DateTimeString $_.time}
+          }
         }
       }
-    }
     $result = Set-ObjectTypeName -TypeName $resources.ObjectTName -result $result
     return $result
+
 
   } # End of process
 } # End of function

--- a/Rubrik/Public/Get-RubrikEventSeries.ps1
+++ b/Rubrik/Public/Get-RubrikEventSeries.ps1
@@ -92,6 +92,7 @@ function Get-RubrikEventSeries
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
     $result = Test-FilterObject -filter ($resources.Filter) -result $result
+    $result = Set-ObjectTypeName -TypeName $resources.ObjectTName -result $result
 
     return $result
 

--- a/Rubrik/Public/Get-RubrikEventSeries.ps1
+++ b/Rubrik/Public/Get-RubrikEventSeries.ps1
@@ -18,8 +18,19 @@ function Get-RubrikEventSeries
 
       .EXAMPLE
       Get-RubrikEventSeries
-      This will query for all of the event series in the Rubrik Cluster
+      This will query for all of the events belonging to event series in the Rubrik Cluster
 
+      .EXAMPLE
+      Get-RubrikEventSeries -id '1111-2222-3333'
+      This will query for all of the events belonging to the specified event series in the Rubrik Cluster
+
+      .EXAMPLE
+      Get-RubrikEventSeries -Status 'Failure'
+      This will query for all of the failed events belonging to event series in the Rubrik Cluster
+
+      .EXAMPLE
+      Get-RubrikEventSeries -EventType 'Backup'
+      This will query for all of the backup events belonging to event series in the Rubrik Cluster
   #>
 
   [CmdletBinding()]

--- a/Rubrik/Public/Get-RubrikEventSeries.ps1
+++ b/Rubrik/Public/Get-RubrikEventSeries.ps1
@@ -14,7 +14,7 @@ function Get-RubrikEventSeries
       GitHub: mwpreston
 
       .LINK
-      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/Get-rubrikeventseries
+      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/get-rubrikeventseries
 
       .EXAMPLE
       Get-RubrikEventSeries

--- a/Rubrik/Public/Get-RubrikEventSeries.ps1
+++ b/Rubrik/Public/Get-RubrikEventSeries.ps1
@@ -1,0 +1,88 @@
+﻿#requires -Version 3
+function Get-RubrikEventSeries
+{
+  <#
+      .SYNOPSIS
+      Retrieve information for events grouped by event series
+
+      .DESCRIPTION
+      The Get-RubrikEventSeries cmdlet is used to pull a event data from a event series within a Rubrik cluster.
+
+      .NOTES
+      Written by Mike Preston for community usage
+      Twitter: @mwpreston
+      GitHub: mwpreston
+
+      .LINK
+      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/Get-rubrikeventseries
+
+      .EXAMPLE
+      Get-RubrikEventSeries
+      This will query for all of the event series in the Rubrik Cluster
+
+  #>
+
+  [CmdletBinding()]
+  Param(
+    # Filter by Event Series ID
+    [parameter()]
+    [string]$Id,
+    # Filter by Status. Enter any of the following values: 'Failure', 'Warning', 'Running', 'Success', 'Canceled', 'Cancelingâ€™.
+    [ValidateSet('Failure', 'Success', 'Queued', 'Active', IgnoreCase = $false)]
+    [parameter()]
+    [string]$Status,
+    # Filter by Event Type.
+    [ValidateSet('Archive', 'Backup', 'Instantiate', 'Recovery', 'Replication', IgnoreCase = $false)]
+    [Alias('event_type')]
+    [parameter()]
+    [string]$EventType,
+    # Filter by a comma separated list of object IDs.
+    [Alias('object_ids')]
+    [Parameter(ValueFromPipelineByPropertyName = $true)]
+    [array]$objectIds,
+    # Filter all the events according to the provided name using infix search for resources and exact search for usernames.
+    [Alias('object_name')]
+    [parameter()]
+    [string]$ObjectName,
+    # Filter all the events by object type. Enter any of the following values: 'VmwareVm', 'Mssql', 'LinuxFileset', 'WindowsFileset', 'WindowsHost', 'LinuxHost', 'StorageArrayVolumeGroup', 'VolumeGroup', 'NutanixVm', 'Oracle', 'AwsAccount', and 'Ec2Instance'. WindowsHost maps to both WindowsFileset and VolumeGroup, while LinuxHost maps to LinuxFileset and StorageArrayVolumeGroup.
+    [Alias('object_type')]
+    [parameter()]
+    [string]$ObjectType,
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = Get-RubrikAPIData -endpoint $function
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+
+  }
+
+  Process {
+    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+    $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+    $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+    return $result
+
+  } # End of process
+} # End of function

--- a/Rubrik/Public/Get-RubrikEventSeries.ps1
+++ b/Rubrik/Public/Get-RubrikEventSeries.ps1
@@ -18,19 +18,19 @@ function Get-RubrikEventSeries
 
       .EXAMPLE
       Get-RubrikEventSeries
-      This will query for all of the events belonging to event series in the Rubrik Cluster
+      This will return information around the latest event within an event series (within the last 24 hours) from the Rubrik Cluster
 
       .EXAMPLE
       Get-RubrikEventSeries -id '1111-2222-3333'
-      This will query for all of the events belonging to the specified event series in the Rubrik Cluster
+      This will return details for the specified event series, along with its' associated events in the Rubrik Cluster
 
       .EXAMPLE
       Get-RubrikEventSeries -Status 'Failure'
-      This will query for all of the failed events belonging to event series in the Rubrik Cluster
+      This will the latest failed event belonging to each event series (within the last 24 hours) in the Rubrik Cluster
 
       .EXAMPLE
       Get-RubrikEventSeries -EventType 'Backup'
-      This will query for all of the backup events belonging to event series in the Rubrik Cluster
+      This will return the latest backup event belonging to each event series(within the last 24 hours) in the Rubrik Cluster
   #>
 
   [CmdletBinding()]
@@ -92,6 +92,9 @@ function Get-RubrikEventSeries
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
     $result = Test-FilterObject -filter ($resources.Filter) -result $result
+    if ($id) {
+      $resources.ObjectTName = 'Rubrik.EventSeriesById'
+    }
     $result = Set-ObjectTypeName -TypeName $resources.ObjectTName -result $result
 
     return $result

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -72,6 +72,7 @@
                    'ObjectDefinitions/Rubrik.MSSQLDatabaseFiles.ps1xml',
                    'ObjectDefinitions/Rubrik.MSSQLDatabaseMount.ps1xml',
                    'ObjectDefinitions/Rubrik.Event.ps1xml',
+                   'ObjectDefinitions/Rubrik.EventSeries.ps1xml',
                    'ObjectDefinitions/Rubrik.Fileset.ps1xml',
                    'ObjectDefinitions/Rubrik.FilesetTemplate.ps1xml',
                    'ObjectDefinitions/Rubrik.Host.ps1xml',

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -10,340 +10,341 @@
 
     # Script module or binary module file associated with this manifest.
     RootModule = 'Rubrik.psm1'
-    
+
     # Version number of this module.
     ModuleVersion = '5.0.1'
-    
+
     # Supported PSEditions
     # CompatiblePSEditions = @()
-    
+
     # ID used to uniquely identify this module
     GUID = 'a4cb0e3e-b1fe-4da8-9c75-d445e5f96cfb'
-    
+
     # Author of this module
     Author = 'Chris Wahl'
-    
+
     # Company or vendor of this module
     CompanyName = 'Rubrik'
-    
+
     # Copyright statement for this module
     Copyright = '(c) 2015-2020 Rubrik, Inc. All rights reserved.'
-    
+
     # Description of the functionality provided by this module
     Description = 'This is a community project that provides a Windows PowerShell module for managing and monitoring Rubrik''s Cloud Data Management platform.'
-    
+
     # Minimum version of the Windows PowerShell engine required by this module
     PowerShellVersion = '4.0'
-    
+
     # Name of the Windows PowerShell host required by this module
     # PowerShellHostName = ''
-    
+
     # Minimum version of the Windows PowerShell host required by this module
     # PowerShellHostVersion = ''
-    
+
     # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
     # DotNetFrameworkVersion = ''
-    
+
     # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
     # CLRVersion = ''
-    
+
     # Processor architecture (None, X86, Amd64) required by this module
     # ProcessorArchitecture = ''
-    
+
     # Modules that must be imported into the global environment prior to importing this module
     # RequiredModules = @()
-    
+
     # Assemblies that must be loaded prior to importing this module
     # RequiredAssemblies = @()
-    
+
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
     # ScriptsToProcess = @()
-    
+
     # Type files (.ps1xml) to be loaded when importing this module
     # TypesToProcess = @()
-    
+
     # Format files (.ps1xml) to be loaded when importing this module
     FormatsToProcess = @(
-                   'ObjectDefinitions/Rubrik.SLADomain.ps1xml', 
-                   'ObjectDefinitions/Rubrik.VMwareVM.ps1xml', 
-                   'ObjectDefinitions/Rubrik.APIToken.ps1xml', 
-                   'ObjectDefinitions/Rubrik.AvailabilityGroup.ps1xml', 
-                   'ObjectDefinitions/Rubrik.MSSQLDatabase.ps1xml', 
-                   'ObjectDefinitions/Rubrik.MSSQLDatabaseFiles.ps1xml', 
-                   'ObjectDefinitions/Rubrik.MSSQLDatabaseMount.ps1xml', 
-                   'ObjectDefinitions/Rubrik.Event.ps1xml', 
-                   'ObjectDefinitions/Rubrik.Fileset.ps1xml', 
-                   'ObjectDefinitions/Rubrik.FilesetTemplate.ps1xml', 
-                   'ObjectDefinitions/Rubrik.Host.ps1xml', 
+                   'ObjectDefinitions/Rubrik.SLADomain.ps1xml',
+                   'ObjectDefinitions/Rubrik.VMwareVM.ps1xml',
+                   'ObjectDefinitions/Rubrik.APIToken.ps1xml',
+                   'ObjectDefinitions/Rubrik.AvailabilityGroup.ps1xml',
+                   'ObjectDefinitions/Rubrik.MSSQLDatabase.ps1xml',
+                   'ObjectDefinitions/Rubrik.MSSQLDatabaseFiles.ps1xml',
+                   'ObjectDefinitions/Rubrik.MSSQLDatabaseMount.ps1xml',
+                   'ObjectDefinitions/Rubrik.Event.ps1xml',
+                   'ObjectDefinitions/Rubrik.Fileset.ps1xml',
+                   'ObjectDefinitions/Rubrik.FilesetTemplate.ps1xml',
+                   'ObjectDefinitions/Rubrik.Host.ps1xml',
                    'ObjectDefinitions/Rubrik.HyperVHost.ps1xml',
-                   'ObjectDefinitions/Rubrik.HyperVVM.ps1xml', 
-                   'ObjectDefinitions/Rubrik.LDAP.ps1xml', 
-                   'ObjectDefinitions/Rubrik.LogShipping.ps1xml', 
-                   'ObjectDefinitions/Rubrik.ManagedVolume.ps1xml', 
-                   'ObjectDefinitions/Rubrik.NASShare.ps1xml', 
-                   'ObjectDefinitions/Rubrik.ProxySetting.ps1xml', 
-                   'ObjectDefinitions/Rubrik.NutanixVM.ps1xml', 
-                   'ObjectDefinitions/Rubrik.OracleDatabase.ps1xml', 
-                   'ObjectDefinitions/Rubrik.OrgAuthorization.ps1xml', 
-                   'ObjectDefinitions/Rubrik.Report.ps1xml', 
-                   'ObjectDefinitions/Rubrik.MSSQLInstance.ps1xml', 
-                   'ObjectDefinitions/Rubrik.UnmanagedObject.ps1xml', 
+                   'ObjectDefinitions/Rubrik.HyperVVM.ps1xml',
+                   'ObjectDefinitions/Rubrik.LDAP.ps1xml',
+                   'ObjectDefinitions/Rubrik.LogShipping.ps1xml',
+                   'ObjectDefinitions/Rubrik.ManagedVolume.ps1xml',
+                   'ObjectDefinitions/Rubrik.NASShare.ps1xml',
+                   'ObjectDefinitions/Rubrik.ProxySetting.ps1xml',
+                   'ObjectDefinitions/Rubrik.NutanixVM.ps1xml',
+                   'ObjectDefinitions/Rubrik.OracleDatabase.ps1xml',
+                   'ObjectDefinitions/Rubrik.OrgAuthorization.ps1xml',
+                   'ObjectDefinitions/Rubrik.Report.ps1xml',
+                   'ObjectDefinitions/Rubrik.MSSQLInstance.ps1xml',
+                   'ObjectDefinitions/Rubrik.UnmanagedObject.ps1xml',
                    'ObjectDefinitions/Rubrik.vCenter.ps1xml',
                    'ObjectDefinitions/Rubrik.VMwareCluster.ps1xml',
-                   'ObjectDefinitions/Rubrik.VMwareDatacenter.ps1xml', 
-                   'ObjectDefinitions/Rubrik.VMwareDatastore.ps1xml', 
-                   'ObjectDefinitions/Rubrik.VMwareHost.ps1xml', 
-                   'ObjectDefinitions/Rubrik.VolumeGroup.ps1xml', 
-                   'ObjectDefinitions/Rubrik.User.ps1xml', 
+                   'ObjectDefinitions/Rubrik.VMwareDatacenter.ps1xml',
+                   'ObjectDefinitions/Rubrik.VMwareDatastore.ps1xml',
+                   'ObjectDefinitions/Rubrik.VMwareHost.ps1xml',
+                   'ObjectDefinitions/Rubrik.VolumeGroup.ps1xml',
+                   'ObjectDefinitions/Rubrik.User.ps1xml',
                    'ObjectDefinitions/Rubrik.SLADomainv1.ps1xml',
                    'ObjectDefinitions/Rubrik.Scvmm.ps1xml',
                    'ObjectDefinitions/Rubrik.Archive.ps1xml',
                    'ObjectDefinitions/Rubrik.ArchiveDetailed.ps1xml',
                    'ObjectDefinitions/Rubrik.VCDvApp.ps1xml',
                    'ObjectDefinitions/Rubrik.VCDServer.ps1xml')
-    
+
     # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
     # NestedModules = @()
-    
+
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @(
                    'Connect-Rubrik',
                    'Disconnect-Rubrik',
-                   'Export-RubrikDatabase', 
+                   'Export-RubrikDatabase',
                    'Export-RubrikReport',
-                   'Export-RubrikVApp', 
+                   'Export-RubrikVApp',
                    'Export-RubrikVCDTemplate',
                    'Export-RubrikVM',
-                   'Get-RubrikAPIToken', 
+                   'Get-RubrikAPIToken',
                    'Get-RubrikAPIVersion',
                    'Get-RubrikArchive',
-                   'Get-RubrikAvailabilityGroup', 
+                   'Get-RubrikAvailabilityGroup',
                    'Get-RubrikBackupServiceDeployment',
                    'Get-RubrikBootStrap',
-                   'Get-RubrikClusterInfo', 
+                   'Get-RubrikClusterInfo',
                    'Get-RubrikClusterNetworkInterface',
-                   'Get-RubrikClusterStorage', 
+                   'Get-RubrikClusterStorage',
                    'Get-RubrikDatabase',
-                   'Get-RubrikDatabaseFiles', 
+                   'Get-RubrikDatabaseFiles',
                    'Get-RubrikDatabaseMount',
-                   'Get-RubrikDatabaseRecoverableRange', 
+                   'Get-RubrikDatabaseRecoverableRange',
                    'Get-RubrikDatabaseRecoveryPoint',
-                   'Get-RubrikDNSSetting', 
+                   'Get-RubrikDNSSetting',
                    'Get-RubrikEmailSetting',
                    'Get-RubrikEvent',
-                   'Get-RubrikFileset', 
+                   'Get-RubrikEventSeries',
+                   'Get-RubrikFileset',
                    'Get-RubrikFilesetTemplate',
                    'Get-RubrikGuestOSCredential',
                    'Get-RubrikHost',
                    'Get-RubrikHostVolume',
                    'Get-RubrikHyperVHost',
                    'Get-RubrikHyperVMount',
-                   'Get-RubrikHyperVVM', 
+                   'Get-RubrikHyperVVM',
                    'Get-RubrikIPMI',
                    'Get-RubrikLDAP',
                    'Get-RubrikLoginBanner',
-                   'Get-RubrikLogShipping', 
+                   'Get-RubrikLogShipping',
                    'Get-RubrikManagedVolume',
-                   'Get-RubrikManagedVolumeExport', 
+                   'Get-RubrikManagedVolumeExport',
                    'Get-RubrikMount',
                    'Get-RubrikNASShare',
-                   'Get-RubrikNetworkThrottle', 
+                   'Get-RubrikNetworkThrottle',
                    'Get-RubrikNfsArchive',
                    'Get-RubrikNode',
-                   'Get-RubrikNotificationSetting', 
+                   'Get-RubrikNotificationSetting',
                    'Get-RubrikNTPServer',
                    'Get-RubrikNutanixCluster',
                    'Get-RubrikNutanixVM',
-                   'Get-RubrikObject', 
+                   'Get-RubrikObject',
                    'Get-RubrikObjectStoreArchive',
                    'Get-RubrikOracleDB',
-                   'Get-RubrikOrganization', 
+                   'Get-RubrikOrganization',
                    'Get-RubrikOrgAuthorization',
                    'Get-RubrikQstarArchive',
                    'Get-RubrikProxySetting',
                    'Get-RubrikReplicationSource',
-                   'Get-RubrikReplicationTarget', 
+                   'Get-RubrikReplicationTarget',
                    'Get-RubrikReport',
                    'Get-RubrikReportData',
                    'Get-RubrikRequest',
                    'Get-RubrikScvmm',
-                   'Get-RubrikSecurityClassification', 
+                   'Get-RubrikSecurityClassification',
                    'Get-RubrikSetting',
                    'Get-RubrikSLA',
                    'Get-RubrikSmbDomain',
                    'Get-RubrikSmbSecurity',
-                   'Get-RubrikSnapshot', 
+                   'Get-RubrikSnapshot',
                    'Get-RubrikSNMPSetting',
-                   'Get-RubrikSoftwareVersion', 
+                   'Get-RubrikSoftwareVersion',
                    'Get-RubrikSQLInstance',
-                   'Get-RubrikSupportTunnel', 
+                   'Get-RubrikSupportTunnel',
                    'Get-RubrikSyslogServer',
                    'Get-RubrikUnmanagedObject',
                    'Get-RubrikUser',
-                   'Get-RubrikUserRole', 
+                   'Get-RubrikUserRole',
                    'Get-RubrikVApp',
-                   'Get-RubrikVAppExportOption', 
+                   'Get-RubrikVAppExportOption',
                    'Get-RubrikVAppRecoverOption',
-                   'Get-RubrikVAppSnapshot', 
+                   'Get-RubrikVAppSnapshot',
                    'Get-RubrikVCD',
-                   'Get-RubrikVCDTemplateExportOption', 
+                   'Get-RubrikVCDTemplateExportOption',
                    'Get-RubrikVCenter',
                    'Get-RubrikVersion',
-                   'Get-RubrikVM', 
+                   'Get-RubrikVM',
                    'Get-RubrikVMSnapshot',
                    'Get-RubrikVMwareCluster',
                    'Get-RubrikVMwareDatacenter',
-                   'Get-RubrikVMwareDatastore', 
+                   'Get-RubrikVMwareDatastore',
                    'Get-RubrikVMwareHost',
-                   'Get-RubrikVolumeGroup', 
+                   'Get-RubrikVolumeGroup',
                    'Get-RubrikVolumeGroupMount',
-                   'Invoke-RubrikRESTCall', 
+                   'Invoke-RubrikRESTCall',
                    'Move-RubrikMountVMDK',
                    'New-RubrikAPIToken',
-                   'New-RubrikBootStrap', 
+                   'New-RubrikBootStrap',
                    'New-RubrikDatabaseMount',
-                   'New-RubrikFileset', 
+                   'New-RubrikFileset',
                    'New-RubrikFilesetTemplate',
                    'New-RubrikHost',
                    'New-RubrikHyperVVMMount',
-                   'New-RubrikLDAP', 
+                   'New-RubrikLDAP',
                    'New-RubrikLogBackup',
-                   'New-RubrikLogShipping', 
+                   'New-RubrikLogShipping',
                    'New-RubrikManagedVolume',
-                   'New-RubrikManagedVolumeExport', 
+                   'New-RubrikManagedVolumeExport',
                    'New-RubrikMount',
                    'New-RubrikNASShare',
-                   'New-RubrikOrganization', 
+                   'New-RubrikOrganization',
                    'New-RubrikReport',
                    'New-RubrikSLA',
-                   'New-RubrikSnapshot', 
+                   'New-RubrikSnapshot',
                    'New-RubrikUser',
                    'New-RubrikVCenter',
-                   'New-RubrikVMDKMount', 
+                   'New-RubrikVMDKMount',
                    'New-RubrikVolumeGroupMount',
                    'Suspend-RubrikSLA',
-                   'Protect-RubrikDatabase', 
+                   'Protect-RubrikDatabase',
                    'Protect-RubrikFileset',
-                   'Protect-RubrikHyperVVM', 
+                   'Protect-RubrikHyperVVM',
                    'Protect-RubrikNutanixVM',
                    'Protect-RubrikTag',
-                   'Protect-RubrikVApp', 
+                   'Protect-RubrikVApp',
                    'Protect-RubrikVM',
                    'Protect-RubrikVolumeGroup',
-                   'Register-RubrikBackupService', 
+                   'Register-RubrikBackupService',
                    'Remove-RubrikAPIToken',
-                   'Remove-RubrikDatabaseMount', 
+                   'Remove-RubrikDatabaseMount',
                    'Remove-RubrikFileset',
-                   'Remove-RubrikHost', 
+                   'Remove-RubrikHost',
                    'Remove-RubrikHyperVMount',
                    'Remove-RubrikLogShipping',
-                   'Remove-RubrikManagedVolume', 
+                   'Remove-RubrikManagedVolume',
                    'Remove-RubrikManagedVolumeExport',
-                   'Remove-RubrikMount', 
+                   'Remove-RubrikMount',
                    'Remove-RubrikNASShare',
-                   'Remove-RubrikOrganization', 
+                   'Remove-RubrikOrganization',
                    'Remove-RubrikOrgAuthorization',
-                   'Remove-RubrikProxySetting', 
+                   'Remove-RubrikProxySetting',
                    'Remove-RubrikReport',
-                   'Remove-RubrikSLA', 
+                   'Remove-RubrikSLA',
                    'Remove-RubrikUnmanagedObject',
-                   'Remove-RubrikUser', 
+                   'Remove-RubrikUser',
                    'Remove-RubrikVCenter',
-                   'Remove-RubrikVMSnapshot', 
+                   'Remove-RubrikVMSnapshot',
                    'Remove-RubrikVolumeGroupMount',
                    'Reset-RubrikLogShipping',
                    'Resume-RubrikSLA',
                    'Restore-RubrikDatabase',
-                   'Restore-RubrikVApp', 
+                   'Restore-RubrikVApp',
                    'Set-RubrikAvailabilityGroup',
-                   'Set-RubrikBlackout', 
+                   'Set-RubrikBlackout',
                    'Set-RubrikDatabase',
                    'Set-RubrikHyperVVM',
-                   'Set-RubrikLogShipping', 
+                   'Set-RubrikLogShipping',
                    'Set-RubrikManagedVolume',
                    'Set-RubrikMount',
-                   'Set-RubrikNASShare', 
+                   'Set-RubrikNASShare',
                    'Set-RubrikNutanixVM',
-                   'Set-RubrikOrgAuthorization', 
+                   'Set-RubrikOrgAuthorization',
                    'Set-RubrikProxySetting',
                    'Set-RubrikSetting',
-                   'Set-RubrikSLA', 
+                   'Set-RubrikSLA',
                    'Set-RubrikSQLInstance',
                    'Set-RubrikSupportTunnel',
-                   'Set-RubrikUser', 
+                   'Set-RubrikUser',
                    'Set-RubrikUserRole',
                    'Set-RubrikVCD',
-                   'Set-RubrikVCenter', 
+                   'Set-RubrikVCenter',
                    'Set-RubrikVM',
-                   'Set-RubrikVolumeFilterDriver', 
-                   'Start-RubrikManagedVolumeSnapshot', 
+                   'Set-RubrikVolumeFilterDriver',
+                   'Start-RubrikManagedVolumeSnapshot',
                    'Stop-RubrikManagedVolumeSnapshot',
-                   'Sync-RubrikAnnotation', 
+                   'Sync-RubrikAnnotation',
                    'Sync-RubrikTag',
                    'Update-RubrikHost',
-                   'Update-RubrikVCD', 
+                   'Update-RubrikVCD',
                    'Update-RubrikVCenter',
                    'Update-RubrikVMwareVM')
-    
+
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport = @()
-    
+
     # Variables to export from this module
     # VariablesToExport = @()
-    
+
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
     AliasesToExport = @(
                     'Pause-RubrikSLA'
     )
-    
+
     # DSC resources to export from this module
     # DscResourcesToExport = @()
-    
+
     # List of all modules packaged with this module
     # ModuleList = @()
-    
+
     # List of all files packaged with this module
     # FileList = @()
-    
+
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData = @{
-    
+
         PSData = @{
-    
+
             # Tags applied to this module. These help with module discovery in online galleries.
             Tags = 'Rubrik','Cloud_Data_Management','CDM','Backup','Recovery','Data_Protection'
-    
+
             # A URL to the license for this module.
             LicenseUri = 'https://github.com/rubrikinc/rubrik-sdk-for-powershell/blob/master/LICENSE'
-    
+
             # A URL to the main website for this project.
             ProjectUri = 'https://github.com/rubrikinc/rubrik-sdk-for-powershell'
-    
+
             # A URL to an icon representing this module.
             IconUri = 'http://i.imgur.com/Zbdd4Ko.jpg'
-    
+
             # ReleaseNotes of this module
             # ReleaseNotes = ''
-    
+
             # Prerelease string of this module
             # Prerelease = 'devel517'
-    
+
             # Flag to indicate whether the module requires explicit user acceptance for install/update
             # RequireLicenseAcceptance = $false
-    
+
             # External dependent modules of this module
             # ExternalModuleDependencies = @()
-    
+
         } # End of PSData hashtable
-    
+
      } # End of PrivateData hashtable
-    
+
     # HelpInfo URI of this module
     # HelpInfoURI = ''
-    
+
     # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
     # DefaultCommandPrefix = ''
-    
+
     }
-    
-    
+
+

--- a/Tests/Get-RubrikEventSeries.Tests.ps1
+++ b/Tests/Get-RubrikEventSeries.Tests.ps1
@@ -1,0 +1,114 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikEventSeries' -Tag 'Public', 'Get-RubrikEventSeries' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                "taskType" = "Backup"
+                "objectInfo" =@{
+                  "objectId" = "VirtualMachine:::4c0f0c71-1390-4017-9206-f8b16bd7ca8c-vm-102"
+                  "objectName" = "WINVM"
+                  "objectType" = "VmwareVm"
+                }
+                "eventSeriesId" = "b7b95048-9c06-4d22-83cc-ff40099cedf4"
+                "eventId" = "2020-03-10:14:0:::1583848919749-1138d4df-3060-468a-a7ec-dadf022e2c7f"
+                "status" = "Success"
+                "eventDate" = "2020-03-10T14:01:59.749Z"
+            },
+            @{
+                "taskType" = "Backup"
+                "objectInfo" = @{
+                    "objectId"= "VirtualMachine:::4c0f0c71-1390-4017-9206-f8b16bd7ca8c-vm-102"
+                    "objectName"= "WINVM2"
+                    "objectType"= "VmwareVm"
+                }
+                "eventSeriesId"= "5027ec0e-175a-475a-823c-4ad6c3f9aa12"
+                "eventId"= "2020-03-10:14:0:::1583848919651-12064137-8b4c-404d-afaf-f7c6ff1b0a64"
+                "status"= "Scheduled"
+                "eventDate"= "2020-03-10T14:01:59.651Z"
+            },
+            @{
+                "taskType"= "Backup"
+                "objectInfo"= @{
+                    "objectId"= "VirtualMachine:::4c0f0c71-1390-4017-9206-f8b16bd7ca8c-vm-5968"
+                    "objectName"= "WINVM3"
+                    "objectType"= "VmwareVm"
+                }
+                "eventSeriesId"= "4bc9289d-6399-46a3-ba0c-51a1e39fe7e3"
+                "eventId"= "2020-03-10:13:5:::1583848610181-8a435030-bc69-416e-a344-74db8be413b3"
+                "status"= "Success"
+                "eventDate"= "2020-03-10T13:56:50.181Z"
+            }
+        }
+        It -Name 'Should Return count of 3' -Test {
+            (Get-RubrikEventSeries).Count |
+                Should -BeExactly 3
+        }
+        It -Name 'Verify Status ValidateSet' -Test {
+            { Get-RubrikEventSeries -Status 'NonExistant' } |
+                Should -Throw "Cannot validate argument on parameter 'Status'."
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
+    }
+    Context -Name 'Results Filtering with ID' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                "taskType"= "Replication"
+                "objectId"= "MssqlDatabase:::125af122-5925-4a4f-9d26-7fcf0eae01dc"
+                "objectType"= "Mssql"
+                "objectName"= "AdventureWorks2016"
+                "status"= "Success"
+                "startTime"= "2020-03-10T13:46:30.764Z"
+                "endTime"= "2020-03-10T13:46:30.678Z"
+                "total"= "2"
+                "eventDetailList"=
+                  @{
+                    "id"= "1583847985143-d6920ab4-bf0f-4913-b432-87a704c5c721"
+                    "status"= "Running"
+                    "time"= "Tue Mar 10 13:46:25 UTC 2020"
+                    "objectId"= "125af122-5925-4a4f-9d26-7fcf0eae01dc"
+                    "objectType"= "Mssql"
+                    "objectName"= "AdventureWorks2016"
+                  },
+                  @{
+                    "id"= "1583847990678-26601933-fe16-493d-9c1c-afec7988a59b"
+                    "status"= "Success"
+                    "time"= "Tue Mar 10 13:46:30 UTC 2020"
+                    "objectId"= "125af122-5925-4a4f-9d26-7fcf0eae01dc"
+                    "objectType"= "Mssql"
+                    "objectName"= "AdventureWorks2016"
+                  }
+              }
+        }
+        It -Name 'Should return 2 events' -Test {
+            ((Get-RubrikEventSeries -id '11111').eventDetailList).Count |
+                Should -BeExactly 2
+        }
+
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
+    }
+}

--- a/Tests/Get-RubrikEventSeries.Tests.ps1
+++ b/Tests/Get-RubrikEventSeries.Tests.ps1
@@ -15,7 +15,7 @@ Describe -Name 'Public/Get-RubrikEventSeries' -Tag 'Public', 'Get-RubrikEventSer
         header  = @{ 'Authorization' = 'Bearer test-authorization' }
         time    = (Get-Date)
         api     = 'v1'
-        version = '4.0.5'
+        version = '5.1'
     }
     #endregion
 


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

Changed `Get-RubrikEvent`, adding parametersets to isolate eventSeriesId. When cmdlet is called with eventSeriesId the `Get-RubrikEventSeries` cmdlet is now called rather than filtering through a giant, unindexed table. Details in [Issue 580](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/580) and updated unit tests.

## Related Issue

[Issue 580](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/580)

## Motivation and Context

When using the eventSeriesId parameter on Get-RubrikEvent it will now call Get-RubrikEventSeries which in turn calls the API which utilizes the properly indexed table to retrieve events based on eventSeries.

## How Has This Been Tested?

Tested against 5.0 and 5.1 in the TM lab

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
