### PR TITLE
Add new Update-RubrikNutanixCluster cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added `Update-RubrikNutanixCluster` as requested by Teixeirapa, also updated documentation in `Invoke-RubrikRestCall` to provide an example to do an empty post request. Resolves [Issue 669](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/669)
 * Added 5.2 API calls for `Get-RubrikClusterStorage` as the endpoint to retrieve Average Daily Growth no longer exists in CDM 5.2. Resolves [Issue 664](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/664)
 * Updated API stanza for 5.2 for the `Get-RubrikSyslogServer` cmdlet
 

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -3334,6 +3334,18 @@ function Get-RubrikAPIData {
                 Success     = '202'
             }
         }
+        'Update-RubrikNutanixCluster'         = @{
+            '1.0' = @{
+                Description = 'Refresh the metadata for the specified Nutanix Cluster'
+                URI         = '/api/internal/nutanix/cluster/{id}/refresh'
+                Method      = 'Post'
+                Body        = ''
+                Query       = ''
+                Result      = ''
+                Filter      = ''
+                Success     = '202'
+            }
+        }
         'Update-RubrikVCD'         = @{
             '1.0' = @{
                 Description = 'Refresh the metadata for the specified vCD Server'

--- a/Rubrik/Public/Get-RubrikVM.ps1
+++ b/Rubrik/Public/Get-RubrikVM.ps1
@@ -29,6 +29,11 @@ function Get-RubrikVM
       This will return all removed virtual machines that were formerly protected by Rubrik.
 
       .EXAMPLE
+      Get-RubrikVM -SLAAssignment Unassigned
+
+      Retrieves all VMware VMs that are currently not protected by any SLA
+
+      .EXAMPLE
       Get-RubrikVM -Name myserver01 -DetailedObject
       This will return the VM object with all properties, including additional details such as snapshots taken of the VM. Using this switch parameter negatively affects performance
   #>

--- a/Rubrik/Public/Invoke-RubrikRESTCall.ps1
+++ b/Rubrik/Public/Invoke-RubrikRESTCall.ps1
@@ -39,6 +39,11 @@ function Invoke-RubrikRESTCall {
       Invoke-RubrikRESTCall -Endpoint 'fileset_template/bulk' -Method POST -Body $body -BodyAsArray
 
       Creates a new fileset from the given fileset template and the given host id supporting Direct Archive.  Since fileset_template/bulk expects an array, we force the single item array with the BodyAsArray parameter.
+
+      .EXAMPLE
+      Invoke-RubrikRESTCall -api internal -Endpoint nutanix/cluster/NutanixCluster:::d34d42c0-5468-4c37-a3cf-4376baf018e4/refresh -Method post
+
+      Refreshes the information of the Nutanix cluster
   #>
 
   [cmdletbinding()]

--- a/Rubrik/Public/Update-RubrikNutanixCluster.ps1
+++ b/Rubrik/Public/Update-RubrikNutanixCluster.ps1
@@ -17,7 +17,7 @@ function Update-RubrikNutanixCluster
       https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/update-rubriknutanixcluster
       
       .EXAMPLE
-      Get-RubrikNutanixCluster -Name 'vcsa.domain.local' | Update-RubrikNutanixCluster
+      Get-RubrikNutanixCluster -Name 'nutanix.domain.local' | Update-RubrikNutanixCluster
       This will refresh the vCenter metadata on the currently connected Rubrik cluster
 
       .EXAMPLE

--- a/Rubrik/Public/Update-RubrikNutanixCluster.ps1
+++ b/Rubrik/Public/Update-RubrikNutanixCluster.ps1
@@ -1,0 +1,75 @@
+#Requires -Version 3
+function Update-RubrikNutanixCluster
+{
+  <#  
+      .SYNOPSIS
+      Connects to Rubrik to refresh the metadata for the specified vCenter Server
+            
+      .DESCRIPTION
+      The Update-RubrikNutanixCluster cmdlet will refresh all vCenter metadata known to the connected Rubrik cluster.
+            
+      .NOTES
+      Written by Jaap Brasser for community usage
+      Twitter: @jaap_brasser
+      GitHub: jaapbrasser
+
+      .LINK
+      https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/update-rubriknutanixcluster
+      
+      .EXAMPLE
+      Get-RubrikNutanixCluster -Name 'vcsa.domain.local' | Update-RubrikNutanixCluster
+      This will refresh the vCenter metadata on the currently connected Rubrik cluster
+
+      .EXAMPLE
+      Get-RubrikNutanixCluster | Update-RubrikNutanixCluster
+      This will refresh the vCenter metadata for all connecter vCenter instances on the currently connected Rubrik cluster
+  #>
+
+  [CmdletBinding()]
+  Param(
+    # vCenter id value from the Rubrik Cluster
+    [Parameter(
+      ValueFromPipelineByPropertyName = $true,
+      Mandatory = $true )]
+    [ValidateNotNullOrEmpty()]
+    [String]$id,
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [ValidateNotNullorEmpty()]
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+    
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+        
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = Get-RubrikAPIData -endpoint $function
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+  
+  }
+
+  Process {
+
+    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+    $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+    $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+    return $result
+
+  } # End of process
+} # End of function

--- a/Rubrik/Public/Update-RubrikNutanixCluster.ps1
+++ b/Rubrik/Public/Update-RubrikNutanixCluster.ps1
@@ -1,13 +1,13 @@
 #Requires -Version 3
 function Update-RubrikNutanixCluster
 {
-  <#  
+  <#
       .SYNOPSIS
-      Connects to Rubrik to refresh the metadata for the specified vCenter Server
-            
+      Connects to Rubrik to refresh the metadata for the specified Nutanix cluster
+
       .DESCRIPTION
-      The Update-RubrikNutanixCluster cmdlet will refresh all vCenter metadata known to the connected Rubrik cluster.
-            
+      The Update-RubrikNutanixCluster cmdlet will refresh all Nutanix metadata known to the connected Rubrik cluster.
+
       .NOTES
       Written by Jaap Brasser for community usage
       Twitter: @jaap_brasser
@@ -15,19 +15,19 @@ function Update-RubrikNutanixCluster
 
       .LINK
       https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/update-rubriknutanixcluster
-      
+
       .EXAMPLE
       Get-RubrikNutanixCluster -Name 'nutanix.domain.local' | Update-RubrikNutanixCluster
-      This will refresh the vCenter metadata on the currently connected Rubrik cluster
+      This will refresh the Nutanix metadata on the currently connected Rubrik cluster
 
       .EXAMPLE
       Get-RubrikNutanixCluster | Update-RubrikNutanixCluster
-      This will refresh the vCenter metadata for all connecter vCenter instances on the currently connected Rubrik cluster
+      This will refresh the Nutanix metadata for all connected Nutanix instances on the currently connected Rubrik cluster
   #>
 
   [CmdletBinding()]
   Param(
-    # vCenter id value from the Rubrik Cluster
+    # Nutanix Cluster id value from the Rubrik Cluster
     [Parameter(
       ValueFromPipelineByPropertyName = $true,
       Mandatory = $true )]
@@ -47,17 +47,17 @@ function Update-RubrikNutanixCluster
 
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
-    
+
     # API data references the name of the function
     # For convenience, that name is saved here to $function
     $function = $MyInvocation.MyCommand.Name
-        
+
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
+
   }
 
   Process {

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -297,6 +297,7 @@
                    'Sync-RubrikAnnotation',
                    'Sync-RubrikTag',
                    'Update-RubrikHost',
+                   'Update-RubrikNutanixCluster',
                    'Update-RubrikVCD',
                    'Update-RubrikVCenter',
                    'Update-RubrikVMwareVM')

--- a/Tests/Update-RubrikNutanixCluster.Tests.ps1
+++ b/Tests/Update-RubrikNutanixCluster.Tests.ps1
@@ -1,0 +1,49 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Update-RubrikNutanixCluster' -Tag 'Public', 'Update-RubrikNutanixCluster' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '4.0.5'
+    }
+    #endregion
+
+    Context -Name 'Request Succeeds' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'id'        = 'REFRESH_METADATA_11111'
+                'status'    = 'QUEUED'
+                'progress'  = '0'
+            }
+        }
+        It -Name 'Should return QUEUED status' -Test {
+            ( Update-RubrikNutanixCluster -id '11111').status |
+                Should -BeExactly 'QUEUED'
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Times 1
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Times 1
+    }
+    Context -Name 'Parameter Validation' {
+        It -Name 'Parameter ID cannot be null' -Test {
+           { Update-RubrikNutanixCluster -id $null } |
+                Should -Throw "Cannot validate argument on parameter 'id'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        } 
+        It -Name 'Parameter ID cannot be empty' -Test {
+            { Update-RubrikNutanixCluster -id '' } |
+                Should -Throw "Cannot validate argument on parameter 'id'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+    }
+}

--- a/azure-pipelines/scripts/Invoke-RunTests.ps1
+++ b/azure-pipelines/scripts/Invoke-RunTests.ps1
@@ -1,5 +1,5 @@
 Install-Module -Name Pester -MaximumVersion 4.99.99 -Force
-Remove-Module Pester
+Remove-Module Pester -ErrorAction SilentlyContinue
 Import-Module -Name Pester -MaximumVersion 4.99.99 
 
 $PesterSplat = @{

--- a/azure-pipelines/scripts/Invoke-RunTests.ps1
+++ b/azure-pipelines/scripts/Invoke-RunTests.ps1
@@ -1,4 +1,6 @@
-Install-Module -Name Pester -RequiredVersion 4.10.1 -Force
+Install-Module -Name Pester -MaximumVersion 4.99.99 -Force
+Remove-Module Pester
+Import-Module -Name Pester -MaximumVersion 4.99.99 
 
 $PesterSplat = @{
     PassThru = $true


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

**Is your feature request related to a problem? Please describe.**

Customer needs to refresh Nutanix Cluster after restoring replicated vms in AHV and be able to start backup on Rubrik 

**Describe the solution you'd like**

Customer needs to use the following endpoint nutanix/cluster/$($_.id)/refresh every time new vms are restored into AHV central cluster so Rubrik will be updated once Acropolis its updated.

**Describe alternatives you've considered**

Customer is using CURL to same endpoint or Invoke-RubrikRESTCall 

**Additional context**

By using above methods customer could see all vms updated in Rubrik GUI

## Related Issue

Resolve #669 
Resolve #670

## Motivation and Context

Why is this change required? What problem does it solve?

## How Has This Been Tested?

New unit tests have been written, old ones pass

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12744735/89812326-3b72f180-db40-11ea-92df-245ec8a33902.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
