### PR TITLE
Issue 345 - Various Unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Added $rubrikConnections = $null to `Connect-Rubrik.Tests.ps1` in order to allow test to be ran within the same PS session of which it ran previously.
+* Added parameters to `New-RubrikvCenter` and `Set-RubrikvCenter` allowing users to send username/password or credential objects to the cmdlets. This allows true scripting of these cmdlets rather than prompting for credentials by default.
 * Added -Force parameter and confirmation prompts to `Remove-RubrikUnmanagedObject`. This allows for the deletion of snapshots protected by retention SLAs as per [Issue 314](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/314)
 * Modified default behavior for `Export-RubrikVM`, when -PowerOn is not specified it will send `"powerOn": false` to the endpoint [Issue 594](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/594)
 * Modified Link for `Protect-RubrikVolumeGroup` to lowercase
@@ -33,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added unit tests for `New-RubrikLDAP`, `Get-RubrikvCenter`, `New-RubrikvCenter`, `Remove-RubrikvCenter`, `Set-RubrikvCenter`, `Get-RubrikSetting`, `Set-RubrikSetting`, and `Remove-RubrikHost` as per [Issue 345](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/345)
 * Added new unit tests: `CommentBasedHelp`, `ObjectDefinitions`, `Connect-Rubrik`, `Disconnect-Rubrik`
 * Added `Remove-RubrikFilesetSnapshot`, `RemoveRubrikDatabaseSnapshots`, `Remove-RubrikHyperVSnapshot`, `Remove-RubrikManagedVolumeSnapshot`, `Remove-RubrikNutanixVMSnapshot`, and `Remove-RubrikVolumeGroupSnapshot` along with associated unit tests as outlined in [Issue 309](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/309) *NOTE Remove-RubrikDatabaseSnapshots deletes ALL snapshots for a given database - there is currently no endpoint to support the deletion of a single snapshot*
 * Added `Suspend-RubrikSLA` and `Resume-RubrikSLA`

--- a/Rubrik/Public/New-RubrikVCenter.ps1
+++ b/Rubrik/Public/New-RubrikVCenter.ps1
@@ -1,22 +1,22 @@
 #Requires -Version 3
 function New-RubrikVCenter
 {
-  <#  
+  <#
       .SYNOPSIS
       Connects to Rubrik and creates new vCenter connection
-            
+
       .DESCRIPTION
       The New-RubrikVCenter cmdlet will  creates new vCenter connection on the system. This does require authentication.
-            
+
       .NOTES
       Adapted by Adam Shuttleworth from scripts by Chris Wahl for community usage
-            
+
       .LINK
       https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/new-rubrikvcenter
-            
+
       .EXAMPLE
       New-RubrikVCenter -hostname "test-vcenter.domain.com"
-      This will creates new vCenter connection to "test-vcenter.domain.com" on the current Rubrik cluster  
+      This will creates new vCenter connection to "test-vcenter.domain.com" on the current Rubrik cluster
   #>
 
   [CmdletBinding()]
@@ -24,6 +24,18 @@ function New-RubrikVCenter
     # Hostname (FQDN) of your vCenter Server
     [Parameter(Mandatory=$True)]
     [string]$Hostname,
+    # Username with permissions to connect to the vCenter
+    # Optionally, use the Credential parameter
+    [Parameter(ParameterSetName='UserPassword',Mandatory=$true)]
+    [String]$Username,
+    # Password for the Username provided
+    # Optionally, use the Credential parameter
+    [Parameter(ParameterSetName='UserPassword',Mandatory=$true)]
+    [SecureString]$Password,
+    # Credentials with permission to connect to the vCenter
+    # Optionally, use the Username and Password parameters
+    [Parameter(ParameterSetName='Credential',Mandatory=$true)]
+    [System.Management.Automation.CredentialAttribute()] $Credential,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
     # ID of the Rubrik cluster or me for self
@@ -37,23 +49,29 @@ function New-RubrikVCenter
 
     # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
     # If a command needs to be run with each iteration or pipeline input, place it in the Process section
-    $Credentials=$(Get-Credential -Message "Type vCenter Credentials.")
-    $username = $Credentials.UserName
-    $password = $Credentials.GetNetworkCredential().Password
+
+    if ($Credential) {
+      $usernameforbody = $Credential.UserName
+      $passwordforbody = $Credential.GetNetworkCredential().Password
+    }
+    elseif ($Username) {
+      $usernameforbody = $Username
+      $passwordforbody = ConvertFrom-SecureString -SecureString $password -AsPlainText
+    }
 
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
-    
+
     # API data references the name of the function
     # For convenience, that name is saved here to $function
     $function = $MyInvocation.MyCommand.Name
-        
+
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
+
   }
 
   Process {
@@ -65,14 +83,14 @@ function New-RubrikVCenter
 
     $body = @{
         $resources.Body.hostname = $hostname
-        $resources.Body.username = $username
-        $resources.Body.password = $password
+        $resources.Body.username = $usernameforbody
+        $resources.Body.password = $passwordforbody
     }
-        
+
     $body = ConvertTo-Json $body
     Write-Verbose -Message "Body = $body"
     #endregion
-    
+
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
     #$uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
     #$body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)

--- a/Rubrik/Public/New-RubrikVCenter.ps1
+++ b/Rubrik/Public/New-RubrikVCenter.ps1
@@ -56,7 +56,7 @@ function New-RubrikVCenter
     }
     elseif ($Username) {
       $usernameforbody = $Username
-      $passwordforbody = ConvertFrom-SecureString -SecureString $password -AsPlainText
+      $passwordforbody = ConvertFrom-SecureString -SecureString $password -AsPlainText -Force
     }
 
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication

