### PR TITLE
New-RubrikLiveMount incorrectly puts timestampMs in an array area-rcdm exp-expert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Added `Get-RubrikEventSeries` to now parse the event_series API rather than events as per [Issue 580](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/580)
 * Added unit tests to cover `Get-RubrikEventSeries` and changes to `Get-RubrikEvent`
 
+### Fixed
+
+* Fixed incorrect array in body of `New-RubrikDatabaseMount` and added tests to validate new behavior in `New-RubrikDatabaseMount.Tests`
+
 ## [5.0.1](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/5.0.1) - 2020-03-05
 
 ### Added

--- a/Rubrik/Public/New-RubrikDatabaseMount.ps1
+++ b/Rubrik/Public/New-RubrikDatabaseMount.ps1
@@ -87,11 +87,10 @@ function New-RubrikDatabaseMount
     $body = @{
       $resources.Body.targetInstanceId = $targetInstanceId
       $resources.Body.mountedDatabaseName = $mountedDatabaseName
-      recoveryPoint = @()
     }
-    $body.recoveryPoint += @{
-          $resources.Body.recoveryPoint.timestampMs = $timestampMs
-          }
+    $body.recoveryPoint = @{
+      $resources.Body.recoveryPoint.timestampMs = $timestampMs
+    }
     $body = ConvertTo-Json $body
     Write-Verbose -Message "Body = $body"
     #endregion

--- a/Tests/New-RubrikDatabaseMount.Tests.ps1
+++ b/Tests/New-RubrikDatabaseMount.Tests.ps1
@@ -33,9 +33,16 @@ Describe -Name 'Public/New-RubrikDatabaseMount' -Tag 'Public', 'New-RubrikDataba
             ( New-RubrikDatabaseMount -id MssqlDatabase:::12345678-1234-abcd-8910-1234567890ab -targetInstanceId MssqlInstance:::12345678-1234-abcd-8910-1234567890ab -mountedDatabaseName 'ExampleDB1-LM' -recoveryDateTime 'July 2, 2019 7:42:06 PM' ).status |
                 Should -BeExactly 'QUEUED'
         }
+
+        It -Name 'timestampMs should not be in an array' -Test {
+            $output = ( New-RubrikDatabaseMount -id MssqlDatabase:::12345678-1234-abcd-8910-1234567890ab -targetInstanceId MssqlInstance:::12345678-1234-abcd-8910-1234567890ab -mountedDatabaseName 'ExampleDB1-LM' -recoveryDateTime 'July 2, 2019 7:42:06 PM' ).status 4>&1
+            (-join $output) |
+                Should -Not -BeLike '*[*]*'
+        }
+
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 2
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 2
     }
 
     Context -Name 'Parameter Validation' {


### PR DESCRIPTION
# Description

Provide information about the failure by issuing the command using the -Verbose command. Ensure that any identifiable information (server names, tokens, passwords) is removed from your logs before sharing this on GitHub.

Currently the body looks like this, note the [ ] characters. These cause issues on Rubrik CDM 5.2 and are not required on older versions of CDM.

## Related Issue

Resolve #608

## Motivation and Context

Fixes SQL live mount issue in 5.2

## How Has This Been Tested?

Existing unit tests, new unit test written and ran against 5.1 and 5.2 on test clusters.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
