### PR TITLE
Issue 604 - Content body errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Removed -Body $body from `Get-RubrikClusterInfo` when it passes variables to Submit-Request as per [Issue 604](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/604)
 * Added support to `Get-RubrikObject` for ClusterNetworkInterfaces, Event Series, HyperV Hosts, Nodes, Notification Settings, NTP Servers, Nutanix Clusters and SMB Domains
 * Added support to `Get-RubrikObject` to support searching by id on an attribute which isn't named `id`
 * Fixed how `Disconnect-Rubrik` handles cleaning up `$RubrikConnection(s)` variables

--- a/Rubrik/Public/Get-RubrikClusterInfo.ps1
+++ b/Rubrik/Public/Get-RubrikClusterInfo.ps1
@@ -1,23 +1,23 @@
 #Requires -Version 3
 function Get-RubrikClusterInfo
 {
-  <#  
+  <#
       .SYNOPSIS
       Connects to Rubrik and retrieves node information for a given cluster
-            
+
       .DESCRIPTION
       The Get-RubrikClusterInfo cmdlet will retrieve various information and settings for a given cluster.
-            
+
       .NOTES
       Written by Mike Preston for community usage
       Twitter: @mwpreston
       GitHub: mwpreston
-            
+
       .LINK
       https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/get-rubrikclusterinfo
-            
+
       .EXAMPLE
-      Get-RubrikClusterInfo 
+      Get-RubrikClusterInfo
       This will return the advanced settings and information around the currently authenticated cluster.
   #>
 
@@ -36,48 +36,48 @@ function Get-RubrikClusterInfo
 
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
-    
+
     # API data references the name of the function
     # For convenience, that name is saved here to $function
     $function = $MyInvocation.MyCommand.Name
-        
+
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
+
   }
 
   Process {
-    
+
     $result = @{}
     foreach ($key in $resources.URI.Keys ) {
         $uri = New-URIString -server $Server -endpoint $Resources.URI[$key] -id $id
-        $iresult = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+        $iresult = Submit-Request -uri $uri -header $Header -method $($resources.Method)
         switch ($key) {
             {$_ -in "BrikCount","CPUCoresCount"} { $result.Add($key, $iresult.count) }
-            
-            "MemoryCapacityInGb" { $result.add($key,($iresult.bytes / 1GB)) } 
-            "ConnectedToPolaris"  { $result.add($key,$iresult.isConnected) } 
-            "NodeCount"         { $result.add($key, $iresult.total) } 
-            "Platform"         { $result.add($key,$iresult.platform ) } 
-            {$_ -in "HasTPM","OnlyAzureSupport","IsEncrypted","IsHardwareEncrypted","IsOnCloud","IsRegistered","IsSingleNode" }  { 
-              $result.add($key, $iresult.value )  
+
+            "MemoryCapacityInGb" { $result.add($key,($iresult.bytes / 1GB)) }
+            "ConnectedToPolaris"  { $result.add($key,$iresult.isConnected) }
+            "NodeCount"         { $result.add($key, $iresult.total) }
+            "Platform"         { $result.add($key,$iresult.platform ) }
+            {$_ -in "HasTPM","OnlyAzureSupport","IsEncrypted","IsHardwareEncrypted","IsOnCloud","IsRegistered","IsSingleNode" }  {
+              $result.add($key, $iresult.value )
             }
             "GeneralInfo" {
-              $result.add("Name", $iresult.name) 
-              $result.add("Id",$iresult.id  ) | Add-Member -NotePropertyName "Id" -NotePropertyValue $iresult.id 
+              $result.add("Name", $iresult.name)
+              $result.add("Id",$iresult.id  ) | Add-Member -NotePropertyName "Id" -NotePropertyValue $iresult.id
               $result.add("APIVersion", $iresult.apiVersion)
-              $result.add("timezone",$iresult.timezone ) 
+              $result.add("timezone",$iresult.timezone )
               $result.add("geolocation", $iresult.geolocation)
-              $result.add("acceptedEulaVersion",$iresult.acceptedEulaVersion) 
-              $result.add("softwareVersion", $iresult.version) 
+              $result.add("acceptedEulaVersion",$iresult.acceptedEulaVersion)
+              $result.add("softwareVersion", $iresult.version)
             }
             "Status" {
-              $result.add("ClusterStatus",$iresult.status ) 
+              $result.add("ClusterStatus",$iresult.status )
             }
-            
+
         }
     }
 


### PR DESCRIPTION
# Description

Customer was getting errors running Get-RubrikClusterInfo as per outlined in below issue

## Related Issue

[Issue 604](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/604)

## Motivation and Context

This should allow the errors to stop.

## How Has This Been Tested?

Tested in the TM lab, however I couldn't reproduce issue to begin with.  This will ensure there is no $body passed to the GET endpoints.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