--- a/Rubrik/Public/Set-RubrikVCenter.ps1
+++ b/Rubrik/Public/Set-RubrikVCenter.ps1
@@ -1,19 +1,19 @@
 #Requires -Version 3
 function Set-RubrikVCenter
 {
-    <#  
+    <#
         .SYNOPSIS
         Connects to Rubrik and modifies an existing vCenter connection
-            
+
         .DESCRIPTION
         The Set-RubrikVCenter cmdlet will modifies an existing vCenter connection on the system. This does require authentication.
-            
+
         .NOTES
         Adapted by Adam Shuttleworth from scripts by Chris Wahl for community usage
-            
+
         .LINK
         https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/set-rubrikvcenter
-            
+
         .EXAMPLE
         Set-RubrikVCenter -hostname "test-vcenter.domain.com"
         This will return the running cluster settings on the Rubrik cluster.
@@ -27,6 +27,18 @@ function Set-RubrikVCenter
     # vCenter Hostname (FQDN)
     [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
     [string]$Hostname,
+    # Username with permissions to connect to the vCenter
+    # Optionally, use the Credential parameter
+    [Parameter(ParameterSetName='UserPassword',Mandatory=$true)]
+    [String]$Username,
+    # Password for the Username provided
+    # Optionally, use the Credential parameter
+    [Parameter(ParameterSetName='UserPassword',Mandatory=$true)]
+    [SecureString]$Password,
+    # Credentials with permission to connect to the vCenter
+    # Optionally, use the Username and Password parameters
+    [Parameter(ParameterSetName='Credential',Mandatory=$true)]
+    [System.Management.Automation.CredentialAttribute()] $Credential,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
     # API version
@@ -39,23 +51,32 @@ function Set-RubrikVCenter
     # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
     # If a command needs to be run with each iteration or pipeline input, place it in the Process section
     $id = $Encode = [System.Web.HttpUtility]::UrlEncode($id)
-    $Credentials=$(Get-Credential -Message "Type vCenter Credentials.")
-    $username = $Credentials.UserName
-    $password = $Credentials.GetNetworkCredential().Password
+
+    if ($Credential) {
+        $usernameforbody = $Credential.UserName
+        $passwordforbody = $Credential.GetNetworkCredential().Password
+      }
+      elseif ($Username) {
+        $usernameforbody = $Username
+        $passwordforbody = ConvertFrom-SecureString -SecureString $password -AsPlainText -Force
+    }
+    #$Credentials=$(Get-Credential -Message "Type vCenter Credentials.")
+    #$username = $Credentials.UserName
+    #$password = $Credentials.GetNetworkCredential().Password
 
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
-    
+
     # API data references the name of the function
     # For convenience, that name is saved here to $function
     $function = $MyInvocation.MyCommand.Name
-        
+
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
+
     }
 
     Process {
@@ -64,14 +85,14 @@ function Set-RubrikVCenter
 
     $body = @{
         $resources.Body.hostname = $hostname
-        $resources.Body.username = $username
-        $resources.Body.password = $password
+        $resources.Body.username = $usernameforbody
+        $resources.Body.password = $passwordforbody
     }
-        
+
     $body = ConvertTo-Json $body
     Write-Verbose -Message "Body = $body"
     #endregion
-    
+
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
     #$uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
     #$body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)

--- a/Tests/Connect-Rubrik.Tests.ps1
+++ b/Tests/Connect-Rubrik.Tests.ps1
@@ -7,6 +7,7 @@ foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' |
 
 Describe -Name 'Public/Connect-Rubrik' -Tag 'Public', 'Connect-Rubrik' -Fixture {
     #region init
+    $global:rubrikConnections = $null
     $global:rubrikConnection = @{
         id      = 'test-id'
         userId  = 'test-userId'
@@ -51,7 +52,7 @@ Describe -Name 'Public/Connect-Rubrik' -Tag 'Public', 'Connect-Rubrik' -Fixture 
         }
 
         It -Name 'RubrikConnections array should contain 3 entries' -Test {
-            @($RubrikConnections).Count | 
+            @($RubrikConnections).Count |
                 Should -Be 3
         }
 

--- a/Tests/Get-RubrikHost.Tests.ps1
+++ b/Tests/Get-RubrikHost.Tests.ps1
@@ -65,7 +65,7 @@ Describe -Name 'Public/Get-RubrikHost' -Tag 'Public', 'Get-RubrikHost' -Fixture 
                 Should -BeExactly 0
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 4
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 4
     }
 }

--- a/Tests/Get-RubrikSetting.Tests.ps1
+++ b/Tests/Get-RubrikSetting.Tests.ps1
@@ -1,0 +1,49 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikSetting' -Tag 'Public', 'Get-RubrikSetting' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Returned Results' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+                @{
+                    'id'                    = '8b4fe6f6-cc87-4354-a125-b65e23cf8c90'
+                    'version'               = '5.1.1'
+                    'apiVersion'            = '1'
+                    'name'                  = 'RubrikCluster'
+                    'acceptedEulaVersion'   = '1.1'
+                    'latestEulaVersion'     = '1.1'
+                }
+
+        }
+        It -Name 'No parameters returns all results' -Test {
+            @( Get-RubrikSetting).Count |
+                Should -BeExactly 1
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
+    }
+    Context -Name 'Parameter Validation' {
+        It -Name 'ID is missing' -Test {
+            { Get-RubrikSetting -id } |
+                Should -Throw "Missing an argument for parameter 'id'"
+        }
+    }
+}

