### PR TITLE
Added structured output to Get-RubrikReportData - #549

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Added new property to `Get-RubrikReportData` : `DataGridObject` which returns the datagrid results as PowerShell custom objects [Issue 549](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/549)
 * Changed how `Set-RubrikNASShare` creates the body object [Issue 614](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/614) and added new unit tests for this function
 * Modified `Set-RubrikAvailabilityGroup` and made `-LogRetentionHours` parameters mandatory while removing default value of -1
 * Modified private function `Set-ObjectTypeName.ps1` to support the new `ApplyCustomViewDefinitions`.

--- a/Rubrik/Public/Get-RubrikReportData.ps1
+++ b/Rubrik/Public/Get-RubrikReportData.ps1
@@ -1,6 +1,6 @@
 #requires -Version 3
 function Get-RubrikReportData {
-  <#  
+  <#
       .SYNOPSIS
       Retrieve table data for a specific Envision report
 
@@ -30,12 +30,16 @@ function Get-RubrikReportData {
       .EXAMPLE
       Get-RubrikReport -Name 'Object Protection Summary' | Get-RubrikReportData -Limit -1
       This will return all of the table data from the "Object Protection Summary" report. Note: Using '-Limit -1' may affect performance for reports containing large amounts of data.
+
+      .EXAMPLE
+      (Get-RubrikReport -Name "System Capacity" | Get-RubrikReportData).DatagridObject | Format-Table
+      This will return a human readable table view of the items within the System Capacity report.
   #>
 
   [CmdletBinding()]
   Param(
     # The ID of the report
-    [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]    
+    [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
     [String]$id,
     # Search table data by object name
     [Alias('search_value')]
@@ -52,7 +56,7 @@ function Get-RubrikReportData {
     # Filter table data on compliance status
     [Alias('compliance_status')]
     [ValidateSet('InCompliance','NonCompliance')]
-    [String]$ComplianceStatus,  
+    [String]$ComplianceStatus,
     #limit the number of rows returned, defaults to maximum pageSize of 9999. Use a value of '-1' to remove limit restrictions
     [int]$limit,
     #cursor start (if necessary)
@@ -67,20 +71,20 @@ function Get-RubrikReportData {
 
     # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
     # If a command needs to be run with each iteration or pipeline input, place it in the Process section
-    
+
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
-    
+
     # API data references the name of the function
     # For convenience, that name is saved here to $function
     $function = $MyInvocation.MyCommand.Name
-        
+
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
+
     # Set limit to default of 9999 if not set, both limit and psboundparameters are set, this is because New-BodyString builds the query using both variables
     if ($null -eq $PSBoundParameters.limit) {
       $PSBoundParameters.Add('limit',9999) | Out-Null
@@ -92,24 +96,24 @@ function Get-RubrikReportData {
       $limit = 150
       $returnAll = $true
     }
-    
+
   }
 
   Process {
 
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
-    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)    
-    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body 
+    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
 
     # if limit has been set to -1
     if ($returnAll -and $result.hasMore -eq 'true') {
       # duplicate response to save initial returned data
       $nextresult = $result
       $PSBoundParameters.Add('cursor',$nextresult.cursor)
-      
+
       Write-Verbose -Message "Result limits hit. Retrieving remaining data based on pagination"
-      $result.dataGrid += 
+      $result.dataGrid +=
         do {
           $cursor = $nextresult.cursor
           $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)

--- a/Rubrik/Public/Get-RubrikReportData.ps1
+++ b/Rubrik/Public/Get-RubrikReportData.ps1
@@ -120,6 +120,23 @@ function Get-RubrikReportData {
     }
     $result.hasMore = 'false'
 
+    $result = $result | Select-Object -Property *,@{
+      name = 'DatagridObject'
+      expression = {
+        $result.datagrid | ForEach-Object {
+          $_ | ForEach-Object -Begin {
+              $Count = 0
+              $HashProps = [ordered]@{}
+          } -Process {
+              $HashProps.$($result.columns[$Count]) = $_
+              $Count++
+          } -End {
+              [pscustomobject]$HashProps
+          }
+        }
+      }
+    }
+
     return $result
 
   } # End of process

--- a/Tests/Get-RubrikReportData.Tests.ps1
+++ b/Tests/Get-RubrikReportData.Tests.ps1
@@ -22,11 +22,12 @@ Describe -Name 'Public/Get-RubrikReportData' -Tag 'Public', 'Get-RubrikReportDat
     Context -Name 'Returned Results' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}    
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{ 
+            [pscustomobject]@{ 
                 'columns'               = @('TaskStatus','TaskType','ObjectId','ObjectName')
                 'cursor'                = '1111-2222-3333'
                 'reportTemplate'        = 'ProtectionTaskDetails'
-                'datagrid'              = @('OracleDatabase','Backup','11111','OracleHR')  
+                'datagrid'              = @('OracleDatabase','Backup','11111','OracleHR')
+                'hasmore'               = $false
             }
         }
         It -Name 'Returns reportTemplate' -Test {

--- a/Tests/Get-RubrikReportData.Tests.ps1
+++ b/Tests/Get-RubrikReportData.Tests.ps1
@@ -67,4 +67,25 @@ Describe -Name 'Public/Get-RubrikReportData' -Tag 'Public', 'Get-RubrikReportDat
                 Should -Throw 'The argument "NotCorrect" does not belong to the set "InCompliance,NonCompliance" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.'
         }
     }
+
+    Context -Name 'DatagridObject Validation' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}    
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            [pscustomobject]@{ 
+                'columns'               = ('ObjectId','ObjectState','ComplianceStatus','MissedLocalSnapshots') -as [array]
+                'cursor'                = '1111-2222-3333'
+                'reportTemplate'        = 'ProtectionTaskDetails'
+                'datagrid'              = 'ManagedVolume:::1111','Active','NonCompliance','42'
+                'hasmore'               = $false
+            }
+        }
+
+        $ReportDataResult = Get-RubrikReportData -id 1111
+
+        it "Datagridobject 'ObjectId' should be correct" {
+            $ReportDataResult.DatagridObject.ObjectId[0] |
+                Should -BeExactly 'ManagedVolume:::1111'
+        }
+
+    }
 }


### PR DESCRIPTION
# Description

Is your feature request related to a problem? Please describe.

No. Currently when running Get-RubrikReportData with the reporting ID, it returns a valid response, however, Rubrik Reporting keeps the Column names separated to the actual data, meaning when you loop through the dataGrid object, you are unable to correlate the columns.

It's difficult for users of the SDK to easily handle reporting data. For example:

## Related Issue

Resolves #549 

## Motivation and Context

Adds structured output, makes it easier to filter and process output of this cmdlet

## How Has This Been Tested?

Existing tests pass, new test added

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
