### PR TITLE
Additional `ReportTemplate` reports to the validation in `New-RubrikReport` [Issue 628]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added additional `ReportTemplate` reports to the validation in `New-RubrikReport` [Issue 628](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/628)
 * Added public cmdlets `Get-RubrikModuleOption`,`Set-RubrikModuleOption`,`Get-RubrikModuleDefaultParameter`,`Set-RubrikModuleDefaultParameter`, and `Remove-RubrikModuleDefaultParameter`.  Added Private functions `Set-RubrikDefaultParameterValue.ps1`, `Update-RubrikModuleOption.ps1`, and `Sync-RubrikOptionsFile` to support the creation of customized module options and default parameters as per [Issue 518](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/518)
 * Added public cmdlets `Get-RubrikModuleOption`,`Set-RubrikModuleOption`,`Get-RubrikModuleDefaultParameter`,`Set-RubrikModuleDefaultParameter`, and `Remove-RubrikModuleDefaultParameter`.  Added Private functions `Set-RubrikDefaultParameterValues.ps1`, `Update-RubrikModuleOption.ps1`, and `Sync-RubrikOptionsFile` to support the creation of customized module options and default parameters as per [Issue 518](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/518)
 * Added new private function `Get-RubrikDetailedResult` to replace duplicated -DetailedObject code.

--- a/Rubrik/Public/New-RubrikReport.ps1
+++ b/Rubrik/Public/New-RubrikReport.ps1
@@ -1,7 +1,7 @@
 #requires -Version 3
 function New-RubrikReport
 {
-  <#  
+  <#
       .SYNOPSIS
       Create a new report by specifying one of the report templates
 
@@ -27,8 +27,8 @@ function New-RubrikReport
     [Parameter(Mandatory = $true)]
     [String]$Name,
     # The template this report is based on
-    [Parameter(Mandatory = $true)]    
-    [ValidateSet('ProtectionTasksDetails','ProtectionTasksSummary','SystemCapacity','SlaComplianceSummary')]
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('CapacityOverTime', 'ObjectProtectionSummary', 'ObjectTaskSummary', 'ObjectIndexingSummary', 'ProtectionTasksDetails', 'ProtectionTasksSummary', 'RecoveryTasksDetails', 'SlaComplianceSummary', 'SystemCapacity')]
     [String]$ReportTemplate,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,

--- a/Tests/New-RubrikReport.Tests.ps1
+++ b/Tests/New-RubrikReport.Tests.ps1
@@ -48,7 +48,7 @@ Describe -Name 'Public/New-RubrikReport' -Tag 'Public', 'New-RubrikReport' -Fixt
         }
         It -Name 'ValidateSet ReportTemplate' -Test {
             { New-RubrikReport -name 'Test' -ReportTemplate 'NotCorrect'  } |
-                Should -Throw 'The argument "NotCorrect" does not belong to the set "ProtectionTasksDetails,ProtectionTasksSummary,SystemCapacity,SlaComplianceSummary" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.'
+                Should -Throw 'The argument "NotCorrect" does not belong to the set "CapacityOverTime,ObjectProtectionSummary,ObjectTaskSummary,ObjectIndexingSummary,ProtectionTasksDetails,ProtectionTasksSummary,RecoveryTasksDetails,SlaComplianceSummary,SystemCapacity" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.'
         }
     }
 }


### PR DESCRIPTION
## Current Behavior:

Create report using ObjectProtectionSummary template:

```
PS /mnt/c/WINDOWS/System32> $report = new-rubrikreport -Name $ReportName -ReportTemplate 'ObjectProtectionSummary' -Verbose
New-RubrikReport: Cannot validate argument on parameter 'ReportTemplate'. The argument "ObjectProtectionSummary" does not belong to the set "ProtectionTasksDetails,ProtectionTasksSummary,SystemCapacity,SlaComplianceSummary" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.
Expected Behavior:
```

Can use any of the available templates. In 5.1 this is the list:

![image](https://user-images.githubusercontent.com/12744735/82204083-8ba53380-9904-11ea-9d4a-81db45120f32.png)


## Related Issue

Resolve #628

## How Has This Been Tested?

Existing tests pass 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.

