### PR TITLE
Issue 309 - Individual Snapshot deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Modified `Remove-RubrikVMSnapshot` to support -Confirm before performing action
 * Changed example documentation for `New-RubrikDatabaseMount`
 * Added `-DetailedObject` parameter to `Get-RubrikLogShipping`
 * Updated unit tests for `Get-RubrikLogShipping` to include test for `-DetailedObject` parameter
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added `Remove-RubrikFilesetSnapshot`, `RemoveRubrikDatabaseSnapshots`, `Remove-RubrikHyperVSnapshot`, `Remove-RubrikManagedVolumeSnapshot`, `Remove-RubrikNutanixVMSnapshot`, and `Remove-RubrikVolumeGroupSnapshot` along with associated unit tests as outlined in [Issue 309](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/309) *NOTE Remove-RubrikDatabaseSnapshots deletes ALL snapshots for a given database - there is currently no endpoint to support the deletion of a single snapshot*
 * Added `Suspend-RubrikSLA` and `Resume-RubrikSLA`
 * Added `Get-RubrikEventSeries` to now parse the event_series API rather than events as per [Issue 580](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/580)
 * Added unit tests to cover `Get-RubrikEventSeries` and changes to `Get-RubrikEvent`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Modified Link for `Protect-RubrikVolumeGroup` to lowercase
 * Modified `Remove-RubrikVMSnapshot` to support -Confirm before performing action
+* Updated help for all fileset and fileset template related cmdlets as per [Issue 284](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/284)
 * Changed example documentation for `New-RubrikDatabaseMount`
 * Added `-DetailedObject` parameter to `Get-RubrikLogShipping`
 * Updated unit tests for `Get-RubrikLogShipping` to include test for `-DetailedObject` parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Modified Link for `Protect-RubrikVolumeGroup` to lowercase
 * Modified `Remove-RubrikVMSnapshot` to support -Confirm before performing action
 * Changed example documentation for `New-RubrikDatabaseMount`
 * Added `-DetailedObject` parameter to `Get-RubrikLogShipping`

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -2236,6 +2236,17 @@ function Get-RubrikAPIData {
                 Success     = '202'
             }
         }
