### PR TITLE
Added Invoke-RubrikGraphQLCall to the module - Issue #637

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added new public cmdlet `Invoke-RubrikGraphQLCall` to provide a way of interacting with the GraphQL endpoint using this module [Issue 637](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/637)
 * Added public cmdlets `Get-RubrikModuleOption`,`Set-RubrikModuleOption`,`Get-RubrikModuleDefaultParameter`,`Set-RubrikModuleDefaultParameter`, and `Remove-RubrikModuleDefaultParameter`.  Added Private functions `Set-RubrikDefaultParameterValue.ps1`, `Update-RubrikModuleOption.ps1`, and `Sync-RubrikOptionsFile` to support the creation of customized module options and default parameters as per [Issue 518](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/518)
 * Added public cmdlets `Get-RubrikModuleOption`,`Set-RubrikModuleOption`,`Get-RubrikModuleDefaultParameter`,`Set-RubrikModuleDefaultParameter`, and `Remove-RubrikModuleDefaultParameter`.  Added Private functions `Set-RubrikDefaultParameterValues.ps1`, `Update-RubrikModuleOption.ps1`, and `Sync-RubrikOptionsFile` to support the creation of customized module options and default parameters as per [Issue 518](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/518)
 * Added new private function `Get-RubrikDetailedResult` to replace duplicated -DetailedObject code.

--- a/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
@@ -38,10 +38,29 @@ Returns informations on Rubrik Organizations, filtered by name in ascending orde
     [cmdletbinding()]
     Param (
         #Hash table body to pass to API call
-        [Parameter(Mandatory = $false,HelpMessage = 'REST Content')]
+        [Parameter(
+            Mandatory,
+            ParameterSetName='JSON'
+        )]
+        [Parameter(
+            Mandatory,
+            ParameterSetName='Node'
+        )]
+        [Parameter(
+            Mandatory,
+            ParameterSetName='Default'
+        )]
         [ValidateNotNullorEmpty()]
         [string]$Body,
+        [Parameter(
+            Mandatory,
+            ParameterSetName='JSON'
+        )]
         [switch]$ReturnJSON,
+        [Parameter(
+            Mandatory,
+            ParameterSetName='Node'
+        )]
         [switch]$ReturnNode,
         # Rubrik server IP or FQDN
         [String]$Server = $global:RubrikConnection.server,

--- a/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
@@ -25,6 +25,11 @@ Invoke-RubrikGraphQLCall -ReturnJSON -Body '{"query":"query{vms {\nnumProtected\
 Returns the number of protected and unprotected VMware VM objects as a JSON string
 
 .EXAMPLE
+Invoke-RubrikGraphQLCall -ReturnJSON -Verbose -Body '{"query":"query{\r\n  vmwareVirtualMachineConnection(name: \"jbrasser-win\", primaryClusterId: \"local\") {\nedges {\n  node {\n name,\n id,\n primaryClusterId,\n configuredSlaDomainId\n  }\n}\r\n  }\r\n}"}''{"query":"query{\r\n  vmwareVirtualMachineConnection(name: \"jbrasser-win\", primaryClusterId: \"local\") {\nedges {\n  node {\n name,\n id,\n primaryClusterId,\n configuredSlaDomainId\n  }\n}\r\n  }\r\n}"}'
+
+Returns Jaap's Windows VM on the local Rubrik cluster as a JSON string, while displaying Verbose information
+
+.EXAMPLE
 Invoke-RubrikGraphQLCall -ReturnNode -Body '{"query":"query{\r\n  vmwareVirtualMachineConnection{\nedges {\n  node {\nhostId\neffectiveSlaDomain {\nid\nname\n}\nprimaryClusterId\nconfiguredSlaDomainId\nid\nvmwareToolsInstalled\nisRelic\nname\nvcenterId\nfolderPath {\nid\nname\n}\ninfraPath {\nid\nname\n}\nagentStatus {\nagentStatus\ndisconnectReason\n}\nhostName\nclusterName\n  }\n}\r\n  }\r\n}","variables":{}}'
 
 Returns all VMware VMs on the Rubrik Cluster and displays the individual objects by using the -ReturnNode parameter

--- a/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
@@ -30,6 +30,12 @@ Invoke-RubrikGraphQLCall -ReturnJSON -Verbose -Body '{"query":"query{\r\n  vmwar
 Returns Jaap's Windows VM on the local Rubrik cluster as a JSON string, while displaying Verbose information
 
 .EXAMPLE
+Invoke-RubrikGraphQLCall -ReturnNode -Body '{"query":"query ( $name: String) {\nvmwareVirtualMachineConnection(name: $name, primaryClusterId: \"local\") {\n  edges {\nnode {\n  name,\n  id,\n  primaryClusterId,\n  configuredSlaDomainId\n}\n  }\n}\r\n}",
+    "variables":{"name":"jbrasser-lin"}}'
+
+Returns Jaap's Linux VM on the local Rubrik cluster as the VM Object, using a variable as input for vmwareVirtualMachineConnection 
+
+.EXAMPLE
 Invoke-RubrikGraphQLCall -ReturnNode -Body '{"query":"query{\r\n  vmwareVirtualMachineConnection{\nedges {\n  node {\nhostId\neffectiveSlaDomain {\nid\nname\n}\nprimaryClusterId\nconfiguredSlaDomainId\nid\nvmwareToolsInstalled\nisRelic\nname\nvcenterId\nfolderPath {\nid\nname\n}\ninfraPath {\nid\nname\n}\nagentStatus {\nagentStatus\ndisconnectReason\n}\nhostName\nclusterName\n  }\n}\r\n  }\r\n}","variables":{}}'
 
 Returns all VMware VMs on the Rubrik Cluster and displays the individual objects by using the -ReturnNode parameter

