### PR TITLE
Fix for issue #619 - Made parameters in Set AvailabilityGroup mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Modified `Set-RubrikAvailabilityGroup` and made `-LogRetentionHours` parameters mandatory while removing default value of -1
 * Modified private function `Set-ObjectTypeName.ps1` to support the new `ApplyCustomViewDefinitions`.
 * Modified module script file `rubrik.psm1` to create options file if it doesn't exist, and update any current options file if it does exist. Also loads any default parameter options into $global:PSDefaultParameterValues
 * Modified `Get-RubrikVM`, `Get-RubrikDatabase`, `Get-RubrikFileset`, `Get-RubrikHost`, `Get-RubrikLogShipping`, `Get-RubrikNutanixCluster`, `Get-RubrikOracleDB`, `Get-RubrikReplicationSource`,`Get-RubrikReplicationTarget`, `Get-RubrikScvmm`, `Get-RubrikvApp`, `Get-RubrikVCD`, `Get-RubrikVMwareCluster`, and `Get-RubrikVMwareDatacenter` to call the new `Get-RubrikDetailedResult` function when -DetailedObject is present. `Get-RubrikArchive` was left alone as it uses -DetailedObject differently.

--- a/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
+++ b/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
@@ -36,7 +36,8 @@ function Set-RubrikAvailabilityGroup
     [int]$LogBackupFrequencyInSeconds =-1,
     
     #How long should we keep the backup for
-    [int]$LogRetentionHours =-1,    
+    [Parameter(Mandatory = $true)]
+    [int]$LogRetentionHours,    
 
     #Boolean declaration for copy only backups on the database.
     [switch]$CopyOnly,   

--- a/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
+++ b/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
@@ -31,17 +31,18 @@ function Set-RubrikAvailabilityGroup
     #Availability Group ID
     [Parameter(ValueFromPipelineByPropertyName = $true)]
     [String]$id,
-    
-    #How often we should backup the transaction log  
-    [Parameter(Mandatory = $true)]
+
+    #How often we should backup the transaction log
+    [Parameter(ParameterSetName='LogOptions')]
     [int]$LogBackupFrequencyInSeconds,
     
     #How long should we keep the backup for
-    [Parameter(Mandatory = $true)]
-    [int]$LogRetentionHours,    
+    [Parameter(ParameterSetName='LogOptions')]
+    [int]$LogRetentionHours,
 
     #Boolean declaration for copy only backups on the database.
-    [switch]$CopyOnly,   
+    [Parameter(ParameterSetName='CopyOnly')]
+    [switch]$CopyOnly,
 
     #SLA Domain Name
     [string]$SLA,
@@ -52,6 +53,7 @@ function Set-RubrikAvailabilityGroup
     
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
+    
     # API version
     [ValidateNotNullorEmpty()]
     [String]$api = $global:RubrikConnection.api
@@ -100,7 +102,6 @@ function Set-RubrikAvailabilityGroup
     
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
-#    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)  
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
     $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
     $result = Test-FilterObject -filter ($resources.Filter) -result $result

--- a/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
+++ b/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
@@ -33,11 +33,11 @@ function Set-RubrikAvailabilityGroup
     [String]$id,
 
     #How often we should backup the transaction log
-    [Parameter(ParameterSetName='LogOptions')]
+    [Parameter(ParameterSetName='LogOptions', Mandatory = $true)]
     [int]$LogBackupFrequencyInSeconds,
     
     #How long should we keep the backup for
-    [Parameter(ParameterSetName='LogOptions')]
+    [Parameter(ParameterSetName='LogOptions', Mandatory = $true)]
     [int]$LogRetentionHours,
 
     #Boolean declaration for copy only backups on the database.
@@ -98,6 +98,7 @@ function Set-RubrikAvailabilityGroup
         if((Get-Variable -Name $p).Value -eq -1){$resources.Body.Remove($p)}
     }     
     $body = ConvertTo-Json $body
+    Write-Verbose "Body: $($body | Out-String)"
     #endregion
     
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id

--- a/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
+++ b/Rubrik/Public/Set-RubrikAvailabilityGroup.ps1
@@ -33,7 +33,8 @@ function Set-RubrikAvailabilityGroup
     [String]$id,
     
     #How often we should backup the transaction log  
-    [int]$LogBackupFrequencyInSeconds =-1,
+    [Parameter(Mandatory = $true)]
+    [int]$LogBackupFrequencyInSeconds,
     
     #How long should we keep the backup for
     [Parameter(Mandatory = $true)]

