### PR TITLE
Update Protect-RubrikVM with -ExistingSnapshotRetention #298

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added new parameter to `Protect-RubrikVM` `-ExistingSnapshotRetention` as requested in [Issue 298](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/298)
 * Added public cmdlets `Get-RubrikModuleOption`,`Set-RubrikModuleOption`,`Get-RubrikModuleDefaultParameter`,`Set-RubrikModuleDefaultParameter`, and `Remove-RubrikModuleDefaultParameter`.  Added Private functions `Set-RubrikDefaultParameterValue.ps1`, `Update-RubrikModuleOption.ps1`, and `Sync-RubrikOptionsFile` to support the creation of customized module options and default parameters as per [Issue 518](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/518)
 * Added public cmdlets `Get-RubrikModuleOption`,`Set-RubrikModuleOption`,`Get-RubrikModuleDefaultParameter`,`Set-RubrikModuleDefaultParameter`, and `Remove-RubrikModuleDefaultParameter`.  Added Private functions `Set-RubrikDefaultParameterValues.ps1`, `Update-RubrikModuleOption.ps1`, and `Sync-RubrikOptionsFile` to support the creation of customized module options and default parameters as per [Issue 518](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/518)
 * Added new private function `Get-RubrikDetailedResult` to replace duplicated -DetailedObject code.

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -2156,7 +2156,8 @@ function Get-RubrikAPIData {
                 URI         = '/api/v1/vmware/vm/{id}'
                 Method      = 'Patch'
                 Body        = @{
-                    configuredSlaDomainId = 'configuredSlaDomainId'
+                    configuredSlaDomainId     = 'configuredSlaDomainId'
+                    existingSnapshotRetention = 'existingSnapshotRetention'
                 }
                 Query       = ''
                 Result      = ''

--- a/Rubrik/Public/Protect-RubrikVM.ps1
+++ b/Rubrik/Public/Protect-RubrikVM.ps1
@@ -4,30 +4,37 @@ function Protect-RubrikVM
   <#
       .SYNOPSIS
       Connects to Rubrik and assigns an SLA to a virtual machine
-            
+
       .DESCRIPTION
       The Protect-RubrikVM cmdlet will update a virtual machine's SLA Domain assignment within the Rubrik cluster.
       The SLA Domain contains all policy-driven values needed to protect workloads.
       Note that this function requires the virtual machine ID value, not the name of the virtual machine, since virtual machine names are not unique across clusters.
       It is suggested that you first use Get-RubrikVM to narrow down the one or more virtual machine to protect, and then pipe the results to Protect-RubrikVM.
       You will be asked to confirm each virtual machine you wish to protect, or you can use -Confirm:$False to skip confirmation checks.
-            
+
       .NOTES
       Written by Chris Wahl for community usage
       Twitter: @ChrisWahl
       GitHub: chriswahl
-            
+
       .LINK
       https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/protect-rubrikvm
-            
+
       .EXAMPLE
       Get-RubrikVM "VM1" | Protect-RubrikVM -SLA 'Gold'
+
       This will assign the Gold SLA Domain to any virtual machine named "VM1"
 
       .EXAMPLE
       Get-RubrikVM "VM1" -SLA Silver | Protect-RubrikVM -SLA 'Gold' -Confirm:$False
+
       This will assign the Gold SLA Domain to any virtual machine named "VM1" that is currently assigned to the Silver SLA Domain
       without asking for confirmation
+
+      .EXAMPLE
+      Get-RubrikVM "VM1" -SLA Silver | Protect-RubrikVM -SLA 'Gold' -ExistingSnapshotRetention KeepForever
+
+      This will assign the Gold SLA Domain to any virtual machine named "VM1" that is currently assigned to the Silver SLA Domain keeping existing snapshots forever
   #>
 
   [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = 'High',DefaultParameterSetName="None")]
@@ -47,7 +54,10 @@ function Protect-RubrikVM
     [Switch]$Inherit,
     # SLA id value
     [Alias('configuredSlaDomainId')]
-    [String]$SLAID = (Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect -Mandatory:$true),    
+    [String]$SLAID = (Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect -Mandatory:$true),
+    # Determine the retention settings for the already existing snapshots
+    [ValidateSet('RetainSnapshots', 'KeepForever', 'ExpireImmediately')]
+    [string] $ExistingSnapshotRetention,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
     # API version

--- a/Rubrik/Public/Protect-RubrikVM.ps1
+++ b/Rubrik/Public/Protect-RubrikVM.ps1
@@ -56,8 +56,9 @@ function Protect-RubrikVM
     [Alias('configuredSlaDomainId')]
     [String]$SLAID = (Test-RubrikSLA -SLA $SLA -Inherit $Inherit -DoNotProtect $DoNotProtect -Mandatory:$true),
     # Determine the retention settings for the already existing snapshots
+    [Parameter(ParameterSetName = 'SLA_Unprotected')]
     [ValidateSet('RetainSnapshots', 'KeepForever', 'ExpireImmediately')]
-    [string] $ExistingSnapshotRetention,
+    [string] $ExistingSnapshotRetention = 'RetainSnapshots',
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,
     # API version

--- a/Tests/Protect-RubrikVM.Tests.ps1
+++ b/Tests/Protect-RubrikVM.Tests.ps1
@@ -100,5 +100,9 @@ Describe -Name 'Public/Protect-RubrikVM' -Tag 'Public', 'Protect-RubrikVM' -Fixt
             { Protect-RubrikVM -Id VirtualMachine:::1226ff04-6100-454f-905b-5df817b6981a-vm-1025 -DoNotProtect -Inherit} |
                 Should -Throw "Parameter set cannot be resolved using the specified named parameters."
         }
+        It -Name 'Should use correct ExistingSnapshotRetention value' -Test {
+            { Protect-RubrikVM -Id VirtualMachine:::1226ff04-6100-454f-905b-5df817b6981a-vm-1025 -DoNotProtect -ExistingSnapshotRetention ThisShouldFail} |
+                Should -Throw 'The argument "ThisShouldFail" does not belong to the set "RetainSnapshots,KeepForever,ExpireImmediately" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.'
+        }
     }
 }


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

Unable to use Protect-RubrikVM (or Database/Fileset/HyperVVM/NutanixVM) to unprotect an object and set snapshot retention to one of the following (new in 5.0):

RetainSnapshots (Use current SLA domain for retention)
KeepForever
ExpireImmediately

## Related Issue

Resolves #298

## Motivation and Context

New switches to specify these options

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
