### PR TITLE
Fixed bugs in New-RubrikLDAP 🐛

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Changed default value of DefaultWebRequestTimeout module option to 100 seconds to match cmdlets timeout.  Resolves [Issue 667](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/667)  [Issue 663](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/663) and [Issue 666](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/666)
+* Added check to `Invoke-RubrikWebRequest` to check DefaultWebRequestTimeOut.  If the value is not set, or set to something less than 100, `Invoke-WebRequest` will default to 100 seconds, otherwise, if the value is greater than 100 `Invoke-WebRequest` will use the custom timeout
+* Added verbose messages around the timeout values
+
+### Added
+
+* Added 5.2 API calls for `Get-RubrikClusterStorage` as the endpoint to retrieve Average Daily Growth no longer exists in CDM 5.2. Resolves [Issue 664](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/664)
+* Updated API stanza for 5.2 for the `Get-RubrikSyslogServer` cmdlet
+
+### Fixed
+
+## [5.0.2](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/5.0.2) - 2020-07-08
+
+### Changed
+
+* Changed max length of ID allowed to resolve [Issue 656](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/656)
+* Private function `Invoke-RubrikWebRequest` now correctly uses the `DefaultWebRequestTimeOut` default module option. Default is set to 15 seconds, but can be changed [Issue 216](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/216)
+* `Update-RubrikModuleOption` now also uses `Get-HomePath` private function, its unit tests have been updated as well
 * Added new property to `Get-RubrikReportData` : `DataGridObject` which returns the datagrid results as PowerShell custom objects [Issue 549](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/549)
 * `New-URIString` private function now validates `$id` input [Issue 627](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/627)
 * Changed how `Set-RubrikNASShare` creates the body object [Issue 614](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/614) and added new unit tests for this function
@@ -52,6 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added two new public cmdlets `Get-RubrikDownloadLink` and `Start-RubrikDownload` to manage downloads of snapshots or partial snapshots from the Rubrik Cluster [Issue 624](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/624)
 * Added new public cmdlet `Invoke-RubrikGraphQLCall` to provide a way of interacting with the GraphQL endpoint using this module [Issue 637](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/637)
 * Added new parameter to `Protect-RubrikVM` `-ExistingSnapshotRetention` as requested in [Issue 298](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/298)
 * Added additional `ReportTemplate` reports to the validation in `New-RubrikReport` [Issue 628](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/628)
@@ -71,7 +90,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-* Fixed bugs in `New-RubrikLDAP` and updated documentation and verbose logging [Issue 648](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/648)
+* Fixed bug in New-RubrikLogShipping cmdlets and added additional unit tests [Issue 644](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/644)
+* Fixed `Set-RubrikModuleOption`, it could not set module defaults, now it can
 * Azure DevOps issues with Pester v5
 * Added error handling for cases where Add-Type in `Unblock-SelfSignedCert` fails. `-Debug` switch can be used to determine root cause of failure. [Issue 613](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/613)
 * Fixed incorrect array in body of `Restore-RubrikDatabase` and added tests to validate new behavior in `Restore-RubrikDatabase.Tests`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Fixed bugs in `New-RubrikLDAP` and updated documentation and verbose logging [Issue 648](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/648)
+
 ## [5.0.2](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/5.0.2) - 2020-07-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Fixed bugs in `New-RubrikLDAP` and updated documentation and verbose logging [Issue 648](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/648)
 * Azure DevOps issues with Pester v5
 * Added error handling for cases where Add-Type in `Unblock-SelfSignedCert` fails. `-Debug` switch can be used to determine root cause of failure. [Issue 613](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/613)
 * Fixed incorrect array in body of `Restore-RubrikDatabase` and added tests to validate new behavior in `Restore-RubrikDatabase.Tests`

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -1821,7 +1821,7 @@ function Get-RubrikAPIData {
                     dynamicDnsName = "dynamicDnsName"
                     bindUserName = "bindUserName"
                     bindUserPassword = "bindUserPassword"
-                    baseDN = "baseDN"
+                    baseDn = "baseDn"
                     authServers = "authServers"
                     advancedOptions = "advancedOptions"
                 }

--- a/Rubrik/Public/New-RubrikLDAP.ps1
+++ b/Rubrik/Public/New-RubrikLDAP.ps1
@@ -16,7 +16,20 @@ function New-RubrikLDAP
             
       .EXAMPLE
       New-RubrikLDAP -Name "Test LDAP Settings" -baseDN "DC=domain,DC=local" -authServers "192.168.1.8"
+
       This will create LDAP settings on the Rubrik cluster defined by Connect-Rubrik function