--- a/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
@@ -118,7 +118,7 @@ Returns informations on Rubrik Organizations, filtered by name in ascending orde
                         $result = Invoke-WebRequest -TimeoutSec $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut @WebSplat |
                             Select-Object -ExpandProperty Content
                     } else {
-                        $result = Invoke-WebRequest @WebSplat 
+                        $result = Invoke-WebRequest @WebSplat |
                             Select-Object -ExpandProperty Content
                     }
                 }

--- a/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
@@ -1,15 +1,10 @@
 function Invoke-RubrikGraphQLCall {
 <#
 .SYNOPSIS
-Provides generic interface to make Rubrik REST API calls
+Provides generic interface to make Rubrik GraphQL API calls
 
 .DESCRIPTION
-The Invoke-RubrikGraphQLCall allows users to make raw API endpoint calls to the Rubrik REST interface. The user
-will need to manage the format of both the endpoint call(including resource ids) and body, but provides the
-option to make cmdlet independent API calls for automating Rubrik actions through PowerShell. The Rubrik API
-reference is found on the Rubrik device at:
-<Rubrik IP>/docs/v1
-<Rubrik IP>/docs/v1/playground
+The Invoke-RubrikGraphQLCall allows users to make raw API endpoint calls to the Rubrik GraphQL interface. To find out more about the GraphQL endpoint take a look at the Rubrik GraphQL Playground project that is hosted on GitHub: https://github.com/rubrikinc/graphql-playground
 
 .NOTES
 Written by Jaap Brasser for community usage
@@ -20,88 +15,100 @@ GitHub: jaapbrasser
 https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/invoke-rubrikgraphqlcall
 
 .EXAMPLE
-Invoke-RubrikGraphQLCall -Endpoint 'vmware/vm' -Method GET
+Invoke-RubrikGraphQLCall -Body '{"query":"{vmwareVcenterTotalCount}"}' -Verbose
 
-Retrieve the raw output for all VMWare VMs being managed by the Rubrik device.
-
-.EXAMPLE
-Invoke-RubrikGraphQLCall -Endpoint 'vmware/vm' -Method GET -Query @{'name'='msf-sql2016'}
-Retrieve the raw output for the VMWare VM msf-sql2016 using a query parameter.
+Will retrieve the total count of VMware vCenters connected to the Rubrik cluster as a PowerShell object
 
 .EXAMPLE
-$body = New-Object -TypeName PSObject -Property @{'slaID'='INHERIT';'ForceFullSnapshot'='FALSE'}
-Invoke-RubrikGraphQLCall -Endpoint 'vmware/vm/VirtualMachine:::fbcb1f51-9520-4227-a68c-6fe145982f48-vm-649/snapshot' -Method POST -Body $body
+Invoke-RubrikGraphQLCall -ReturnJSON -Body '{"query":"query{vms {\nnumProtected\n  numUnprotected\n}}"}'
 
-Execute an on-demand snapshot for the VMWare VM where the id is part of the endpoint.
+Returns the number of protected and unprotected VMware VM objects as a JSON string
 
 .EXAMPLE
-$body = New-Object -TypeName PSObject -Property @{'isPassthrough'=$true;'shareId'='HostShare:::11111';'templateId'='FilesetTemplate:::22222'}
-Invoke-RubrikGraphQLCall -Endpoint 'fileset_template/bulk' -Method POST -Body $body -BodyAsArray
+Invoke-RubrikGraphQLCall -ReturnNode -Body '{"query":"query{\r\n  vmwareVirtualMachineConnection{\nedges {\n  node {\nhostId\neffectiveSlaDomain {\nid\nname\n}\nprimaryClusterId\nconfiguredSlaDomainId\nid\nvmwareToolsInstalled\nisRelic\nname\nvcenterId\nfolderPath {\nid\nname\n}\ninfraPath {\nid\nname\n}\nagentStatus {\nagentStatus\ndisconnectReason\n}\nhostName\nclusterName\n  }\n}\r\n  }\r\n}","variables":{}}'
 
-Creates a new fileset from the given fileset template and the given host id supporting Direct Archive.  Since fileset_template/bulk expects an array, we force the single item array with the BodyAsArray parameter.
+Returns all VMware VMs on the Rubrik Cluster and displays the individual objects by using the -ReturnNode parameter
+
+.EXAMPLE
+Invoke-RubrikGraphQLCall -ReturnNode -Body '{"query":"query OrganizationSummary(\n $name: String,\n $isGlobal: Boolean,\n $sortBy: String,\n $sortOrder: String,\n $first: Int,\n $after: String,\n) {\n organizationConnection(\n name: $name,\n isGlobal: $isGlobal,\n sortBy: $sortBy,\n sortOrder: $sortOrder,\n first: $first,\n after: $after\n ) {\n nodes {\n id\n name\n isGlobal\n exclusivenessLevel\n admins {\n id\n name\n }\n envoyStatus\n }\n pageInfo {\n endCursor\n hasNextPage\n }\n }\n}\n","variables":{"sortBy":"name","sortOrder":"asc","first":3,"name":"org","isGlobal":false}}'
+
+Returns informations on Rubrik Organizations, filtered by name in ascending order and only including organizations with 'org' in their name property. Returns the individual organization objects using the -ReturnNode parameter
 #>
     
-      [cmdletbinding()]
-      Param (
-          #Rubrik API endpoint, DO NOT USE LEADING '/'
-          [Parameter(Mandatory = $true,HelpMessage = 'REST Endpoint')]
-          [ValidateNotNullorEmpty()]
-          [System.String]$Endpoint,
-          #Hash table body to pass to API call
-          [Parameter(Mandatory = $false,HelpMessage = 'REST Content')]
-          [ValidateNotNullorEmpty()]
-          [psobject]$Body,
-          #Force the body as an array (For endpoints requiring single item arrays)
-          [Parameter(Mandatory = $false, HelpMessage = 'Force Body to be an array')]
-          [Switch]$BodyAsArray,
-          # Rubrik server IP or FQDN
-          [String]$Server = $global:RubrikConnection.server,
-          # API version
-          [ValidateNotNullorEmpty()]
-          [String]$api = $global:RubrikConnection.api
-      )
-      BEGIN
-      {
+    [cmdletbinding()]
+    Param (
+        #Hash table body to pass to API call
+        [Parameter(Mandatory = $false,HelpMessage = 'REST Content')]
+        [ValidateNotNullorEmpty()]
+        [string]$Body,
+        [switch]$ReturnJSON,
+        [switch]$ReturnNode,
+        # Rubrik server IP or FQDN
+        [String]$Server = $global:RubrikConnection.server,
+        # API version
+        [ValidateNotNullorEmpty()]
+        [String]$api = $global:RubrikConnection.api
+    )
+
+    begin {
         #connect to Rubrik if not already connected
         Test-RubrikConnection
-      }
-    
-      PROCESS
-      {
+    }
+
+    process {
         #execute GraphQL operation
         try {
-    
+
             #construct uri
             [string]$uri = New-URIString -server $Server -endpoint "/api/internal/graphql"
-    
-            #If query object, add query parameters to URI
-            if($query)
-            {
-                $querystring = @()
-                foreach($q in $query.Keys)
-                {
-                    $querystring += "$q=$($query[$q])"
+            Write-Verbose -Message "Body = $Body"
+            
+            if ($ReturnJSON) {
+                $WebSplat = @{
+                    Uri = $uri
+                    Headers = $Header
+                    ContentType = 'application/json'
+                    Body = $Body
+                    Method = 'POST'
+                    UseBasicParsing = $true
                 }
-                $uri = New-QueryString -query $querystring -uri $uri
+
+                if (Test-PowerShellSix) {
+                    if ($rubrikOptions.ModuleOption.DefaultWebRequestTimeOut) {
+                        $result = Invoke-WebRequest -SkipCertificateCheck -TimeoutSec $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut @WebSplat |
+                            Select-Object -ExpandProperty Content
+                    } else {
+                        $result = Invoke-WebRequest -SkipCertificateCheck @WebSplat |
+                            Select-Object -ExpandProperty Content
+                    }
+                } else {
+                    if ($rubrikOptions.ModuleOption.DefaultWebRequestTimeOut) {
+                        $result = Invoke-WebRequest -TimeoutSec $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut @WebSplat |
+                            Select-Object -ExpandProperty Content
+                    } else {
+                        $result = Invoke-WebRequest @WebSplat 
+                            Select-Object -ExpandProperty Content
+                    }
+                }
+            } elseif ($ReturnNode) {
+                $result = Submit-Request -uri $uri -header $Header -method POST -body $Body |
+                    Select-Object -ExpandProperty data
+                if (($newresult = $result.$($result.psobject.properties.name).nodes)) {
+                    $result = $newresult
+                } elseif (($newresult = $result.$($result.psobject.properties.name).edges.node)) {
+                    $result = $newresult
+                } else {
+                    Write-Verbose -Message "Nodes property not found in $($result.psobject.properties.name), either no results or results are nested."
+                }
+            } else {
+                $result = Submit-Request -uri $uri -header $Header -method POST -body $Body |
+                    Select-Object -ExpandProperty data
             }
-    
-            #If Method is not a GET call and a REST Body is passed, build the JSON body
-            if($Method -ne 'GET' -and $body){
-                if ($BodyAsArray) {
-                    [string]$JsonBody = ConvertTo-Json -inputobject @($Body) -Depth 10
-                }
-                else {
-                    [string]$JsonBody = $Body | ConvertTo-Json -Depth 10
-                }
-            }
-            Write-Verbose "URI string: $uri"
-            Write-Verbose "Body string: $JsonBody"
-            $result = Submit-Request -uri $uri -header $Header -method $Method -body $JsonBody
         }
         catch {
             throw $_
         }
-    
+
         return $result
-      }
     }
+}

--- a/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
@@ -42,7 +42,7 @@ Returns informations on Rubrik Organizations, filtered by name in ascending orde
     
     [cmdletbinding()]
     Param (
-        #Hash table body to pass to API call
+        # GraphQL Body to send to GraphQL endpoint
         [Parameter(
             Mandatory,
             ParameterSetName='JSON'
@@ -57,11 +57,13 @@ Returns informations on Rubrik Organizations, filtered by name in ascending orde
         )]
         [ValidateNotNullorEmpty()]
         [string]$Body,
+        # Return the JSON object instead of converting it to PowerShell custom objects
         [Parameter(
             Mandatory,
             ParameterSetName='JSON'
         )]
         [switch]$ReturnJSON,
+        # Return the objects in the Node(s) property rather than returning the output as a single custom Object
         [Parameter(
             Mandatory,
             ParameterSetName='Node'

--- a/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
@@ -1,0 +1,107 @@
+function Invoke-RubrikGraphQLCall {
+<#
+.SYNOPSIS
+Provides generic interface to make Rubrik REST API calls
+
+.DESCRIPTION
+The Invoke-RubrikGraphQLCall allows users to make raw API endpoint calls to the Rubrik REST interface. The user
+will need to manage the format of both the endpoint call(including resource ids) and body, but provides the
+option to make cmdlet independent API calls for automating Rubrik actions through PowerShell. The Rubrik API
+reference is found on the Rubrik device at:
+<Rubrik IP>/docs/v1
+<Rubrik IP>/docs/v1/playground
+
+.NOTES
+Written by Jaap Brasser for community usage
+Twitter: @jaap_brasser
+GitHub: jaapbrasser
+
+.LINK
+https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/invoke-rubrikgraphqlcall
+
+.EXAMPLE
+Invoke-RubrikGraphQLCall -Endpoint 'vmware/vm' -Method GET
+
+Retrieve the raw output for all VMWare VMs being managed by the Rubrik device.
+
+.EXAMPLE
+Invoke-RubrikGraphQLCall -Endpoint 'vmware/vm' -Method GET -Query @{'name'='msf-sql2016'}
+Retrieve the raw output for the VMWare VM msf-sql2016 using a query parameter.
+
+.EXAMPLE
+$body = New-Object -TypeName PSObject -Property @{'slaID'='INHERIT';'ForceFullSnapshot'='FALSE'}
+Invoke-RubrikGraphQLCall -Endpoint 'vmware/vm/VirtualMachine:::fbcb1f51-9520-4227-a68c-6fe145982f48-vm-649/snapshot' -Method POST -Body $body
+
+Execute an on-demand snapshot for the VMWare VM where the id is part of the endpoint.
+
+.EXAMPLE
+$body = New-Object -TypeName PSObject -Property @{'isPassthrough'=$true;'shareId'='HostShare:::11111';'templateId'='FilesetTemplate:::22222'}
+Invoke-RubrikGraphQLCall -Endpoint 'fileset_template/bulk' -Method POST -Body $body -BodyAsArray
+
+Creates a new fileset from the given fileset template and the given host id supporting Direct Archive.  Since fileset_template/bulk expects an array, we force the single item array with the BodyAsArray parameter.
+#>
+    
+      [cmdletbinding()]
+      Param (
+          #Rubrik API endpoint, DO NOT USE LEADING '/'
+          [Parameter(Mandatory = $true,HelpMessage = 'REST Endpoint')]
+          [ValidateNotNullorEmpty()]
+          [System.String]$Endpoint,
+          #Hash table body to pass to API call
+          [Parameter(Mandatory = $false,HelpMessage = 'REST Content')]
+          [ValidateNotNullorEmpty()]
+          [psobject]$Body,
+          #Force the body as an array (For endpoints requiring single item arrays)
+          [Parameter(Mandatory = $false, HelpMessage = 'Force Body to be an array')]
+          [Switch]$BodyAsArray,
+          # Rubrik server IP or FQDN
+          [String]$Server = $global:RubrikConnection.server,
+          # API version
+          [ValidateNotNullorEmpty()]
+          [String]$api = $global:RubrikConnection.api
+      )
+      BEGIN
+      {
+        #connect to Rubrik if not already connected
+        Test-RubrikConnection
+      }
+    
+      PROCESS
+      {
+        #execute GraphQL operation
+        try {
+    
+            #construct uri
+            [string]$uri = New-URIString -server $Server -endpoint "/api/internal/graphql"
+    
+            #If query object, add query parameters to URI
+            if($query)
+            {
+                $querystring = @()
+                foreach($q in $query.Keys)
+                {
+                    $querystring += "$q=$($query[$q])"
+                }
+                $uri = New-QueryString -query $querystring -uri $uri
+            }
+    
+            #If Method is not a GET call and a REST Body is passed, build the JSON body
+            if($Method -ne 'GET' -and $body){
+                if ($BodyAsArray) {
+                    [string]$JsonBody = ConvertTo-Json -inputobject @($Body) -Depth 10
+                }
+                else {
+                    [string]$JsonBody = $Body | ConvertTo-Json -Depth 10
+                }
+            }
+            Write-Verbose "URI string: $uri"
+            Write-Verbose "Body string: $JsonBody"
+            $result = Submit-Request -uri $uri -header $Header -method $Method -body $JsonBody
+        }
+        catch {
+            throw $_
+        }
+    
+        return $result
+      }
+    }

--- a/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
@@ -25,7 +25,7 @@ Invoke-RubrikGraphQLCall -ReturnJSON -Body '{"query":"query{vms {\nnumProtected\
 Returns the number of protected and unprotected VMware VM objects as a JSON string
 
 .EXAMPLE
-Invoke-RubrikGraphQLCall -ReturnJSON -Verbose -Body '{"query":"query{\r\n  vmwareVirtualMachineConnection(name: \"jbrasser-win\", primaryClusterId: \"local\") {\nedges {\n  node {\n name,\n id,\n primaryClusterId,\n configuredSlaDomainId\n  }\n}\r\n  }\r\n}"}''{"query":"query{\r\n  vmwareVirtualMachineConnection(name: \"jbrasser-win\", primaryClusterId: \"local\") {\nedges {\n  node {\n name,\n id,\n primaryClusterId,\n configuredSlaDomainId\n  }\n}\r\n  }\r\n}"}'
+Invoke-RubrikGraphQLCall -ReturnJSON -Verbose -Body '{"query":"query{\r\n  vmwareVirtualMachineConnection(name: \"jbrasser-win\", primaryClusterId: \"local\") {\nedges {\n  node {\n name,\n id,\n primaryClusterId,\n configuredSlaDomainId\n  }\n}\r\n  }\r\n}"}'
 
 Returns Jaap's Windows VM on the local Rubrik cluster as a JSON string, while displaying Verbose information
 

--- a/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikGraphQLCall.ps1
@@ -17,7 +17,7 @@ https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/refere
 .EXAMPLE
 Invoke-RubrikGraphQLCall -Body '{"query":"{vmwareVcenterTotalCount}"}' -Verbose
 
-Will retrieve the total count of VMware vCenters connected to the Rubrik cluster as a PowerShell object
+Will retrieve the total count of VMware vCenter Servers connected to the Rubrik cluster as a PowerShell object
 
 .EXAMPLE
 Invoke-RubrikGraphQLCall -ReturnJSON -Body '{"query":"query{vms {\nnumProtected\n  numUnprotected\n}}"}'
@@ -27,13 +27,13 @@ Returns the number of protected and unprotected VMware VM objects as a JSON stri
 .EXAMPLE
 Invoke-RubrikGraphQLCall -ReturnJSON -Verbose -Body '{"query":"query{\r\n  vmwareVirtualMachineConnection(name: \"jbrasser-win\", primaryClusterId: \"local\") {\nedges {\n  node {\n name,\n id,\n primaryClusterId,\n configuredSlaDomainId\n  }\n}\r\n  }\r\n}"}'
 
-Returns Jaap's Windows VM on the local Rubrik cluster as a JSON string, while displaying Verbose information
+Returns the 'jbrasser-win' VM on the local Rubrik cluster as a JSON string, while displaying Verbose information
 
 .EXAMPLE
 Invoke-RubrikGraphQLCall -ReturnNode -Body '{"query":"query ( $name: String) {\nvmwareVirtualMachineConnection(name: $name, primaryClusterId: \"local\") {\n  edges {\nnode {\n  name,\n  id,\n  primaryClusterId,\n  configuredSlaDomainId\n}\n  }\n}\r\n}",
     "variables":{"name":"jbrasser-lin"}}'
 
-Returns Jaap's Linux VM on the local Rubrik cluster as the VM Object, using a variable as input for vmwareVirtualMachineConnection 
+Returns the 'jbrasser-lin' VM on the local Rubrik cluster as the VM Object, using a variable as input for vmwareVirtualMachineConnection
 
 .EXAMPLE
 Invoke-RubrikGraphQLCall -ReturnNode -Body '{"query":"query{\r\n  vmwareVirtualMachineConnection{\nedges {\n  node {\nhostId\neffectiveSlaDomain {\nid\nname\n}\nprimaryClusterId\nconfiguredSlaDomainId\nid\nvmwareToolsInstalled\nisRelic\nname\nvcenterId\nfolderPath {\nid\nname\n}\ninfraPath {\nid\nname\n}\nagentStatus {\nagentStatus\ndisconnectReason\n}\nhostName\nclusterName\n  }\n}\r\n  }\r\n}","variables":{}}'
@@ -45,7 +45,7 @@ Invoke-RubrikGraphQLCall -ReturnNode -Body '{"query":"query OrganizationSummary(
 
 Returns informations on Rubrik Organizations, filtered by name in ascending order and only including organizations with 'org' in their name property. Returns the individual organization objects using the -ReturnNode parameter
 #>
-    
+
     [cmdletbinding()]
     Param (
         # GraphQL Body to send to GraphQL endpoint
@@ -94,7 +94,7 @@ Returns informations on Rubrik Organizations, filtered by name in ascending orde
             #construct uri
             [string]$uri = New-URIString -server $Server -endpoint "/api/internal/graphql"
             Write-Verbose -Message "Body = $Body"
-            
+
             if ($ReturnJSON) {
                 $WebSplat = @{
                     Uri = $uri

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -201,6 +201,7 @@
                    'Get-RubrikVolumeGroup',
                    'Get-RubrikVolumeGroupMount',
                    'Invoke-RubrikRESTCall',
+                   'Invoke-RubrikGraphQLCall',
                    'Move-RubrikMountVMDK',
                    'New-RubrikAPIToken',
                    'New-RubrikBootStrap',

--- a/Tests/Get-RubrikAPIData.Tests.ps1
+++ b/Tests/Get-RubrikAPIData.Tests.ps1
@@ -19,7 +19,7 @@ Describe -Name 'Private/Get-RubrikAPIData' -Tag 'Private', 'Get-RubrikAPIData' -
     }
 
     #Function List
-    $ignorelist = @('Invoke-RubrikRESTCall','Move-RubrikMountVMDK','Sync-RubrikAnnotation','Sync-RubrikTag','Get-RubrikModuleDefaultParameter','Set-RubrikModuleDefaultParameter','Get-RubrikModuleOption','Set-RubrikModuleOption','Remove-RubrikModuleDefaultParameter')
+    $ignorelist = @('Invoke-RubrikRESTCall','Invoke-RubrikGraphQLCall','Move-RubrikMountVMDK','Sync-RubrikAnnotation','Sync-RubrikTag','Get-RubrikModuleDefaultParameter','Set-RubrikModuleDefaultParameter','Get-RubrikModuleOption','Set-RubrikModuleOption','Remove-RubrikModuleDefaultParameter')
     $functions = ( Get-ChildItem -Path './Rubrik/Public' | Where-Object extension -eq '.ps1').Name.Replace('.ps1','')
     $functions = $functions | Where-Object {$ignorelist -notcontains $_}
 
@@ -66,7 +66,7 @@ Describe -Name 'Private/Get-RubrikAPIData' -Tag 'Private', 'Get-RubrikAPIData' -
         It -Name 'Verify property exists' -Test {
             $functions = ( Get-ChildItem -Path './Rubrik/Public' |
                 Where-Object extension -eq '.ps1').Name.Replace('.ps1','')
-            $ignorelist = @('Invoke-RubrikRESTCall','Move-RubrikMountVMDK','Sync-RubrikAnnotation','Sync-RubrikTag','Get-RubrikObject','Get-RubrikDatabaseRecoveryPoint','Get-RubrikModuleDefaultParameter','Set-RubrikModuleDefaultParameter','Get-RubrikModuleOption','Set-RubrikModuleOption','Remove-RubrikModuleDefaultParameter')
+            $ignorelist = @('Invoke-RubrikRESTCall','Invoke-RubrikGraphQLCall','Move-RubrikMountVMDK','Sync-RubrikAnnotation','Sync-RubrikTag','Get-RubrikObject','Get-RubrikDatabaseRecoveryPoint','Get-RubrikModuleDefaultParameter','Set-RubrikModuleDefaultParameter','Get-RubrikModuleOption','Set-RubrikModuleOption','Remove-RubrikModuleDefaultParameter')
             $functions = $functions | Where-Object {$ignorelist -notcontains $_}
             $functions | ForEach-Object {
                 (Get-RubrikAPIData -Endpoint $_).Function |

--- a/Tests/Invoke-RubrikGraphQLCall.Tests.ps1
+++ b/Tests/Invoke-RubrikGraphQLCall.Tests.ps1
@@ -79,7 +79,7 @@ Describe -Name 'Public/Invoke-RubrikGraphQLCall' -Tag 'Public', 'Invoke-RubrikGr
         Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 3
         Assert-MockCalled -CommandName Invoke-WebRequest -ModuleName 'Rubrik' -Exactly 2
     }
-    Context -Name 'Parameter Validation' { 
+    Context -Name 'Parameter Validation' {
         It -Name 'Body cannot be null or empty' -Test {
             { Invoke-RubrikGraphQLCall -Body $null } |
                 Should -Throw "Cannot validate argument on parameter 'Body'."
@@ -95,6 +95,10 @@ Describe -Name 'Public/Invoke-RubrikGraphQLCall' -Tag 'Public', 'Invoke-RubrikGr
         It -Name 'Cannot specify same param twice' -Test {
             { Invoke-RubrikGraphQLCall -ReturnJSON -ReturnJSON -Body 'query' } |
                 Should -Throw "Cannot bind parameter because parameter 'ReturnJSON' is specified more than once. To provide multiple values to parameters that can accept multiple values, use the array syntax. For example, ""-parameter value1,value2,value3""."
-        }  
+        }
+        It -Name 'Cannot use both ReturnJSON and ReturnNode parameters' -Test {
+            { Invoke-RubrikGraphQLCall -ReturnJSON -ReturnNode -Body 'query'} |
+                Should -Throw
+        }
     }
 }

--- a/Tests/Invoke-RubrikGraphQLCall.Tests.ps1
+++ b/Tests/Invoke-RubrikGraphQLCall.Tests.ps1
@@ -5,7 +5,7 @@ foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' |
     . $privateFunctionFilePath
 }
 
-Describe -Name 'Public/Invoke-RubrikRestCall' -Tag 'Public', 'Invoke-RubrikRestCall' -Fixture {
+Describe -Name 'Public/Invoke-RubrikGraphQLCall' -Tag 'Public', 'Invoke-RubrikGraphQLCall' -Fixture {
     #region init
     $global:rubrikConnection = @{
         id      = 'test-id'
@@ -21,51 +21,80 @@ Describe -Name 'Public/Invoke-RubrikRestCall' -Tag 'Public', 'Invoke-RubrikRestC
 
     Context -Name 'Results Filtering' {
         Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Invoke-WebRequest -ModuleName 'Rubrik' -MockWith {
+            [pscustomobject]@{
+                'Content' = '{"Name":"VM3","ID":"VirtualMachine:33333","powerStatus":"poweredOff"}'
+            }
+        }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
-            @{ 
-                'total' = '3'
-                'data'  =   @{ 
-                                'Name'        = 'VM1'
-                                'ID'          = 'VirtualMachine:11111'
-                                'powerStatus' = 'poweredOn'
-                            },
-                            @{ 
-                                'Name'        = 'VM2'
-                                'ID'          = 'VirtualMachine:22222'
-                                'powerStatus' = 'poweredOn'
-                            },
-                            @{ 
-                                'Name'        = 'VM3'
-                                'ID'          = 'VirtualMachine:33333'
-                                'powerStatus' = 'poweredOff'
+            [pscustomobject]@{ 
+                'data'  =   [pscustomobject]@{
+                            'Nodes' =[pscustomobject]@{ 
+                                        'Name'        = 'VM1'
+                                        'ID'          = 'VirtualMachine:11111'
+                                        'powerStatus' = 'poweredOn'
+                                    },
+                                    [pscustomobject]@{ 
+                                        'Name'        = 'VM2'
+                                        'ID'          = 'VirtualMachine:22222'
+                                        'powerStatus' = 'poweredOn'
+                                    },
+                                    [pscustomobject]@{ 
+                                        'Name'        = 'VM3'
+                                        'ID'          = 'VirtualMachine:33333'
+                                        'powerStatus' = 'poweredOff'
+                                    }
                             }
             }
         }
 
-        It -Name 'Requesting all should return total of 3' -Test {
-            ( Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "Get"   ).Total |
-                Should -BeExactly '3'
+
+        It -Name 'Request with body should return a single object' -Test {
+            @( Invoke-RubrikGraphQLCall -Body 'query').count |
+                Should -BeExactly 1
         }
+
+        It -Name 'Request should be a PowerShell custom object' -Test {
+            Invoke-RubrikGraphQLCall -Body 'query' |
+                Should -BeOfType 'PSCustomObject'
+        }
+
+        It -Name 'Request with -ReturnNode should return an array of 3 objects' -Test {
+            ( Invoke-RubrikGraphQLCall -ReturnNode -Body 'query').count |
+                Should -BeExactly 3
+        }
+
+        It -Name 'Request with -ReturnJSON should be a string' -Test {
+            ( Invoke-RubrikGraphQLCall -ReturnJSON -Body 'query') |
+                Should -BeOfType 'String'
+        }
+
+        It -Name 'Request with -ReturnJSON should be the correct string and content should expand' -Test {
+            ( Invoke-RubrikGraphQLCall -ReturnJSON -Body 'query') |
+                Should -BeExactly '{"Name":"VM3","ID":"VirtualMachine:33333","powerStatus":"poweredOff"}'
+        }
+        
         Assert-VerifiableMock
-        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
-        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 5
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 3
+        Assert-MockCalled -CommandName Invoke-WebRequest -ModuleName 'Rubrik' -Exactly 2
     }
     Context -Name 'Parameter Validation' { 
-        It -Name 'Endpoint cannot be null or empty' -Test {
-            { Invoke-RubrikRestCall -Endpoint $null -Method "GET" } |
-                Should -Throw "Cannot validate argument on parameter 'Endpoint'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
-        }
-        It -Name 'ValidateSet - Method' -Test {
-            { Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "non-existant" } |
-                Should -Throw "Cannot validate argument on parameter 'Method'."
-        }  
-        It -Name 'Query cannot be null or empty' -Test {
-            { Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "POST" -Query $null } |
-                Should -Throw "Cannot validate argument on parameter 'Query'."
-        } 
         It -Name 'Body cannot be null or empty' -Test {
-            { Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "POST" -Body $null } |
+            { Invoke-RubrikGraphQLCall -Body $null } |
+                Should -Throw "Cannot validate argument on parameter 'Body'."
+        }
+        It -Name 'Body cannot be null or empty - JSON param set' -Test {
+            { Invoke-RubrikGraphQLCall -ReturnJSON -Body $null} |
                 Should -Throw "Cannot validate argument on parameter 'Body'."
         }        
+        It -Name 'Body cannot be null or empty - Node param set' -Test {
+            { Invoke-RubrikGraphQLCall -ReturnNode -Body $null} |
+                Should -Throw "Cannot validate argument on parameter 'Body'."
+        }        
+        It -Name 'Cannot specify same param twice' -Test {
+            { Invoke-RubrikGraphQLCall -ReturnJSON -ReturnJSON -Body 'query' } |
+                Should -Throw "Cannot bind parameter because parameter 'ReturnJSON' is specified more than once. To provide multiple values to parameters that can accept multiple values, use the array syntax. For example, ""-parameter value1,value2,value3""."
+        }  
     }
 }

--- a/Tests/Invoke-RubrikGraphQLCall.Tests.ps1
+++ b/Tests/Invoke-RubrikGraphQLCall.Tests.ps1
@@ -1,0 +1,71 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Invoke-RubrikRestCall' -Tag 'Public', 'Invoke-RubrikRestCall' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'total' = '3'
+                'data'  =   @{ 
+                                'Name'        = 'VM1'
+                                'ID'          = 'VirtualMachine:11111'
+                                'powerStatus' = 'poweredOn'
+                            },
+                            @{ 
+                                'Name'        = 'VM2'
+                                'ID'          = 'VirtualMachine:22222'
+                                'powerStatus' = 'poweredOn'
+                            },
+                            @{ 
+                                'Name'        = 'VM3'
+                                'ID'          = 'VirtualMachine:33333'
+                                'powerStatus' = 'poweredOff'
+                            }
+            }
+        }
+
+        It -Name 'Requesting all should return total of 3' -Test {
+            ( Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "Get"   ).Total |
+                Should -BeExactly '3'
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+    Context -Name 'Parameter Validation' { 
+        It -Name 'Endpoint cannot be null or empty' -Test {
+            { Invoke-RubrikRestCall -Endpoint $null -Method "GET" } |
+                Should -Throw "Cannot validate argument on parameter 'Endpoint'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+        It -Name 'ValidateSet - Method' -Test {
+            { Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "non-existant" } |
+                Should -Throw "Cannot validate argument on parameter 'Method'."
+        }  
+        It -Name 'Query cannot be null or empty' -Test {
+            { Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "POST" -Query $null } |
+                Should -Throw "Cannot validate argument on parameter 'Query'."
+        } 
+        It -Name 'Body cannot be null or empty' -Test {
+            { Invoke-RubrikRestCall -Endpoint 'vmware/vm' -Method "POST" -Body $null } |
+                Should -Throw "Cannot validate argument on parameter 'Body'."
+        }        
+    }
+}

--- a/Tests/Invoke-RubrikGraphQLCall.Tests.ps1
+++ b/Tests/Invoke-RubrikGraphQLCall.Tests.ps1
@@ -64,7 +64,7 @@ Describe -Name 'Public/Invoke-RubrikGraphQLCall' -Tag 'Public', 'Invoke-RubrikGr
                 Should -BeExactly 3
         }
 
-        It -Name 'Request with -ReturnJSON should be a string' -Test {
+        It -Name 'Request with -ReturnJSON should return a JSON string' -Test {
             ( Invoke-RubrikGraphQLCall -ReturnJSON -Body 'query') |
                 Should -BeOfType 'String'
         }


### PR DESCRIPTION
# Description

Added new public cmdlet `Invoke-RubrikGraphQLCall` to provide a way of interacting with the GraphQL endpoint using this module [Issue 637](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/637)

## Related Issue

Resolves #637 

## Motivation and Context

There was no way of interacting with the /internal/graphql endpoint using the PowerShell module. This new function introduces this functionality.

## How Has This Been Tested?

Tested in both Windows PowerShell as well as PowerShell

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12744735/82806980-31b5e800-9e87-11ea-9ef9-efbf57a502b1.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