--- a/Tests/Get-RubrikvCenter.Tests.ps1
+++ b/Tests/Get-RubrikvCenter.Tests.ps1
@@ -1,0 +1,50 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikvCenter' -Tag 'Public', 'Get-RubrikvCenter' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                'name'                   = 'vcsa1.domain.com'
+                'id'                     = '111111'
+                'version'                = '6.7.3'
+                'hostname'               = 'vcsa1.domain.com'
+            },
+            @{
+                'name'                   = 'vcsa2.domain.com'
+                'id'                     = '111111'
+                'version'                = '6.5'
+                'hostname'               = 'vcsa2.domain.com'
+            }
+        }
+        It -Name 'Should Return count of 2' -Test {
+            ( Get-RubrikvCenter).Count |
+                Should -BeExactly 2
+        }
+        It -Name 'Should Return 6.7.3' -Test {
+            (Get-RubrikvCenter -Name 'vcsa1.domain.com').version |
+                Should -BeExactly '6.7.3'
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 2
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 2
+    }
+}

--- a/Tests/New-RubrikLDAP.Tests.ps1
+++ b/Tests/New-RubrikLDAP.Tests.ps1
@@ -1,0 +1,53 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/New-RubrikLDAP' -Tag 'Public', 'New-RubrikLDAP' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Invoke Backup' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                'id'                = '11111-22222-33333'
+                'domainType'        = 'AD'
+                'name'              = 'test.com'
+                'serviceAccount'    = 'username'
+                'dynamicDnsName'    = 'test.com'
+            }
+        }
+
+        It -Name 'Creates new LDAP Connection' -Test {
+            ( New-RubrikLDAP -Name 'test.com' -DynamicDNSName 'test.com' -BindUserName 'asdf' -BindUserPassword (ConvertTo-SecureString -String "password" -AsPlainText)).id |
+                Should -BeExactly '11111-22222-33333'
+        }
+
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
+    }
+    Context -Name 'Parameter Validation' {
+        It -Name 'Name is missing' -Test {
+            { New-RubrikLDAP -Name  } |
+                Should -Throw "Missing an argument for parameter 'Name'. Specify a parameter of type 'System.String' and try again."
+        }
+        It -Name 'DynamicDNSName is missing' -Test {
+            { New-RubrikLDAP -name 'test.com' -DynamicDNSName  } |
+                Should Throw "Missing an argument for parameter 'DynamicDnsName'. Specify a parameter of type 'System.String' and try again."
+        }
+    }
+}