+
+      .EXAMPLE
+      $credential = Get-Credential
+      New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindCredential $Credential -Server "ad1.test.lab" -verbose
+
+      This will create LDAP settings using the credentials object provided as a parameter
+
+      .EXAMPLE
+      $SecPw = Read-Host -AsSecureString
+      New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindUserName jaapjaap -BindUserPassword $SecPw -Server "ad1.test.lab" -verbose
+
+      This will create LDAP settings using the user name and password provided as parameters      
   #>
 
   [cmdletbinding(SupportsShouldProcess=$true,DefaultParametersetName='UserPassword')]

--- a/Rubrik/Public/New-RubrikLDAP.ps1
+++ b/Rubrik/Public/New-RubrikLDAP.ps1
@@ -115,7 +115,7 @@ function New-RubrikLDAP
     }
 
     $body = ConvertTo-Json $bodyHash
-    Write-Verbose -Message "Updated Body with credential object = $($body -replace 'bindUserPassword": "(.*?)"','bindUserPassword": "***"')"
+    Write-Verbose -Message "Updated Body with credential object = $($body -replace 'bindUserPassword":\s*"(.*?)"','bindUserPassword": "***"')"
     #endregion    
 
     $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body

--- a/Rubrik/Public/New-RubrikLDAP.ps1
+++ b/Rubrik/Public/New-RubrikLDAP.ps1
@@ -21,13 +21,13 @@ function New-RubrikLDAP
 
       .EXAMPLE
       $credential = Get-Credential
-      New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindCredential $Credential -Server "ad1.test.lab" -verbose
+      New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindCredential $Credential -Verbose
 
       This will create LDAP settings using the credentials object provided as a parameter
 
       .EXAMPLE
       $SecPw = Read-Host -AsSecureString
-      New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindUserName jaapjaap -BindUserPassword $SecPw -Server "ad1.test.lab" -verbose
+      New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindUserName jaapjaap -BindUserPassword $SecPw -Verbose
 
       This will create LDAP settings using the user name and password provided as parameters      
   #>

--- a/Rubrik/Public/New-RubrikLDAP.ps1
+++ b/Rubrik/Public/New-RubrikLDAP.ps1
@@ -15,19 +15,19 @@ function New-RubrikLDAP
       https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/new-rubrikldap
             
       .EXAMPLE
-      New-RubrikLDAP -Name "Test LDAP Settings" -baseDN "DC=domain,DC=local" -authServers "192.168.1.8"
+      New-RubrikLDAP -Name "Test LDAP Settings" -baseDn "DC=domain,DC=local" -authServers "192.168.1.8"
 
       This will create LDAP settings on the Rubrik cluster defined by Connect-Rubrik function
 
       .EXAMPLE
       $credential = Get-Credential
-      New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindCredential $Credential -Verbose
+      New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -baseDn "DC=rubrik,DC=lab" -BindCredential $Credential -Verbose
 
       This will create LDAP settings using the credentials object provided as a parameter
 
       .EXAMPLE
       $SecPw = Read-Host -AsSecureString
-      New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindUserName jaapjaap -BindUserPassword $SecPw -Verbose
+      New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -baseDn "DC=rubrik,DC=lab" -BindUserName jaapjaap -BindUserPassword $SecPw -Verbose
 
       This will create LDAP settings using the user name and password provided as parameters      
   #>
@@ -45,7 +45,7 @@ function New-RubrikLDAP
     [Parameter(Mandatory=$True)]
     [string]$DynamicDNSName,
     # The path to the directory where searches for users begin.
-    [string]$BaseDN,
+    [string]$baseDn,
     # An ordered list of authentication servers. Servers on this list have priority over servers discovered using dynamic DNS.
     [array]$AuthServers,
     # Bind username with permissions to connect to the LDAP server


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

**Current Behavior**:

Fails for both parameter sets username / password or credential

```
New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindUserName "demo@test.lab" -BindUserPassword $Password -Server "ad1.test.lab" -verbose
```

Fails

**Expected Behavior**:

**Steps to Reproduce**:

```
New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindUserName "demo@test.lab" -BindUserPassword $Password -Server "ad1.test.lab" -verbose
```

Or 

```
New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindCredential $Credential -Server "ad1.test.lab" -verbose
```

## Related Issue

Resolves #648 

## Motivation and Context

Fixes two separate bugs in `New-RubrikLDAP` and added better verbose logging

## How Has This Been Tested?

Ran unit tests and tested against TM Cluster

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12744735/85081323-ef54a200-b1cb-11ea-9d32-9c40c579cbe1.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
