### PR TITLE
Issue 594 Export-RubrikVM cmdlet's -PowerOn switch defaults to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Modified default behavior for `Export-RubrikVM`, when -PowerOn is not specified it will send `"powerOn": false` to the endpoint [Issue 594](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/594)
 * Modified Link for `Protect-RubrikVolumeGroup` to lowercase
 * Modified `Remove-RubrikVMSnapshot` to support -Confirm before performing action
 * Updated help for all fileset and fileset template related cmdlets as per [Issue 284](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/284)

--- a/Rubrik/Public/Export-RubrikVM.ps1
+++ b/Rubrik/Public/Export-RubrikVM.ps1
@@ -91,9 +91,9 @@ function Export-RubrikVM
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
     $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
     if (-not $PowerOn) {
-      $temphash = $body | ConvertFrom-Json -AsHashtable
-      $temphash.Add('powerOn', $false)
-      $body = $temphash | ConvertTo-Json
+      $tempobject = $body | ConvertFrom-Json
+      $tempobject = Add-Member -InputObject $tempobject -MemberType NoteProperty -Name 'powerOn' -Value $false -PassThru
+      $body = $tempobject | ConvertTo-Json
     }
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result

--- a/Rubrik/Public/Export-RubrikVM.ps1
+++ b/Rubrik/Public/Export-RubrikVM.ps1
@@ -90,11 +90,15 @@ function Export-RubrikVM
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
     $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+    if (-not $PowerOn) {
+      $temphash = $body | ConvertFrom-Json -AsHashtable
+      $temphash.Add('powerOn', $false)
+      $body = $temphash | ConvertTo-Json
+    }
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
     $result = Test-FilterObject -filter ($resources.Filter) -result $result
 
     return $result
-
   } # End of process
 } # End of function

--- a/Rubrik/Public/Export-RubrikVM.ps1
+++ b/Rubrik/Public/Export-RubrikVM.ps1
@@ -90,10 +90,11 @@ function Export-RubrikVM
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
     $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
-    if (-not $PowerOn) {
+    if (-not $PowerOn -and (-not ($body -match 'powerOn'))) {
       $tempobject = $body | ConvertFrom-Json
       $tempobject = Add-Member -InputObject $tempobject -MemberType NoteProperty -Name 'powerOn' -Value $false -PassThru
       $body = $tempobject | ConvertTo-Json
+      Write-Verbose -Message "Updated Body = $body"
     }
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result

--- a/Tests/Export-RubrikVM.Tests.ps1
+++ b/Tests/Export-RubrikVM.Tests.ps1
@@ -125,7 +125,7 @@ Describe -Name 'Public/Export-RubrikVM' -Tag 'Public', 'Export-RubrikVM' -Fixtur
             $Output = & {
                 Export-RubrikVM -id 1 -HostId 3 -DatastoreId 2 -Verbose 4>&1
             }
-            (-join $Output) | Should -Not -BeLike '*PowerOn*'
+            (-join $Output) | Should -BeLike '*PowerOn*false*'
         }
         
         It -Name 'Verify switch param - RecoverTags:$true - Switch Param' -Test {


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

Current Behavior:

When using the Export-RubrikVM cmdlet the VMs power on even if you do NOT pass the -PowerOn switch. Looking at the help it appears this switch is incorrectly set with a default of true. This means if you don't pass the switch the VM Powers On and if you do pass the switch the VM Powers On. There is no way to ensure the VM doesn't Power On.

Expected Behavior:
It is expect if you do not pass the switch -PowerOn then the VM will not Power On after it has been exported.

## Related Issue

Resolves #594

## Motivation and Context

The PowerOn switch does not function as expected

## How Has This Been Tested?

* Ran existing unit tests

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