+        'Remove-RubrikDatabaseSnapshots'        = @{
+            '1.0' = @{
+                Description = 'Removes all database snapshots for a MSSQL database'
+                URI         = '/api/v1/mssql/db/{id}/snapshot'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Success     = '204'
+            }
+        }
         'Remove-RubrikFileset'         = @{
             '1.0' = @{
                 Description = 'Delete a fileset by specifying the fileset ID'

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -2374,6 +2374,19 @@ function Get-RubrikAPIData {
                 Success     = '202'
             }
         }
+        'Remove-RubrikNutanixVMSnapshot'        = @{
+            '1.0' = @{
+                Description = 'Removes an expired Nutanix VM snapshot available for garbage collection'
+                URI         = '/api/internal/nutanix/vm/snapshot/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = @{
+                    location = 'location'
+                }
+                Result      = ''
+                Success     = '204'
+            }
+        }
         'Remove-RubrikProxySetting'              = @{
             '1.0' = @{
                 Description = 'Remove Rubrik Node Proxy Configuration'

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -2298,6 +2298,19 @@ function Get-RubrikAPIData {
                 Success     = '202'
             }
         }
+        'Remove-RubrikHyperVSnapshot'        = @{
+            '1.0' = @{
+                Description = 'Removes an expired HyperV VM snapshot available for garbage collection'
+                URI         = '/api/internal/hyperv/vm/snapshot/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = @{
+                    location = 'location'
+                }
+                Result      = ''
+                Success     = '204'
+            }
+        }
         'Remove-RubrikManagedVolume'            = @{
             '1.0' = @{
                 Description = 'Delete a managed volume'

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -2530,6 +2530,19 @@ function Get-RubrikAPIData {
                 Success     = '200'
             }
         }
+        'Remove-RubrikVolumeGroupSnapshot'        = @{
+            '1.0' = @{
+                Description = 'Removes an expired Volume Group snapshot available for garbage collection'
+                URI         = '/api/internal/volume_group/snapshot/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = @{
+                    location = 'location'
+                }
+                Result      = ''
+                Success     = '204'
+            }
+        }
         'Restore-RubrikDatabase'       = @{
             '1.0' = @{
                 Description = 'Export MSSQL Database from Rubrik to Destination Instance.'

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -2335,6 +2335,19 @@ function Get-RubrikAPIData {
                 Success     = '204'
             }
         }
+        'Remove-RubrikManagedVolumeSnapshot'        = @{
+            '1.0' = @{
+                Description = 'Removes an expired Managed Volume snapshot available for garbage collection'
+                URI         = '/api/internal/managed_volume/snapshot/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = @{
+                    location = 'location'
+                }
+                Result      = ''
+                Success     = '204'
+            }
+        }
         'Remove-RubrikMount'           = @{
             '1.0' = @{
                 Description = 'Create a request to delete a live mount'

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -2248,6 +2248,19 @@ function Get-RubrikAPIData {
                 Success     = '204'
             }
         }
+        'Remove-RubrikFilesetSnapshot'        = @{
+            '1.0' = @{
+                Description = 'Removes a fileset snapshot'
+                URI         = '/api/v1/fileset/snapshot/{id}'
+                Method      = 'Delete'
+                Body        = ''
+                Query       = @{
+                    location = 'location'
+                }
+                Result      = ''
+                Success     = '204'
+            }
+        }
         'Remove-RubrikHost'            = @{
             '1.0' = @{
                 Description = 'Delete host by specifying the host ID'

--- a/Rubrik/Public/Protect-RubrikVolumeGroup.ps1
+++ b/Rubrik/Public/Protect-RubrikVolumeGroup.ps1
@@ -4,21 +4,21 @@ function Protect-RubrikVolumeGroup
   <#
       .SYNOPSIS
       Connects to Rubrik and assigns an SLA to a VolumeGroup
-            
+
       .DESCRIPTION
       The Protect-RubrikVolumeGroup cmdlet will assign a SLA Domain to Volumes on a window host.
       The SLA Domain contains all policy-driven values needed to protect workloads.
       You can first use Get-RubrikVolumeGroup to get the one volume group you want to protect, and then pipe the results to Protect-RubrikVolumeGroup.
       You can exclude volumes by specifiying the driveletter or the volumeID.
-            
+
       .NOTES
       Written by Pierre Flammer for community usage
       Twitter: @PierreFlammer
       GitHub: Pierre-PvF
-            
+
       .LINK
-      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/Protect-RubrikVolumeGroup
-            
+      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/protect-rubrikvolumegroup
+
       .EXAMPLE
       Protect-RubrikVolumeGroup -id VolumeGroup:::2038fecb-745b-4d2d-8a71-cf2fc0d0be80 -SLA 'Gold'
       This will assign the Gold SLA Domain to the specified Volume Group, including all volumes presently on the system
@@ -50,7 +50,7 @@ function Protect-RubrikVolumeGroup
     [Switch]$DoNotProtect,
     # SLA id value
     [Alias('configuredSlaDomainId')]
-    [String]$SLAID = (Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect -Mandatory:$true),    
+    [String]$SLAID = (Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect -Mandatory:$true),
     # Specifiy MountPoints to be excluded
     [Array]$ExcludeDrive,
     # Specifiy IDs to be excluded (alternative to MountPoints)
@@ -65,20 +65,20 @@ function Protect-RubrikVolumeGroup
 
     # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
     # If a command needs to be run with each iteration or pipeline input, place it in the Process section
-    
+
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
-    
+
     # API data references the name of the function
     # For convenience, that name is saved here to $function
     $function = $MyInvocation.MyCommand.Name
-        
+
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
+
   }
 
   Process {
@@ -91,11 +91,11 @@ function Protect-RubrikVolumeGroup
     #add SLA to body
     $body = @{
         $resources.Body.configuredSlaDomainId = $SLAID
-        volumeIdsIncludedInSnapshots = @() 
+        volumeIdsIncludedInSnapshots = @()
     }
-   
+
     #get hostid of volumegroup
-    $volumegroup = Get-RubrikVolumeGroup -id $id 
+    $volumegroup = Get-RubrikVolumeGroup -id $id
     #get all volumes of the host, so we can exclude drives or IDs
     $volumes = Get-RubrikHostVolume -id $volumegroup.hostid
 
@@ -110,7 +110,7 @@ function Protect-RubrikVolumeGroup
         }
     }
 
-    #remove all excluded IDs 
+    #remove all excluded IDs
     foreach ($volume in $volumes) {
         foreach ($eID in $ExcludeID) {
             if ($eID -eq $volume.id ) {

--- a/Rubrik/Public/Remove-RubriKManagedVolumeSnapshot.ps1
+++ b/Rubrik/Public/Remove-RubriKManagedVolumeSnapshot.ps1
@@ -1,0 +1,80 @@
+﻿#requires -Version 3
+function Remove-RubrikManagedVolumeSnapshot
+{
+  <#
+      .SYNOPSIS
+      Connects to Rubrik and removes an expired managed volume snapshot available for garbage collection.
+
+      .DESCRIPTION
+      The Remove-RubrikManagedVolumeSnapshot cmdlet will request that the Rubrik API delete an an expired managed volume snapshot.
+      The snapshot must a snapshot from a managed volume that is not assigned to an SLA Domain.
+
+      .NOTES
+      Written by Mike Preston for community usage
+      Twitter: @mwpreston
+      GitHub: mwpreston
+
+      .LINK
+      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/remove-rubrikmanagedvolumesnapshot
+
+      .EXAMPLE
+      Remove-RubrikManagedVolumeSnapshot -id '01234567-8910-1abc-d435-0abc1234d567'
+      This will attempt to remove managed volume snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567`
+
+      .EXAMPLE
+      Remove-RubrikManagedVolumeSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location local -Confirm:$false
+      This will attempt to remove the local copy of the managed volume snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567` without user intevention
+
+      .EXAMPLE
+      Get-RubrikManagedVolume -Name ManagedVolume1 | Get-RubrikSnapshot -Date '03/21/2017' | Remove-RubrikManagedVolumeSnapshot
+      This will attempt to remove any snapshot from `03/21/2017` for the managed volume named `ManagedVolume1`.
+  #>
+
+  [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]
+  Param(
+    # ID of the snapshot to delete
+    [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+    [String]$id,
+    # Snapshot location to delete, either "local" or "all". Defaults to "all"
+    [ValidateSet('all','local')]
+    [String]$location = "all",
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [ValidateNotNullorEmpty()]
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = Get-RubrikAPIData -endpoint $function
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+
+  }
+
+  Process {
+    if ($PSCmdlet.ShouldProcess("$id", "Remove snapshot ")) {
+        $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+        $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+        $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+        $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+        $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+        $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+        return $result
+    }
+  } # End of process
+} # End of function

--- a/Rubrik/Public/Remove-RubrikDatabaseSnapshots.ps1
+++ b/Rubrik/Public/Remove-RubrikDatabaseSnapshots.ps1
@@ -1,0 +1,77 @@
+﻿#requires -Version 3
+function Remove-RubrikDatabaseSnapshots
+{
+  <#
+      .SYNOPSIS
+      Connects to Rubrik and removes all database snapshots for a given database.
+
+      .DESCRIPTION
+      The Remove-RubrikFilesetSnapshot cmdlet will request that the Rubrik API delete all snapshots for a given rubrik database.
+      The database must be unprotected for this operation to succeed.
+
+      .NOTES
+      Written by Mike Preston for community usage
+      Twitter: @mwpreston
+      GitHub: mwpreston
+
+      .LINK
+      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/remove-rubrikdatabasesnapshots
+
+      .EXAMPLE
+      Remove-RubrikDatabaseSnapshots -id '01234567-8910-1abc-d435-0abc1234d567'
+      This will attempt to remove all database snapshots for the database with an id of `01234567-8910-1abc-d435-0abc1234d567`
+
+      .EXAMPLE
+      Remove-RubrikDatabaseSnapshots -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false
+      This will attempt to remove all database snapshots for the database with an id of `01234567-8910-1abc-d435-0abc1234d567` without user confirmation
+
+      .EXAMPLE
+      Get-RubrikDatabase -id '1111-2222-3333' |  Remove-RubrikDatabaseSnapshots
+      This will attempt to remove all database snapshots for the database with an id of '1111-2222-3333'
+  #>
+
+  [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]
+  Param(
+    # Database ID of the database to delete snapshots from
+    [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+    [String]$id,
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [ValidateNotNullorEmpty()]
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = Get-RubrikAPIData -endpoint $function
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+
+  }
+
+  Process {
+    if ($PSCmdlet.ShouldProcess("$id", "Remove all snapshots ")) {
+        $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+        $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+        $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+        $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+        $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+        $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+        return $result
+    }
+  } # End of process
+} # End of function

--- a/Rubrik/Public/Remove-RubrikFilesetSnapshot.ps1
+++ b/Rubrik/Public/Remove-RubrikFilesetSnapshot.ps1
@@ -1,0 +1,78 @@
+﻿#requires -Version 3
+function Remove-RubrikVMSnapshot
+{
+  <#
+      .SYNOPSIS
+      Connects to Rubrik and removes an expired fileset snapshot available for garbage collection.
+
+      .DESCRIPTION
+      The Remove-RubrikFilesetSnapshot cmdlet will request that the Rubrik API delete an an expired fileset snapshot.
+
+      .NOTES
+      Written by Mike Preston for community usage
+      Twitter: @mwpreston
+      GitHub: mwpreston
+
+      .LINK
+      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/remove-rubrikfilesetsnapshot
+
+      .EXAMPLE
+      Remove-RubrikFilesetSnapshot -id '01234567-8910-1abc-d435-0abc1234d567'
+      This will attempt to remove fileset snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567`
+
+      .EXAMPLE
+      Remove-RubrikFilesetSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location local
+      This will attempt to remove the local copy of the fileset snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567`
+
+      .EXAMPLE
+      Get-RubrikFileset Fileset1 | Get-RubrikSnapshot -Date '03/21/2017' | Remove-RubrikFilesetSnapshot
+      This will attempt to remove any snapshot from `03/21/2017` for the fileset named `Fileset1`.
+  #>
+
+  [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]
+  Param(
+    # ID of the snapshot to delete
+    [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+    [String]$id,
+    # Snapshot location to delete, either "local" or "all". Defaults to "all"
+    [String]$location = "all",
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [ValidateNotNullorEmpty()]
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = Get-RubrikAPIData -endpoint $function
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+
+  }
+
+  Process {
+
+    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+    $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+    $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+    return $result
+
+  } # End of process
+} # End of function

--- a/Rubrik/Public/Remove-RubrikFilesetSnapshot.ps1
+++ b/Rubrik/Public/Remove-RubrikFilesetSnapshot.ps1
@@ -1,5 +1,5 @@
 ﻿#requires -Version 3
-function Remove-RubrikVMSnapshot
+function Remove-RubrikFilesetSnapshot
 {
   <#
       .SYNOPSIS
@@ -7,6 +7,7 @@ function Remove-RubrikVMSnapshot
 
       .DESCRIPTION
       The Remove-RubrikFilesetSnapshot cmdlet will request that the Rubrik API delete an an expired fileset snapshot.
+      The snapshot must a snapshot from a fileset that is not assigned to an SLA Domain.
 
       .NOTES
       Written by Mike Preston for community usage
@@ -35,6 +36,7 @@ function Remove-RubrikVMSnapshot
     [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
     [String]$id,
     # Snapshot location to delete, either "local" or "all". Defaults to "all"
+    [ValidateSet('all','local')]
     [String]$location = "all",
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,

--- a/Rubrik/Public/Remove-RubrikFilesetSnapshot.ps1
+++ b/Rubrik/Public/Remove-RubrikFilesetSnapshot.ps1
@@ -22,8 +22,8 @@ function Remove-RubrikFilesetSnapshot
       This will attempt to remove fileset snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567`
 
       .EXAMPLE
-      Remove-RubrikFilesetSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location local
-      This will attempt to remove the local copy of the fileset snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567`
+      Remove-RubrikFilesetSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location local -Confirm:$false
+      This will attempt to remove the local copy of the fileset snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567` without user intevention
 
       .EXAMPLE
       Get-RubrikFileset Fileset1 | Get-RubrikSnapshot -Date '03/21/2017' | Remove-RubrikFilesetSnapshot
@@ -66,15 +66,15 @@ function Remove-RubrikFilesetSnapshot
   }
 
   Process {
+    if ($PSCmdlet.ShouldProcess("$id", "Remove snapshot ")) {
+        $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+        $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+        $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+        $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+        $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+        $result = Test-FilterObject -filter ($resources.Filter) -result $result
 
-    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
-    $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
-    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
-    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
-    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
-    $result = Test-FilterObject -filter ($resources.Filter) -result $result
-
-    return $result
-
+        return $result
+    }
   } # End of process
 } # End of function

--- a/Rubrik/Public/Remove-RubrikHyperVSnapshot.ps1
+++ b/Rubrik/Public/Remove-RubrikHyperVSnapshot.ps1
@@ -1,0 +1,81 @@
+﻿#requires -Version 3
+function Remove-RubrikHyperVSnapshot
+{
+  <#
+      .SYNOPSIS
+      Connects to Rubrik and removes an expired HyperV VM snapshot available for garbage collection.
+
+      .DESCRIPTION
+      The Remove-RubrikHyperVSnapshot cmdlet will request that the Rubrik API delete an an expired HyperV VM snapshot.
+      The snapshot must a snapshot from a HyperV VM that is not assigned to an SLA Domain.
+
+      .NOTES
+      Written by Mike Preston for community usage
+      Twitter: @mwpreston
+      GitHub: mwpreston
+
+      .LINK
+      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/remove-rubrikhypervsnapshot
+
+      .EXAMPLE
+      Remove-RubrikHyperVSnapshot -id '01234567-8910-1abc-d435-0abc1234d567'
+      This will attempt to remove HyperV VM snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567`
+
+      .EXAMPLE
+      Remove-RubrikHyperVSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location local -Confirm:$false
+      This will attempt to remove the local copy of the HyperV VM snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567` without user intevention
+
+      .EXAMPLE
+      Get-RubrikHyperVVM VM1 | Get-RubrikSnapshot -Date '03/21/2017' | Remove-RubrikHyperVSnapshot
+      This will attempt to remove any snapshot from `03/21/2017` for the HyperV VM named `VM1`.
+  #>
+
+  [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]
+  Param(
+    # ID of the snapshot to delete
+    [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+    [Alias('SnapshotId')]
+    [String]$id,
+    # Snapshot location to delete, either "local" or "all". Defaults to "all"
+    [ValidateSet('all','local')]
+    [String]$location = "all",
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [ValidateNotNullorEmpty()]
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = Get-RubrikAPIData -endpoint $function
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+
+  }
+
+  Process {
+    if ($PSCmdlet.ShouldProcess("$id", "Remove snapshot ")) {
+        $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+        $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+        $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+        $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+        $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+        $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+        return $result
+    }
+  } # End of process
+} # End of function

--- a/Rubrik/Public/Remove-RubrikNutanixVMSnapshot.ps1
+++ b/Rubrik/Public/Remove-RubrikNutanixVMSnapshot.ps1
@@ -1,0 +1,80 @@
+﻿#requires -Version 3
+function Remove-RubrikNutanixVMSnapshot
+{
+  <#
+      .SYNOPSIS
+      Connects to Rubrik and removes an expired Nutanix VM snapshot available for garbage collection.
+
+      .DESCRIPTION
+      The Remove-RubrikNutanixVMSnapshot cmdlet will request that the Rubrik API delete an an expired Nutanix VM snapshot.
+      The snapshot must a snapshot from a Nutanix VM that is not assigned to an SLA Domain.
+
+      .NOTES
+      Written by Mike Preston for community usage
+      Twitter: @mwpreston
+      GitHub: mwpreston
+
+      .LINK
+      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/remove-rubriknutanixvmsnapshot
+
+      .EXAMPLE
+      Remove-RubrikNutanixVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567'
+      This will attempt to remove Nutanix VM snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567`
+
+      .EXAMPLE
+      Remove-RubrikNutanixVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location local -Confirm:$false
+      This will attempt to remove the local copy of the Nutanix VM snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567` without user intevention
+
+      .EXAMPLE
+      Get-RubrikNutanixVM VM1 | Get-RubrikSnapshot -Date '03/21/2017' | Remove-RubrikNutanixVMSnapshot
+      This will attempt to remove any snapshot from `03/21/2017` for the Nutanix VM named `VM1`.
+  #>
+
+  [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]
+  Param(
+    # ID of the snapshot to delete
+    [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+    [String]$id,
+    # Snapshot location to delete, either "local" or "all". Defaults to "all"
+    [ValidateSet('all','local')]
+    [String]$location = "all",
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [ValidateNotNullorEmpty()]
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = Get-RubrikAPIData -endpoint $function
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+
+  }
+
+  Process {
+    if ($PSCmdlet.ShouldProcess("$id", "Remove snapshot ")) {
+        $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+        $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+        $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+        $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+        $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+        $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+        return $result
+    }
+  } # End of process
+} # End of function

--- a/Rubrik/Public/Remove-RubrikVMSnapshot.ps1
+++ b/Rubrik/Public/Remove-RubrikVMSnapshot.ps1
@@ -1,29 +1,29 @@
 #requires -Version 3
 function Remove-RubrikVMSnapshot
 {
-  <#  
+  <#
       .SYNOPSIS
       Connects to Rubrik and removes an expired VMware VM snapshot available for garbage collection.
-            
+
       .DESCRIPTION
       The Remove-RubrikVMSnapshot cmdlet will request that the Rubrik API delete an an expired VMware VM snapshot.
       The snapshot must be an on-demand snapshot or a snapshot from a virtual machine that is not assigned to an SLA Domain.
-            
+
       .NOTES
       Written by Matt Elliott for community usage
       Twitter: @NetworkBrouhaha
       GitHub: shamsway
-            
+
       .LINK
       https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/remove-rubrikvmsnapshot
-           
+
       .EXAMPLE
       Remove-RubrikVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567'
       This will attempt to remove VM snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567`
 
       .EXAMPLE
-      Remove-RubrikVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location local
-      This will attempt to remove the local copy of the VM snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567`
+      Remove-RubrikVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location local -Confirm:$false
+      This will attempt to remove the local copy of the VM snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567` without user intevention
 
       .EXAMPLE
       Get-RubrikVM OldVM1 | Get-RubrikSnapshot -Date '03/21/2017' | Remove-RubrikVMSnapshot
@@ -48,32 +48,32 @@ function Remove-RubrikVMSnapshot
 
     # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
     # If a command needs to be run with each iteration or pipeline input, place it in the Process section
-    
+
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
-    
+
     # API data references the name of the function
     # For convenience, that name is saved here to $function
     $function = $MyInvocation.MyCommand.Name
-        
+
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
+
   }
 
   Process {
+    if ($PSCmdlet.ShouldProcess("$id", "Remove snapshot ")) {
+      $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+      $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+      $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+      $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+      $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+      $result = Test-FilterObject -filter ($resources.Filter) -result $result
 
-    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
-    $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
-    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
-    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
-    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
-    $result = Test-FilterObject -filter ($resources.Filter) -result $result
-
-    return $result
-
+      return $result
+    }
   } # End of process
 } # End of function

--- a/Rubrik/Public/Remove-RubrikVolumeGroupSnapshot.ps1
+++ b/Rubrik/Public/Remove-RubrikVolumeGroupSnapshot.ps1
@@ -1,0 +1,80 @@
+﻿#requires -Version 3
+function Remove-RubrikVolumeGroupSnapshot
+{
+  <#
+      .SYNOPSIS
+      Connects to Rubrik and removes an expired Volume Group snapshot available for garbage collection.
+
+      .DESCRIPTION
+      The Remove-RubrikVolumeGroupSnapshot cmdlet will request that the Rubrik API delete an an expired Volume Group snapshot.
+      The snapshot must a snapshot from a Volume Group that is not assigned to an SLA Domain.
+
+      .NOTES
+      Written by Mike Preston for community usage
+      Twitter: @mwpreston
+      GitHub: mwpreston
+
+      .LINK
+      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/remove-rubrikvolumegroupsnapshot
+
+      .EXAMPLE
+      Remove-RubrikVolumeGroupSnapshot -id '01234567-8910-1abc-d435-0abc1234d567'
+      This will attempt to remove Volume Group snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567`
+
+      .EXAMPLE
+      Remove-RubrikVolumeGroupSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location local -Confirm:$false
+      This will attempt to remove the local copy of the Volume Group snapshot (backup) data with the snapshot id `01234567-8910-1abc-d435-0abc1234d567` without user intevention
+
+      .EXAMPLE
+      Get-RubrikVolumeGroup -Name VG1 | Get-RubrikSnapshot -Date '03/21/2017' | Remove-RubrikVolumeGroupSnapshot
+      This will attempt to remove any snapshot from `03/21/2017` for the Volume Group named `VG1`.
+  #>
+
+  [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High')]
+  Param(
+    # ID of the snapshot to delete
+    [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+    [String]$id,
+    # Snapshot location to delete, either "local" or "all". Defaults to "all"
+    [ValidateSet('all','local')]
+    [String]$location = "all",
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [ValidateNotNullorEmpty()]
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = Get-RubrikAPIData -endpoint $function
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+
+  }
+
+  Process {
+    if ($PSCmdlet.ShouldProcess("$id", "Remove snapshot ")) {
+        $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+        $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+        $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+        $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+        $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+        $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+        return $result
+    }
+  } # End of process
+} # End of function

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -240,6 +240,7 @@
                    'Remove-RubrikFilesetSnapshot',
                    'Remove-RubrikHost',
                    'Remove-RubrikHyperVMount',
+                   'Remove-RubrikHyperVSnapshot',
                    'Remove-RubrikLogShipping',
                    'Remove-RubrikManagedVolume',
                    'Remove-RubrikManagedVolumeExport',

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -235,6 +235,7 @@
                    'Register-RubrikBackupService',
                    'Remove-RubrikAPIToken',
                    'Remove-RubrikDatabaseMount',
+                   'Remove-RubrikDatabaseSnapshots',
                    'Remove-RubrikFileset',
                    'Remove-RubrikFilesetSnapshot',
                    'Remove-RubrikHost',

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -247,6 +247,7 @@
                    'Remove-RubrikManagedVolumeSnapshot',
                    'Remove-RubrikMount',
                    'Remove-RubrikNASShare',
+                   'Remove-RubrikNutanixVMSnapshot',
                    'Remove-RubrikOrganization',
                    'Remove-RubrikOrgAuthorization',
                    'Remove-RubrikProxySetting',

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -258,6 +258,7 @@
                    'Remove-RubrikVCenter',
                    'Remove-RubrikVMSnapshot',
                    'Remove-RubrikVolumeGroupMount',
+                   'Remove-RubrikVolumeGroupSnapshot',
                    'Reset-RubrikLogShipping',
                    'Resume-RubrikSLA',
                    'Restore-RubrikDatabase',

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -236,6 +236,7 @@
                    'Remove-RubrikAPIToken',
                    'Remove-RubrikDatabaseMount',
                    'Remove-RubrikFileset',
+                   'Remove-RubrikFilesetSnapshot',
                    'Remove-RubrikHost',
                    'Remove-RubrikHyperVMount',
                    'Remove-RubrikLogShipping',

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -244,6 +244,7 @@
                    'Remove-RubrikLogShipping',
                    'Remove-RubrikManagedVolume',
                    'Remove-RubrikManagedVolumeExport',
+                   'Remove-RubrikManagedVolumeSnapshot',
                    'Remove-RubrikMount',
                    'Remove-RubrikNASShare',
                    'Remove-RubrikOrganization',

--- a/Tests/Remove-RubrikDatabaseSnapshots.Tests.ps1
+++ b/Tests/Remove-RubrikDatabaseSnapshots.Tests.ps1
@@ -1,0 +1,50 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Remove-RubrikDatabaseSnapshots' -Tag 'Public', 'Remove-RubrikDatabaseSnapshots' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Parameters' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                Status = 'Success'
+                HTTPStatusCode = 204
+            }
+        }
+        It -Name 'Should Return status of Success' -Test {
+            ( Remove-RubrikDatabaseSnapshots -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).Status |
+                Should -BeExactly 'Success'
+        }
+
+        It -Name 'Should Return HTTP status code 204' -Test {
+            ( Remove-RubrikDatabaseSnapshots -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).HTTPStatusCode |
+                Should -BeExactly 204
+        }
+
+        Context -Name 'Parameter Validation' {
+            It -Name 'Parameter id cannot be $null or empty' -Test {
+                { Remove-RubrikDatabaseSnapshots -id $null -Confirm:$false } |
+                    Should -Throw "Cannot bind argument to parameter 'id' because it is an empty string."
+            }
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}

--- a/Tests/Remove-RubrikFilesetSnapshot.Tests.ps1
+++ b/Tests/Remove-RubrikFilesetSnapshot.Tests.ps1
@@ -1,0 +1,54 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Remove-RubrikFilesetSnapshot' -Tag 'Public', 'Remove-RubrikFilesetSnapshot' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Parameters' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                Status = 'Success'
+                HTTPStatusCode = 204
+            }
+        }
+        It -Name 'Should Return status of Success' -Test {
+            ( Remove-RubrikFilesetSnapshot -id '01234567-8910-1abc-d435-0abc1234d567').Status |
+                Should -BeExactly 'Success'
+        }
+
+        It -Name 'Should Return HTTP status code 204' -Test {
+            ( Remove-RubrikFilesetSnapshot -id '01234567-8910-1abc-d435-0abc1234d567').HTTPStatusCode |
+                Should -BeExactly 204
+        }
+
+        Context -Name 'Parameter Validation' {
+            It -Name 'Parameter id cannot be $null or empty' -Test {
+                { Remove-RubrikFilesetSnapshot -id $null } |
+                    Should -Throw "Cannot bind argument to parameter 'id' because it is an empty string."
+            }
+            It -Name 'Location parameter set validation should fail' -Test {
+                { Remove-RubrikFilesetSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location 'nonexistant' } |
+                    Should -Throw "Cannot validate argument"
+            }
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}

--- a/Tests/Remove-RubrikHyperVSnapshot.Tests.ps1
+++ b/Tests/Remove-RubrikHyperVSnapshot.Tests.ps1
@@ -1,11 +1,11 @@
-Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
 Import-Module -Name './Rubrik/Rubrik.psd1' -Force
 
 foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
     . $privateFunctionFilePath
 }
 
-Describe -Name 'Public/Remove-RubrikFilesetSnapshot' -Tag 'Public', 'Remove-RubrikFilesetSnapshot' -Fixture {
+Describe -Name 'Public/Remove-RubrikHyperVSnapshot' -Tag 'Public', 'Remove-RubrikHyperVSnapshot' -Fixture {
     #region init
     $global:rubrikConnection = @{
         id      = 'test-id'
@@ -28,22 +28,22 @@ Describe -Name 'Public/Remove-RubrikFilesetSnapshot' -Tag 'Public', 'Remove-Rubr
             }
         }
         It -Name 'Should Return status of Success' -Test {
-            ( Remove-RubrikFilesetSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).Status |
+            ( Remove-RubrikHyperVSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).Status |
                 Should -BeExactly 'Success'
         }
 
         It -Name 'Should Return HTTP status code 204' -Test {
-            ( Remove-RubrikFilesetSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).HTTPStatusCode |
+            ( Remove-RubrikHyperVSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).HTTPStatusCode |
                 Should -BeExactly 204
         }
 
         Context -Name 'Parameter Validation' {
             It -Name 'Parameter id cannot be $null or empty' -Test {
-                { Remove-RubrikFilesetSnapshot -id $null -Confirm:$false } |
+                { Remove-RubrikHyperVSnapshot -id $null -Confirm:$false} |
                     Should -Throw "Cannot bind argument to parameter 'id' because it is an empty string."
             }
             It -Name 'Location parameter set validation should fail' -Test {
-                { Remove-RubrikFilesetSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location 'nonexistant' } |
+                { Remove-RubrikHyperVSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location 'nonexistant' } |
                     Should -Throw "Cannot validate argument"
             }
         }

--- a/Tests/Remove-RubrikManagedVolumeSnapshot.Tests.ps1
+++ b/Tests/Remove-RubrikManagedVolumeSnapshot.Tests.ps1
@@ -1,0 +1,54 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Remove-RubrikManagedVolumeSnapshot' -Tag 'Public', 'Remove-RubrikManagedVolumeSnapshot' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Parameters' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                Status = 'Success'
+                HTTPStatusCode = 204
+            }
+        }
+        It -Name 'Should Return status of Success' -Test {
+            ( Remove-RubrikManagedVolumeSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).Status |
+                Should -BeExactly 'Success'
+        }
+
+        It -Name 'Should Return HTTP status code 204' -Test {
+            ( Remove-RubrikManagedVolumeSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).HTTPStatusCode |
+                Should -BeExactly 204
+        }
+
+        Context -Name 'Parameter Validation' {
+            It -Name 'Parameter id cannot be $null or empty' -Test {
+                { Remove-RubrikManagedVolumeSnapshot -id $null -Confirm:$false} |
+                    Should -Throw "Cannot bind argument to parameter 'id' because it is an empty string."
+            }
+            It -Name 'Location parameter set validation should fail' -Test {
+                { Remove-RubrikManagedVolumeSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location 'nonexistant' } |
+                    Should -Throw "Cannot validate argument"
+            }
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}

--- a/Tests/Remove-RubrikNutanixVMSnapshot.Tests.ps1
+++ b/Tests/Remove-RubrikNutanixVMSnapshot.Tests.ps1
@@ -1,0 +1,54 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Remove-RubrikNutanixVMSnapshot' -Tag 'Public', 'Remove-RubrikNutanixVMSnapshot' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Parameters' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                Status = 'Success'
+                HTTPStatusCode = 204
+            }
+        }
+        It -Name 'Should Return status of Success' -Test {
+            ( Remove-RubrikNutanixVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).Status |
+                Should -BeExactly 'Success'
+        }
+
+        It -Name 'Should Return HTTP status code 204' -Test {
+            ( Remove-RubrikNutanixVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).HTTPStatusCode |
+                Should -BeExactly 204
+        }
+
+        Context -Name 'Parameter Validation' {
+            It -Name 'Parameter id cannot be $null or empty' -Test {
+                { Remove-RubrikNutanixVMSnapshot -id $null -Confirm:$false} |
+                    Should -Throw "Cannot bind argument to parameter 'id' because it is an empty string."
+            }
+            It -Name 'Location parameter set validation should fail' -Test {
+                { Remove-RubrikNutanixVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location 'nonexistant' } |
+                    Should -Throw "Cannot validate argument"
+            }
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}

--- a/Tests/Remove-RubrikVMSnapshot.Tests.ps1
+++ b/Tests/Remove-RubrikVMSnapshot.Tests.ps1
@@ -28,18 +28,18 @@ Describe -Name 'Public/Remove-RubrikVMSnapshot' -Tag 'Public', 'Remove-RubrikVMS
             }
         }
         It -Name 'Should Return status of Success' -Test {
-            ( Remove-RubrikVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567').Status |
+            ( Remove-RubrikVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).Status |
                 Should -BeExactly 'Success'
         }
 
         It -Name 'Should Return HTTP status code 204' -Test {
-            ( Remove-RubrikVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567').HTTPStatusCode |
+            ( Remove-RubrikVMSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).HTTPStatusCode |
                 Should -BeExactly 204
         }
 
         Context -Name 'Parameter Validation' {
             It -Name 'Parameter id cannot be $null or empty' -Test {
-                { Remove-RubrikVMSnapshot -id $null } |
+                { Remove-RubrikVMSnapshot -id $null -Confirm:$false} |
                     Should -Throw "Cannot bind argument to parameter 'id' because it is an empty string."
             }
         }

--- a/Tests/Remove-RubrikVolumeGroupSnapshot.Tests.ps1
+++ b/Tests/Remove-RubrikVolumeGroupSnapshot.Tests.ps1
@@ -1,0 +1,54 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Remove-RubrikVolumeGroupSnapshot' -Tag 'Public', 'Remove-RubrikVolumeGroupSnapshot' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Parameters' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                Status = 'Success'
+                HTTPStatusCode = 204
+            }
+        }
+        It -Name 'Should Return status of Success' -Test {
+            ( Remove-RubrikVolumeGroupSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).Status |
+                Should -BeExactly 'Success'
+        }
+
+        It -Name 'Should Return HTTP status code 204' -Test {
+            ( Remove-RubrikVolumeGroupSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -Confirm:$false).HTTPStatusCode |
+                Should -BeExactly 204
+        }
+
+        Context -Name 'Parameter Validation' {
+            It -Name 'Parameter id cannot be $null or empty' -Test {
+                { Remove-RubrikVolumeGroupSnapshot -id $null -Confirm:$false} |
+                    Should -Throw "Cannot bind argument to parameter 'id' because it is an empty string."
+            }
+            It -Name 'Location parameter set validation should fail' -Test {
+                { Remove-RubrikVolumeGroupSnapshot -id '01234567-8910-1abc-d435-0abc1234d567' -location 'nonexistant' } |
+                    Should -Throw "Cannot validate argument"
+            }
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}


### PR DESCRIPTION
# Description

This PR adds `Remove-RubrikFilesetSnapshot`, `RemoveRubrikDatabaseSnapshots`, `Remove-RubrikHyperVSnapshot`, `Remove-RubrikManagedVolumeSnapshot`, `Remove-RubrikNutanixVMSnapshot`, and `Remove-RubrikVolumeGroupSnapshot` along with associated unit tests

*NOTE Remove-RubrikDatabaseSnapshots deletes ALL snapshots for a given database - there is currently no endpoint to support the deletion of a single snapshot*

Also included is the addition of a confirmation prompt to `Remove-RubrikVMSnapshot`

## Related Issue

[Issue 309](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/309) 

## Motivation and Context

Allows customers to delete expired snapshots manually from their clusters

## How Has This Been Tested?

Tested against 5.0 and 5.1 in the TM lab

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