--- a/Tests/New-RubrikLDAP.Tests.ps1
+++ b/Tests/New-RubrikLDAP.Tests.ps1
@@ -19,7 +19,7 @@ Describe -Name 'Public/New-RubrikLDAP' -Tag 'Public', 'New-RubrikLDAP' -Fixture 
     }
     #endregion
 
-    Context -Name 'Invoke Backup' {
+    Context -Name 'Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             @{

--- a/Tests/New-RubrikLDAP.Tests.ps1
+++ b/Tests/New-RubrikLDAP.Tests.ps1
@@ -32,7 +32,7 @@ Describe -Name 'Public/New-RubrikLDAP' -Tag 'Public', 'New-RubrikLDAP' -Fixture 
         }
 
         It -Name 'Creates new LDAP Connection' -Test {
-            ( New-RubrikLDAP -Name 'test.com' -DynamicDNSName 'test.com' -BindUserName 'asdf' -BindUserPassword (ConvertTo-SecureString -String "password" -AsPlainText)).id |
+            ( New-RubrikLDAP -Name 'test.com' -DynamicDNSName 'test.com' -BindUserName 'asdf' -BindUserPassword (ConvertTo-SecureString -String "password" -AsPlainText -Force)).id |
                 Should -BeExactly '11111-22222-33333'
         }
 

--- a/Tests/New-RubrikvCenter.Tests.ps1
+++ b/Tests/New-RubrikvCenter.Tests.ps1
@@ -1,0 +1,62 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/New-RubrikvCenter' -Tag 'Public', 'New-RubrikvCenter' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                'id'                   = '11111-22222-33333'
+                'progress'             = '0'
+                'startTime'            = '2020-03-30T16:40:20.177'
+            }
+        }
+        It -Name 'Should Return progress of 0' -Test {
+            $secpasswd = ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force
+            $mycreds = New-Object System.Management.Automation.PSCredential ("username", $secpasswd)
+            ( New-RubrikvCenter -HostName 'vcsa1.domain.com' -Credential $mycreds ).progress |
+                Should -BeExactly 0
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
+    }
+    Context -Name 'Parameter Validation' {
+        It -Name 'Missing Username' -Test {
+            $secpasswd = ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force
+            { New-RubrikvCenter -Hostname 'vcsa.domain.local' -username -password $secpasswd } |
+                Should -Throw "Missing an argument for parameter 'Username'. Specify a parameter of type 'System.String' and try again."
+        }
+        It -Name 'Missing Password' -Test {
+            { New-RubrikvCenter  -Hostname 'vcsa.domain.local' -username 'username' -password } |
+                Should -Throw "Missing an argument for parameter 'Password'"
+        }
+        It -Name 'ParameterSet Validation' -Test {
+            $secpasswd = ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force
+            $mycreds = New-Object System.Management.Automation.PSCredential ("username", $secpasswd)
+            { New-RubrikvCenter -Hostname 'vcsa.domain.local' -username 'username' -Credential $mycreds } |
+                Should -Throw "Parameter set cannot be resolved using the specified named parameters."
+        }
+        It -Name 'Missing hostname' -Test {
+            { New-RubrikvCenter -Hostname -username 'username' -Credential $creds } |
+                Should -Throw "Missing an argument for parameter 'Hostname'"
+        }
+    }
+}

