### PR TITLE
Additional error handling and debugging added for `Unblock-SelfSignedCert` - Fixes Issue #613

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Changed how `Set-RubrikNASShare` creates the body object [Issue 614](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/614) and added new unit tests for this function
 * Modified `Set-RubrikAvailabilityGroup` and made `-LogRetentionHours` parameters mandatory while removing default value of -1
 * Modified private function `Set-ObjectTypeName.ps1` to support the new `ApplyCustomViewDefinitions`.
 * Modified module script file `rubrik.psm1` to create options file if it doesn't exist, and update any current options file if it does exist. Also loads any default parameter options into $global:PSDefaultParameterValues
@@ -49,7 +50,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-* Added two new public cmdlets `Get-RubrikDownloadLink` and `Start-RubrikDownload` to manage downloads of snapshots or partial snapshots from the Rubrik Cluster [Issue 624](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/624)
 * Added public cmdlets `Get-RubrikModuleOption`,`Set-RubrikModuleOption`,`Get-RubrikModuleDefaultParameter`,`Set-RubrikModuleDefaultParameter`, and `Remove-RubrikModuleDefaultParameter`.  Added Private functions `Set-RubrikDefaultParameterValue.ps1`, `Update-RubrikModuleOption.ps1`, and `Sync-RubrikOptionsFile` to support the creation of customized module options and default parameters as per [Issue 518](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/518)
 * Added public cmdlets `Get-RubrikModuleOption`,`Set-RubrikModuleOption`,`Get-RubrikModuleDefaultParameter`,`Set-RubrikModuleDefaultParameter`, and `Remove-RubrikModuleDefaultParameter`.  Added Private functions `Set-RubrikDefaultParameterValues.ps1`, `Update-RubrikModuleOption.ps1`, and `Sync-RubrikOptionsFile` to support the creation of customized module options and default parameters as per [Issue 518](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/518)
 * Added new private function `Get-RubrikDetailedResult` to replace duplicated -DetailedObject code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-* Changed how `Set-RubrikNASShare` creates the body object [Issue 614](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/614) and added new unit tests for this function
 * Modified `Set-RubrikAvailabilityGroup` and made `-LogRetentionHours` parameters mandatory while removing default value of -1
 * Modified private function `Set-ObjectTypeName.ps1` to support the new `ApplyCustomViewDefinitions`.
 * Modified module script file `rubrik.psm1` to create options file if it doesn't exist, and update any current options file if it does exist. Also loads any default parameter options into $global:PSDefaultParameterValues
@@ -50,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added two new public cmdlets `Get-RubrikDownloadLink` and `Start-RubrikDownload` to manage downloads of snapshots or partial snapshots from the Rubrik Cluster [Issue 624](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/624)
 * Added public cmdlets `Get-RubrikModuleOption`,`Set-RubrikModuleOption`,`Get-RubrikModuleDefaultParameter`,`Set-RubrikModuleDefaultParameter`, and `Remove-RubrikModuleDefaultParameter`.  Added Private functions `Set-RubrikDefaultParameterValue.ps1`, `Update-RubrikModuleOption.ps1`, and `Sync-RubrikOptionsFile` to support the creation of customized module options and default parameters as per [Issue 518](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/518)
 * Added public cmdlets `Get-RubrikModuleOption`,`Set-RubrikModuleOption`,`Get-RubrikModuleDefaultParameter`,`Set-RubrikModuleDefaultParameter`, and `Remove-RubrikModuleDefaultParameter`.  Added Private functions `Set-RubrikDefaultParameterValues.ps1`, `Update-RubrikModuleOption.ps1`, and `Sync-RubrikOptionsFile` to support the creation of customized module options and default parameters as per [Issue 518](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/518)
 * Added new private function `Get-RubrikDetailedResult` to replace duplicated -DetailedObject code.
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Added error handling for cases where Add-Type in `Unblock-SelfSignedCert` fails. `-Debug` switch can be used to determine root cause of failure. [Issue 613](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/613)
 * Fixed incorrect array in body of `Restore-RubrikDatabase` and added tests to validate new behavior in `Restore-RubrikDatabase.Tests`
 * Fixed incorrect array in body of `Export-RubrikDatabase` and added tests to validate new behavior in `Export-RubrikDatabase.Tests`
 * Fixed incorrect array in body of `New-RubrikDatabaseMount` and added tests to validate new behavior in `New-RubrikDatabaseMount.Tests`

--- a/Rubrik/Private/Unblock-SelfSignedCert.ps1
+++ b/Rubrik/Private/Unblock-SelfSignedCert.ps1
@@ -1,4 +1,6 @@
-﻿function Unblock-SelfSignedCert() {
+﻿function Unblock-SelfSignedCert {
+  [cmdletbinding()]
+  param()
   <#
     .SYNOPSIS
     Allows the use of self-signed certficates
@@ -10,17 +12,24 @@
   Write-Verbose -Message 'Allowing self-signed certificates'
     
   if ([System.Net.ServicePointManager]::CertificatePolicy -notlike 'TrustAllCertsPolicy') {
-    Add-Type -TypeDefinition @"
-    using System.Net;
-    using System.Security.Cryptography.X509Certificates;
-    public class TrustAllCertsPolicy : ICertificatePolicy {
-	    public bool CheckValidationResult(
-	        ServicePoint srvPoint, X509Certificate certificate,
-	        WebRequest request, int certificateProblem) {
-	        return true;
-	    }
-    }
+    # Added try catch block to resolve issue #613
+    $ErrorActionPreference = 'Stop'
+    try {
+      Add-Type -TypeDefinition @"
+      using System.Net;
+      using System.Security.Cryptography.X509Certificates;
+      public class TrustAllCertsPolicy : ICertificatePolicy {
+        public bool CheckValidationResult(
+            ServicePoint srvPoint, X509Certificate certificate,
+            WebRequest request, int certificateProblem) {
+            return true;
+        }
+      }
 "@
-    [System.Net.ServicePointManager]::CertificatePolicy = New-Object -TypeName TrustAllCertsPolicy
+      [System.Net.ServicePointManager]::CertificatePolicy = New-Object -TypeName TrustAllCertsPolicy
+    } catch {
+      Write-Warning 'An error occured while attempting to allow self-signed certificates'
+      Write-Debug ($Error[0] | ConvertTo-Json | Out-String)
+    }
   }
 }


### PR DESCRIPTION
# Description

I run a script that connects to Rubrik using a token. Here is the command:
Connect-Rubrik -Server $BackupLocation -Token $Token

It returns the error message below, but at the same time it successfully connects and proceeds with further Rubrik steps (Database Export).

## Related Issue

Resolve #613 

## Motivation and Context

Adding this manual type can throw errors when certain versions of PowerShell, Windows, and .Net are used in combination. Since subsequent commands might run successfully I decided to do a catch all for all compilation errors and add a `-Debug` switch that can be used for further troubleshooting of individual cases.

## How Has This Been Tested?

Existing unit tests passed and ran on pwsh 7 / 5

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
