### PR TITLE
Export-RubrikDatabase failing on v5.2-DA1 clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Fixed incorrect array in body of `Restore-RubrikDatabase` and added tests to validate new behavior in `Restore-RubrikDatabase.Tests`
 * Fixed incorrect array in body of `Export-RubrikDatabase` and added tests to validate new behavior in `Export-RubrikDatabase.Tests`
 * Fixed incorrect array in body of `New-RubrikDatabaseMount` and added tests to validate new behavior in `New-RubrikDatabaseMount.Tests`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Fixed incorrect array in body of `Export-RubrikDatabase` and added tests to validate new behavior in `Export-RubrikDatabase.Tests`
 * Fixed incorrect array in body of `New-RubrikDatabaseMount` and added tests to validate new behavior in `New-RubrikDatabaseMount.Tests`
 
 ## [5.0.1](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/5.0.1) - 2020-03-05

--- a/Rubrik/Public/Export-RubrikDatabase.ps1
+++ b/Rubrik/Public/Export-RubrikDatabase.ps1
@@ -107,7 +107,6 @@ function Export-RubrikDatabase
       $resources.Body.targetInstanceId = $TargetInstanceId
       $resources.Body.targetDatabaseName = $TargetDatabaseName
       $resources.Body.finishRecovery = $FinishRecovery.IsPresent
-      recoveryPoint = @()
     }
 
     if($MaxDataStreams){
@@ -125,9 +124,9 @@ function Export-RubrikDatabase
     }
 
     if($RecoveryLSN){
-      $body.recoveryPoint += @{lsnPoint=@{lsn=$RecoveryLSN}}
+      $body.recoveryPoint = @{lsnPoint=@{lsn=$RecoveryLSN}}
     } else {
-      $body.recoveryPoint += @{timestampMs = $TimestampMs}
+      $body.recoveryPoint = @{timestampMs = $TimestampMs}
     }
 
     if($Overwrite){

--- a/Rubrik/Public/Restore-RubrikDatabase.ps1
+++ b/Rubrik/Public/Restore-RubrikDatabase.ps1
@@ -87,12 +87,10 @@ function Restore-RubrikDatabase
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $Id
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
 
-
     #region One-off
     Write-Verbose -Message "Build the body"
     $body = @{
       $resources.Body.finishRecovery = $FinishRecovery.IsPresent
-      recoveryPoint = @()
     }
 
     if($MaxDataStreams){
@@ -100,15 +98,14 @@ function Restore-RubrikDatabase
     }
 
     if($RecoveryLSN){
-      $body.recoveryPoint += @{lsnPoint=@{lsn=$RecoveryLSN}}
+      $body.recoveryPoint = @{lsnPoint=@{lsn=$RecoveryLSN}}
     } else {
-      $body.recoveryPoint += @{timestampMs = $TimestampMs}
+      $body.recoveryPoint = @{timestampMs = $TimestampMs}
     }
 
     $body = ConvertTo-Json $body -depth 10
     Write-Verbose -Message "Body = $body"
     #endregion
-
 
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result

--- a/Tests/Export-RubrikDatabase.Tests.ps1
+++ b/Tests/Export-RubrikDatabase.Tests.ps1
@@ -66,7 +66,7 @@ Describe -Name 'Public/Export-RubrikDatabase' -Tag 'Public', 'Export-RubrikDatab
             }        
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
     }
 }

--- a/Tests/Export-RubrikDatabase.Tests.ps1
+++ b/Tests/Export-RubrikDatabase.Tests.ps1
@@ -37,6 +37,12 @@ Describe -Name 'Public/Export-RubrikDatabase' -Tag 'Public', 'Export-RubrikDatab
                     Should -BeExactly 'QUEUED'
             }
         }
+
+        It -Name 'timestampMs should not be in an array' -Test {
+            $output = ( Export-RubrikDatabase -id MssqlDatabase:::12345678-1234-abcd-8910-1234567890ab -targetInstanceId MssqlInstance:::12345678-1234-abcd-8910-1234567890ab -targetDatabaseName 'ExampleDB1-LM' -recoveryDateTime 'July 2, 2019 7:42:06 PM' ).status 4>&1
+            (-join $output) |
+                Should -Not -BeLike '*[*]*'
+        }
         
         Context -Name 'Parameter Validation' {
             It -Name 'Parameter id must be specified' -Test {
@@ -66,7 +72,7 @@ Describe -Name 'Public/Export-RubrikDatabase' -Tag 'Public', 'Export-RubrikDatab
             }        
         }
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 2
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 2
     }
 }

--- a/Tests/Restore-RubrikDatabase.Tests.ps1
+++ b/Tests/Restore-RubrikDatabase.Tests.ps1
@@ -35,9 +35,15 @@ Describe -Name 'Public/Restore-RubrikDatabase' -Tag 'Public', 'Restore-RubrikDat
                 Should -BeExactly 'QUEUED'
         }
 
+        It -Name 'timestampMs should not be in an array' -Test {
+            $output = ( Restore-RubrikDatabase -Id 'MssqlDatabase:::12345678-1234-abcd-8910-1234567890ab' -RecoveryDateTime 'July 2, 2019 11:21:22 PM' -FinishRecovery ).status 4>&1
+            (-join $output) |
+                Should -Not -BeLike '*[*]*'
+        }
+
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 2
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 2
     }
 
     Context -Name 'Parameter Validation' {


### PR DESCRIPTION
# Description

On 5.1 and earlier the same syntax queues an export job successfully:

PS C:\> Export-RubrikDatabase -id $dbid -targetInstanceId $dbinst -targetDatabaseName 'h2016-2' -targetFilePaths $targetfiles -finishRecovery -recoveryDateTime (Get-Date (Get-RubrikDatabase $dbid).latestRecoveryPoint)


progress  : 0.0
status    : QUEUED
startTime : 2020-05-01T12:53:25.500Z
id        : RESTORE_MSSQL_DB_79481aa4-a531-4e46-be74-b1425bc39534_bf9b3345-553f-48c9-a782-0d1f51779499:::0
links     : @{rel=self; href=https://192.168.75.200/api/v1/mssql/request/RESTORE_MSSQL_DB_79481aa4-a531-4e46-be74-b1425bc39534_bf9b3345-553f-48c9-a782-0d1f51779499:::0}

Steps to Reproduce:

Run Export-RubrikDatabase or Export-RubrikDatabasesJob.ps1 script against a cluster running Rubrik CDM v5.2-DA1

## Context:

Please provide any relevant information about your setup. This is important in case the issue is not reproducible except for under certain conditions.

Rubrik PowerShell Module Version:
ModuleType Version Name ExportedCommands

## Related Issue

Resolve #620 
Resolve #622

## Motivation and Context

Fix the bug

## How Has This Been Tested?

Ran unit tests and created new

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12744735/80842957-40e8a380-8c03-11ea-9bfa-f3185154df38.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