--- a/Tests/Remove-RubrikHost.Tests.ps1
+++ b/Tests/Remove-RubrikHost.Tests.ps1
@@ -1,0 +1,50 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Remove-RubrikHost' -Tag 'Public', 'Remove-RubrikHost' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Validate Results' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                Status = 'Success'
+                HTTPStatusCode = 204
+            }
+        }
+        It -Name 'Should Return status of Success' -Test {
+            ( Remove-RubrikHost -id '01234567-8910-1abc-d435-0abc1234d567').Status |
+                Should -BeExactly 'Success'
+        }
+
+        It -Name 'Should Return HTTP status code 204' -Test {
+            ( Remove-RubrikHost -id '01234567-8910-1abc-d435-0abc1234d567').HTTPStatusCode |
+                Should -BeExactly 204
+        }
+
+        Context -Name 'Parameter Validation' {
+            It -Name 'Parameter id cannot be $null or empty' -Test {
+                { Remove-RubrikHost -id $null -Confirm:$false } |
+                    Should -Throw "Cannot bind argument to parameter 'id' because it is an empty string."
+            }
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+}

--- a/Tests/Remove-RubrikvCenter.Tests.ps1
+++ b/Tests/Remove-RubrikvCenter.Tests.ps1
@@ -1,0 +1,45 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Remove-RubrikvCenter' -Tag 'Public', 'Remove-RubrikvCenter' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                'id'                   = '11111-22222-33333'
+                'progress'             = '0'
+                'startTime'            = '2020-03-30T16:40:20.177'
+            }
+        }
+        It -Name 'Should Return progress of 0' -Test {
+            ( Remove-RubrikvCenter -id '11111-22222-33333' ).progress |
+                Should -BeExactly 0
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
+    }
+    Context -Name 'Parameter Validation' {
+        It -Name 'Missing id' -Test {
+            { Remove-RubrikvCenter -id  } |
+                Should -Throw "Missing an argument for parameter 'id'. Specify a parameter of type 'System.String' and try again."
+        }
+    }
+}

--- a/Tests/Set-RubrikSetting.Tests.ps1
+++ b/Tests/Set-RubrikSetting.Tests.ps1
@@ -1,0 +1,65 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Set-RubrikSetting' -Tag 'Public', 'Set-RubrikSetting' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Returned Results' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith { }
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+                @{
+                    'id'                    = '8b4fe6f6-cc87-4354-a125-b65e23cf8c90'
+                    'version'               = '5.1.1'
+                    'apiVersion'            = '1'
+                    'name'                  = 'RubrikCluster'
+                    'acceptedEulaVersion'   = '1.1'
+                    'latestEulaVersion'     = '1.1'
+                }
+
+        }
+        It -Name 'No parameters returns all results' -Test {
+            @( Set-RubrikSetting -ClusterName "RubrikCluster" -ClusterLocation "Toronto" -Timezone "America/New_York").Count |
+                Should -BeExactly 1
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
+    }
+    Context -Name 'Parameter Validation' {
+        It -Name 'ClusterName is missing' -Test {
+            { Set-RubrikSetting -ClusterName  -ClusterLocation "Toronto" -Timezone "America/New_York" } |
+                Should -Throw "Missing an argument for parameter 'ClusterName'"
+        }
+        It -Name 'ClusterLocation is missing' -Test {
+            { Set-RubrikSetting -ClusterName "RubrikCluster"  -ClusterLocation  -Timezone "America/New_York" } |
+                Should -Throw "Missing an argument for parameter 'ClusterLocation'"
+        }
+        It -Name 'Timezone is missing' -Test {
+            { Set-RubrikSetting -ClusterName "RubrikCluster" -ClusterLocation "Toronto" -Timezone  } |
+                Should -Throw "Missing an argument for parameter 'Timezone'"
+        }
+        It -Name 'Validate Timezone Input' -Test {
+            { Set-RubrikSetting -ClusterName "RubrikCluster" -ClusterLocation "Toronto" -Timezone "Eastern" } |
+                Should -Throw "Cannot validate argument on parameter 'Timezone'"
+        }
+        It -Name 'ClusterName is null' -Test {
+            { Set-RubrikSetting -ClusterName $null -ClusterLocation "Toronto" -Timezone "America/New_York" } |
+                Should -Throw "Cannot bind argument to parameter 'ClusterName' because it is an empty string."
+        }
+    }
+}