--- a/Tests/Set-RubrikAvailabilityGroup.Tests.ps1
+++ b/Tests/Set-RubrikAvailabilityGroup.Tests.ps1
@@ -61,7 +61,7 @@ Describe -Name 'Public/Set-RubrikAvailabilityGroup' -Tag 'Public', 'Set-RubrikAv
 
         It -Name 'Parameter sets should be enforced' -Test {
             { Set-RubrikAvailabilityGroup -SLA 'Gold' -id 'AG:1111' -CopyOnly -LogBackupFrequencyInSeconds 60 -LogRetentionHours 1 } |
-                Should -Throw 'Parameter set cannot be resolved using the specified named parameters. One or more parameters issued cannot be used together or an insufficient number of parameters were provided.'
+                Should -Throw -ErrorId 'AmbiguousParameterSet,Set-RubrikAvailabilityGroup'
         }
 
         It -Name 'Parameter LogRetentionHours is integer' -Test {

--- a/Tests/Set-RubrikAvailabilityGroup.Tests.ps1
+++ b/Tests/Set-RubrikAvailabilityGroup.Tests.ps1
@@ -35,13 +35,19 @@ Describe -Name 'Public/Set-RubrikAvailabilityGroup' -Tag 'Public', 'Set-RubrikAv
                 'copyOnly'                      = 'true'
             }
         }
-        It -Name 'Should return AG1' -Test {
-            (Set-RubrikAvailabilityGroup -SLA 'Gold' -id 'AG:1111' -CopyOnly -LogBackupFrequencyInSeconds 60 -LogRetentionHours 1).Name |
+        It -Name 'Should return Name as value "AG1"' -Test {
+            (Set-RubrikAvailabilityGroup -SLA 'Gold' -id 'AG:1111' -CopyOnly).Name |
                 Should -BeExactly 'AG1'
         }
+
+        It -Name 'Should return correct LogRetentionHours value' -Test {
+            (Set-RubrikAvailabilityGroup -SLA 'Gold' -id 'AG:1111' -LogBackupFrequencyInSeconds 60 -LogRetentionHours 1).logRetentionHours |
+                Should -BeExactly '1'
+        }
+        
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Exactly 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 2
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik'  -Exactly 2
     }
     Context -Name 'Parameter Validation' {
         It -Name 'Parameter id missing' -Test {
@@ -52,6 +58,12 @@ Describe -Name 'Public/Set-RubrikAvailabilityGroup' -Tag 'Public', 'Set-RubrikAv
             { Set-RubrikAvailabilityGroup -id 'AG1' -LogBackupFrequencyInSeconds 'sixty'  } |
                 Should -Throw "Cannot process argument transformation on parameter 'LogBackupFrequencyInSeconds'."
         }
+
+        It -Name 'Parameter sets should be enforced' -Test {
+            { Set-RubrikAvailabilityGroup -SLA 'Gold' -id 'AG:1111' -CopyOnly -LogBackupFrequencyInSeconds 60 -LogRetentionHours 1 } |
+                Should -Throw 'Parameter set cannot be resolved using the specified named parameters. One or more parameters issued cannot be used together or an insufficient number of parameters were provided.'
+        }
+
         It -Name 'Parameter LogRetentionHours is integer' -Test {
             { Set-RubrikAvailabilityGroup -id 'AG1' -LogRetentionHours 'one'  } |
                 Should -Throw "Cannot process argument transformation on parameter 'LogRetentionHours'."


### PR DESCRIPTION
# Description

Running a command like this:
Get-RubrikAvailabilityGroup -GroupName 'TBXAGQA01' | Set-RubrikAvailabilityGroup -LogBackupFrequencyInSeconds 900

Will set the LogRetentionHours to -1.
From reading the code both LogRetentionHours and LogBackupFrequencyInSeconds have a default value of -1 if nothing is provided.

Provide information about the failure by issuing the command using the -Verbose command. Ensure that any identifiable information (server names, tokens, passwords) is removed from your logs before sharing this on GitHub.

Paste the verbose output from the command here
Expected Behavior:
When passing in LogBackupFrequencyInSeconds, LogRetentionHours should be a mandatory value to fill in and vice versa.

## Related Issue

Resolve #619 

## How Has This Been Tested?

Existing tests pass 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
