### PR TITLE
Issue 604 - More content-body errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Removed -Body $body from `Get-RubrikClusterStorage` and `Get-RubrikDNSSetting` when it passes variables to Submit-Request as per [Issue 604](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/604)
 * Removed -Body $body from `Get-RubrikClusterInfo` when it passes variables to Submit-Request as per [Issue 604](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/604)
 * Added support to `Get-RubrikObject` for ClusterNetworkInterfaces, Event Series, HyperV Hosts, Nodes, Notification Settings, NTP Servers, Nutanix Clusters and SMB Domains
 * Added support to `Get-RubrikObject` to support searching by id on an attribute which isn't named `id`

--- a/Rubrik/Public/Get-RubrikDNSSetting.ps1
+++ b/Rubrik/Public/Get-RubrikDNSSetting.ps1
@@ -1,23 +1,23 @@
 #Requires -Version 3
 function Get-RubrikDNSSetting
 {
-  <#  
+  <#
       .SYNOPSIS
       Connects to Rubrik and retrieves DNS Settings assigned to a given cluster
-            
+
       .DESCRIPTION
       The Get-RubrikDNSSetting cmdlet will retrieve information around the node members of a given cluster.
-            
+
       .NOTES
       Written by Mike Preston for community usage
       Twitter: @mwpreston
       GitHub: mwpreston
-            
+
       .LINK
       https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/get-rubrikdnssetting
-            
+
       .EXAMPLE
-      Get-RubrikDNSSetting 
+      Get-RubrikDNSSetting
       This will return the information around the DNS settings of the currently authenticated cluster
   #>
 
@@ -36,17 +36,17 @@ function Get-RubrikDNSSetting
 
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
-    
+
     # API data references the name of the function
     # For convenience, that name is saved here to $function
     $function = $MyInvocation.MyCommand.Name
-        
+
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
+
   }
 
   Process {
@@ -54,10 +54,10 @@ function Get-RubrikDNSSetting
     $result = New-Object -TypeName psobject
     foreach ($key in $resources.URI.Keys ) {
         $uri = New-URIString -server $Server -endpoint $Resources.URI[$key] -id $id
-        $iresult = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+        $iresult = Submit-Request -uri $uri -header $Header -method $($resources.Method)
         # support for < 5.0
         if ($null -ne $iresult.data ) { $iresult = $iresult.data }
-        
+
         switch ($key) {
             "DNSServers"        {$result | Add-Member -NotePropertyName "$key" -NotePropertyValue $iresult}
             "DNSSearchDomain"   {$result | Add-Member -NotePropertyName "$key" -NotePropertyValue $iresult}


### PR DESCRIPTION
# Description

Removed -Body $body from `Get-RubrikClusterStorage` and `Get-RubrikDNSSetting` when it passes variables to Submit-Request
## Related Issue

Resolves #604 

## Motivation and Context

Doesn't provide customer an error

## How Has This Been Tested?

Tested in TM Lab

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
