### PR TITLE
Fixed bugs in New-RubrikLDAP 🐛

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Fixed bugs in `New-RubrikLDAP` and updated documentation and verbose logging [Issue 648](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/648)
+
 ## [5.0.2](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/5.0.2) - 2020-07-08
 
 ### Changed

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -1851,7 +1851,7 @@ function Get-RubrikAPIData {
                     dynamicDnsName = "dynamicDnsName"
                     bindUserName = "bindUserName"
                     bindUserPassword = "bindUserPassword"
-                    baseDN = "baseDN"
+                    baseDn = "baseDn"
                     authServers = "authServers"
                     advancedOptions = "advancedOptions"
                 }


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

**Current Behavior**:

Fails for both parameter sets username / password or credential

```
New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindUserName "demo@test.lab" -BindUserPassword $Password -Server "ad1.test.lab" -verbose
```

Fails

**Expected Behavior**:

**Steps to Reproduce**:

```
New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindUserName "demo@test.lab" -BindUserPassword $Password -Server "ad1.test.lab" -verbose
```

Or 

```
New-RubrikLDAP -Name "rubrik.lab" -DynamicDNSName "ad1.test.lab" -BaseDN "DC=rubrik,DC=lab" -BindCredential $Credential -Server "ad1.test.lab" -verbose
```

## Related Issue

Resolves #648 

## Motivation and Context

Fixes two separate bugs in `New-RubrikLDAP` and added better verbose logging

## How Has This Been Tested?

Ran unit tests and tested against TM Cluster

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12744735/85081323-ef54a200-b1cb-11ea-9d32-9c40c579cbe1.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
