### PR TITLE
Changes to how Disconnect-Rubrik handles variable cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Fixed how `Disconnect-Rubrik` handles cleaning up `$RubrikConnection(s)` variables
 * Added $rubrikConnections = $null to `Connect-Rubrik.Tests.ps1` in order to allow test to be ran within the same PS session of which it ran previously.
 * Added parameters to `New-RubrikvCenter` and `Set-RubrikvCenter` allowing users to send username/password or credential objects to the cmdlets. This allows true scripting of these cmdlets rather than prompting for credentials by default.
 * Added -Force parameter and confirmation prompts to `Remove-RubrikUnmanagedObject`. This allows for the deletion of snapshots protected by retention SLAs as per [Issue 314](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/314)
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added additional unit tests for `Disconnect-Rubrik` as per [Issue 598](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/598)
 * Added unit tests for `New-RubrikLDAP`, `Get-RubrikvCenter`, `New-RubrikvCenter`, `Remove-RubrikvCenter`, `Set-RubrikvCenter`, `Get-RubrikSetting`, `Set-RubrikSetting`, and `Remove-RubrikHost` as per [Issue 345](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/345)
 * Added new unit tests: `CommentBasedHelp`, `ObjectDefinitions`, `Connect-Rubrik`, `Disconnect-Rubrik`
 * Added `Remove-RubrikFilesetSnapshot`, `RemoveRubrikDatabaseSnapshots`, `Remove-RubrikHyperVSnapshot`, `Remove-RubrikManagedVolumeSnapshot`, `Remove-RubrikNutanixVMSnapshot`, and `Remove-RubrikVolumeGroupSnapshot` along with associated unit tests as outlined in [Issue 309](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/309) *NOTE Remove-RubrikDatabaseSnapshots deletes ALL snapshots for a given database - there is currently no endpoint to support the deletion of a single snapshot*

--- a/Rubrik/Public/Disconnect-Rubrik.ps1
+++ b/Rubrik/Public/Disconnect-Rubrik.ps1
@@ -67,12 +67,7 @@ function Disconnect-Rubrik
     # if token was used to authenticate, remove variable and exit
     if ($global:RubrikConnection.authType -eq 'Token') {
       Write-Verbose -Message "Detected token authentication - Disconnecting without deleting token."
-      
-      # Remove from RubrikConnections global Variable
-      $global:RubrikConnections = $RubrikConnections | Where-Object {$_.Token -ne $RubrikConnection.Token}
-      
-      # Remove Global variable, RubrikConnection
-      Remove-Variable -Name RubrikConnection -Scope Global
+
       $result = $null
     }
     else {
@@ -83,6 +78,12 @@ function Disconnect-Rubrik
       $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
       $result = Test-FilterObject -filter ($resources.Filter) -result $result
     }
+
+    # Remove from RubrikConnections global Variable
+    $global:RubrikConnections = $RubrikConnections | Where-Object {$_.Token -ne $RubrikConnection.Token}
+    
+    # Remove Global variable, RubrikConnection
+    Remove-Variable -Name RubrikConnection -Scope Global
 
     return $result
 

--- a/Tests/Disconnect-Rubrik.Tests.ps1
+++ b/Tests/Disconnect-Rubrik.Tests.ps1
@@ -7,16 +7,18 @@ foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' |
 
 Describe -Name 'Public/Disconnect-Rubrik' -Tag 'Public', 'Disconnect-Rubrik' -Fixture {
     #region init
-    $global:rubrikConnection = @{
-        id       = 'test-id'
-        userId   = 'test-userId'
-        token    = 'test-token'
-        server   = 'test-server'
-        authType = 'Basic' 
-        header   = @{ 'Authorization' = 'Bearer test-authorization' }
-        time     = (Get-Date)
-        api      = 'v1'
-        version  = '5.0'
+    function Invoke-InitiateRubrikConnection {
+            $global:rubrikConnection = @{
+            id       = 'test-id'
+            userId   = 'test-userId'
+            token    = 'test-token'
+            server   = 'test-server'
+            authType = 'Basic' 
+            header   = @{ 'Authorization' = 'Bearer test-authorization' }
+            time     = (Get-Date)
+            api      = 'v1'
+            version  = '5.0'
+        }
     }
     #endregion
 
@@ -29,19 +31,36 @@ Describe -Name 'Public/Disconnect-Rubrik' -Tag 'Public', 'Disconnect-Rubrik' -Fi
             }
         }
 
+        Invoke-InitiateRubrikConnection
         It -Name 'Disconnect basic auth' -Test {
             {Disconnect-Rubrik} | 
                 Should -Not -Throw
         }
 
+        It -Name 'Disconnect basic auth - Should Clean RubrikConnection' -Test {
+            Invoke-InitiateRubrikConnection
+            Disconnect-Rubrik
+
+            $rubrikconnection | Should -BeNullOrEmpty  
+        }
+
         It -Name 'Disconnect with a Token' -Test {
+            Invoke-InitiateRubrikConnection
             $rubrikConnection.authType = 'Token'
-           $Output = Disconnect-Rubrik -Verbose 4>&1
-           (-join $Output) | 
+            $Output = Disconnect-Rubrik -Verbose 4>&1
+            (-join $Output) | 
                 Should -BeLike '*Detected token authentication - Disconnecting without deleting token.*'
         }
 
+        It -Name 'Disconnect with a Token - Should Clean RubrikConnection' -Test {
+            Invoke-InitiateRubrikConnection
+            $rubrikConnection.authType = 'Token'
+            Disconnect-Rubrik
+
+            $rubrikconnection | Should -BeNullOrEmpty  
+        }
+
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 2
     }
 }


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

## Current Behavior:

When Disconnect-Rubrik is ran, depending on what method of connection is used, either

## Expected Behavior:

## Steps to Reproduce:

Please provide detailed steps for reproducing the issue.

```
Connect-Rubrik -Credential $Cred
Disconnect-Rubrik
```
$RubrikConnection & $RubrikConnections are not cleared

## Context:

All versions of PowerShell & Windows PowerShell are affected

## Related Issue

Resolve #598 

## Motivation and Context

Fix inconsistency in how `$RubrikConnection(s)` variables are cleaned up

## How Has This Been Tested?

Ran current unit tests and created new unit tests to cover the changes

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