--- a/Tests/Set-RubrikvCenter.Tests.ps1
+++ b/Tests/Set-RubrikvCenter.Tests.ps1
@@ -1,0 +1,67 @@
+﻿Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Set-RubrikvCenter' -Tag 'Public', 'Set-RubrikvCenter' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{
+                'id'                    = '11111-22222-33333'
+                'name'                  = 'vcsa.domain.local'
+                'hostname'              = 'vcsa.domain.local'
+                'version'               = '6.5'
+            }
+        }
+        It -Name 'Should return correct id' -Test {
+            $secpasswd = ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force
+            $mycreds = New-Object System.Management.Automation.PSCredential ("username", $secpasswd)
+            ( Set-RubrikvCenter -ID '11111-22222-33333' -HostName 'vcsa1.domain.com' -Credential $mycreds ).id |
+                Should -BeExactly '11111-22222-33333'
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
+    }
+    Context -Name 'Parameter Validation' {
+        It -Name 'Missing Username' -Test {
+            $secpasswd = ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force
+            { Set-RubrikvCenter -id '11111-22222' -Hostname 'vcsa.domain.local' -username -password $secpasswd } |
+                Should -Throw "Missing an argument for parameter 'Username'. Specify a parameter of type 'System.String' and try again."
+        }
+        It -Name 'Missing Password' -Test {
+            { Set-RubrikvCenter -id '11111-22222' -Hostname 'vcsa.domain.local' -username 'username' -password } |
+                Should -Throw "Missing an argument for parameter 'Password'"
+        }
+        It -Name 'ParameterSet Validation' -Test {
+            $secpasswd = ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force
+            $mycreds = New-Object System.Management.Automation.PSCredential ("username", $secpasswd)
+            { Set-RubrikvCenter -Hostname 'vcsa.domain.local' -username 'username' -Credential $mycreds } |
+                Should -Throw "Parameter set cannot be resolved using the specified named parameters."
+        }
+        It -Name 'Missing hostname' -Test {
+            { Set-RubrikvCenter -Hostname -username 'username' -Credential $creds } |
+                Should -Throw "Missing an argument for parameter 'Hostname'"
+        }
+        It -Name 'Missing id' -Test {
+            { Set-RubrikvCenter -id '11111' -Hostname -username 'username' -Credential $creds } |
+                Should -Throw "Missing an argument for parameter 'Hostname'"
+        }
+    }
+}


### PR DESCRIPTION
# Description

Added unit tests for `New-RubrikLDAP`, `Get-RubrikvCenter`, `New-RubrikvCenter`, `Remove-RubrikvCenter`, `Set-RubrikvCenter`, `Get-RubrikSetting`, `Set-RubrikSetting`, and `Remove-RubrikHost`

Added $rubrikConnections = $null to `Connect-Rubrik.Tests.ps1` in order to allow test to be ran within the same PS session of which it ran previously.
Added parameters to `New-RubrikvCenter` and `Set-RubrikvCenter` allowing users to send username/password or credential objects to the cmdlets. This allows true scripting of these cmdlets rather than prompting for credentials by default.

## Related Issue

[Issue 345](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/345)

## Motivation and Context

Provides more coverage of unit tests and better scripting abilities around managing vCenters within Rubrik

## How Has This Been Tested?

Tested within the TM lab

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
