### PR TITLE
Fix issue with long Id's in New-URIString - Issue 656

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Changed max length of ID allowed to resolve [Issue 656](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/656)
 * Private function `Invoke-RubrikWebRequest` now correctly uses the `DefaultWebRequestTimeOut` default module option. Default is set to 15 seconds, but can be changed [Issue 216](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/216)
 * `Update-RubrikModuleOption` now also uses `Get-HomePath` private function, its unit tests have been updated as well
 * Added new property to `Get-RubrikReportData` : `DataGridObject` which returns the datagrid results as PowerShell custom objects [Issue 549](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/549)

--- a/Rubrik/Private/New-URIString.ps1
+++ b/Rubrik/Private/New-URIString.ps1
@@ -20,7 +20,7 @@
   # Validation of id param
   if ($id -match '^@\{') {
     Write-Error -Message "Please validate ID input, please only input the ID parameter the object: '$id'" -ErrorAction Stop
-  } elseif ($id.Length -gt 100) {
+  } elseif ($id.Length -gt 200) {
     Write-Error -Message "Please validate ID input, invalid ID provided: '$id'" -ErrorAction Stop
   }
 


### PR DESCRIPTION
# Description

in our latest module updates (5.0.2) we limit the ID to be a maximum of 100 characters in New-URIString.ps1? This was not in earlier versions of the module and is now breaking the ability to download database backup files.
When you request to download files in the UI or via the API, we submit an AYSNC request to gather those files and zip them up. This process will create a download link. This process has an ID that looks like this "DOWNLOAD_MSSQL_BACKUP_FILES_80377d45-59d7-49b6-9078-2f98b6265e07_da994f8d-cf28-45d0-a10e-4653cc1f04cb:::0" The length of this ID is 106 characters, which causes New-URIString to error out at line 23 with an error "Please validate ID input, invalid ID provided: '$id'" -ErrorAction Stop

## Related Issue

Resolve #656 

## Motivation and Context

This resolve the issue with long restore URIs failing with this private function

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12744735/86825893-38dc3280-c090-11ea-8e60-30978fdb2fbc.png)


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
