### PR TITLE
changed webrequest timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 * Changed default value of DefaultWebRequestTimeout module option to 100 seconds to match cmdlets timeout.  Resolves [Issue 667](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/667)  [Issue 663](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/663) and [Issue 666](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/666)
+* Added check to `Invoke-RubrikWebRequest` to check DefaultWebRequestTimeOut.  If the value is not set, or set to something less than 100, `Invoke-WebRequest` will default to 100 seconds, otherwise, if the value is greater than 100 `Invoke-WebRequest` will use the custom timeout
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Changed default value of DefaultWebRequestTimeout module option to 100 seconds to match cmdlets timeout.  Resolves [Issue 667](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/667)  [Issue 663](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/663) and [Issue 666](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/666)
+
 ### Added
 
 * Added 5.2 API calls for `Get-RubrikClusterStorage` as the endpoint to retrieve Average Daily Growth no longer exists in CDM 5.2. Resolves [Issue 664](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/664)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Changed default value of DefaultWebRequestTimeout module option to 100 seconds to match cmdlets timeout.  Resolves [Issue 667](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/667)  [Issue 663](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/663) and [Issue 666](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/666)
 * Added check to `Invoke-RubrikWebRequest` to check DefaultWebRequestTimeOut.  If the value is not set, or set to something less than 100, `Invoke-WebRequest` will default to 100 seconds, otherwise, if the value is greater than 100 `Invoke-WebRequest` will use the custom timeout
+* Added verbose messages around the timeout values
 
 ### Added
 

--- a/Rubrik/OptionsDefault/rubrik_sdk_for_powershell_options.json
+++ b/Rubrik/OptionsDefault/rubrik_sdk_for_powershell_options.json
@@ -3,6 +3,6 @@
   "ModuleOption":  {
     "ApplyCustomViewDefinitions":  "True",
     "CredentialPath": "",
-    "DefaultWebRequestTimeOut": 15
+    "DefaultWebRequestTimeOut": 100
   }
 }

--- a/Rubrik/Private/Invoke-RubrikWebRequest.ps1
+++ b/Rubrik/Private/Invoke-RubrikWebRequest.ps1
@@ -13,21 +13,24 @@ function Invoke-RubrikWebRequest {
         $Method,
         $Body
     )
-    
     if (Test-PowerShellSix) {
-        if ($rubrikOptions.ModuleOption.DefaultWebRequestTimeOut) {
+        if ($null -ne $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut -or $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut -gt 99) {
+            Write-Verbose -Message "Invoking request with a custom timeout of $($rubrikOptions.ModuleOption.DefaultWebRequestTimeOut) seconds"
             $result = Invoke-WebRequest -UseBasicParsing -SkipCertificateCheck -TimeoutSec $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut @PSBoundParameters
         } else {
+            Write-Verbose -Message "No custom timeout specified or custom timeout is less than 100 seconds, invoking request with default value of 100 seconds"
             $result = Invoke-WebRequest -UseBasicParsing -SkipCertificateCheck @PSBoundParameters
         }
     } else {
-        if ($rubrikOptions.ModuleOption.DefaultWebRequestTimeOut) {
+        if ($null -ne $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut -or $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut -gt 99) {
+            Write-Verbose -Message "Invoking request with a custom timeout of $($rubrikOptions.ModuleOption.DefaultWebRequestTimeOut) seconds"
             $result = Invoke-WebRequest -UseBasicParsing -TimeoutSec $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut @PSBoundParameters
         } else {
+            Write-Verbose -Message "No custom timeout specified or custom timeout is less than 100 seconds, invoking request with default value of 100 seconds"
             $result = Invoke-WebRequest -UseBasicParsing @PSBoundParameters
         }
     }
-    
+
     Write-Verbose -Message "Received HTTP Status $($result.StatusCode)"
 
     return $result


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

This changes the DefaultWebRequest Timeout option to 100 seconds, matching that of the Invoke-WebRequest timeout.
If the value is already set and is lower than 100, code in this PR will force it to be 100 seconds as a minimum
Added verbose logging around what value has been used for execution

## Related Issue

Resolves #667 #666 #663 


## Motivation and Context

Why is this change required? What problem does it solve?

Customers are receiving more and more errors involving timeouts since this was set.

## How Has This Been Tested?

Tested within the TM lab

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
