### PR TITLE
Updated API data and Event/Eventseries cmdlets for 5.2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Created entries for 5.2 endpoints in `Get-RubrikAPIData` private function for `Get-RubrikEvent` & `Get-RubrikEventSeries` which caused these cmdlets to no longer work on Rubrik CDM 5.2 [Issue 626](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/626)
+
 ## [5.0.3](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/5.0.3) - 2020-08-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* New switch added to `Get-RubrikEvent` `-IncludeEventSeries` which determines if EventSeries events are included in the results [Issue 626](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/626)
+
 ### Fixed
 
 * Created entries for 5.2 endpoints in `Get-RubrikAPIData` private function for `Get-RubrikEvent` & `Get-RubrikEventSeries` which caused these cmdlets to no longer work on Rubrik CDM 5.2 [Issue 626](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/626)
+
+### Deprecated
+
+* Functionality in `Get-RubrikEventSeries` is limited to only queries by specific EventSeries id on Rubrik CDM Clusters running versions higher than 5.2. Original functionality is still available for backwards compatibility with older versions of Rubrik CDM [Issue 626](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/626)
 
 ## [5.0.3](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/5.0.3) - 2020-08-12
 

--- a/Rubrik/ObjectDefinitions/Rubrik.Event.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.Event.ps1xml
@@ -52,5 +52,45 @@
                 </TableRowEntries>
             </TableControl>
         </View>
+        <View>
+            <Name>Default</Name>
+            <ViewSelectedBy>
+                <TypeName>Rubrik.Event.5.2</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Label>Time</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Status</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Object Name</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Message</Label>
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry> 
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Date</PropertyName>   
+                            </TableColumnItem>
+                            <TableColumnItem>
+                               <PropertyName>Status</PropertyName>
+                            </TableColumnItem>                            
+                            <TableColumnItem>
+                                <PropertyName>Name</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Message</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
     </ViewDefinitions>
 </Configuration>

--- a/Rubrik/ObjectDefinitions/Rubrik.Event.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.Event.ps1xml
@@ -66,26 +66,32 @@
                         <Label>Status</Label>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <Label>Object Type</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Label>Object Name</Label>
                     </TableColumnHeader>
                     <TableColumnHeader>
-                        <Label>Message</Label>
+                        <Label>ID</Label>
                     </TableColumnHeader>
                 </TableHeaders>
                 <TableRowEntries>
                     <TableRowEntry> 
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>Date</PropertyName>   
-                            </TableColumnItem>
+                               <PropertyName>time</PropertyName>
+                            </TableColumnItem>     
                             <TableColumnItem>
-                               <PropertyName>Status</PropertyName>
+                               <PropertyName>eventStatus</PropertyName>
                             </TableColumnItem>                            
                             <TableColumnItem>
-                                <PropertyName>Name</PropertyName>
+                                <PropertyName>objectType</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>Message</PropertyName>
+                                <PropertyName>objectName</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>id</PropertyName>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>

--- a/Rubrik/ObjectDefinitions/Rubrik.EventSeries.ps1xml
+++ b/Rubrik/ObjectDefinitions/Rubrik.EventSeries.ps1xml
@@ -50,6 +50,54 @@
         <View>
             <Name>Default</Name>
             <ViewSelectedBy>
+                <TypeName>Rubrik.EventSeries.5.2</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Label>Time</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Status</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Task Type</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Object Location</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Number of Events</Label>
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>endTime</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                               <PropertyName>status</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>taskType</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>location</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    @($_.eventDetailList).count
+                                </ScriptBlock>    
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+        <View>
+            <Name>Default</Name>
+            <ViewSelectedBy>
                 <TypeName>Rubrik.EventSeries</TypeName>
             </ViewSelectedBy>
             <TableControl>

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -517,8 +517,7 @@ function Get-RubrikAPIData {
                     before_date = 'before_date'
                     after_date = 'after_date'
                     object_type = 'object_type'
-                    show_only_latest = 'show_only_latest'
-                    filter_only_on_latest = 'filter_only_on_latest'
+                    should_include_event_series = 'should_include_event_series'
                 }
                 Result      = 'data'
                 Filter      = ''

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -501,6 +501,30 @@ function Get-RubrikAPIData {
                 Success     = '200'
                 ObjectTName = 'Rubrik.Event'
             }
+            '5.2' = @{
+                Description = 'Retrieve information for the latest of related events that match the value specified in any of the following categories: type, status, or ID, and limit events by date.'
+                URI         = '/api/internal/event'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    limit = 'limit'
+                    after_id = 'after_id'
+                    event_series_id = 'event_series_id'
+                    status = 'status'
+                    event_type = 'event_type'
+                    object_ids = 'object_ids'
+                    object_name = 'object_name'
+                    before_date = 'before_date'
+                    after_date = 'after_date'
+                    object_type = 'object_type'
+                    show_only_latest = 'show_only_latest'
+                    filter_only_on_latest = 'filter_only_on_latest'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+                ObjectTName = 'Rubrik.Event'
+            }
         }
         'Get-RubrikEventSeries' = @{
             '5.0' = @{
@@ -508,13 +532,18 @@ function Get-RubrikAPIData {
                 URI         = '/api/internal/event_series'
                 Method      = 'Get'
                 Body        = ''
-                Query       = @{
-                    status = 'status'
-                    event_type = 'event_type'
-                    object_ids = 'object_ids'
-                    object_name = 'object_name'
-                    object_type = 'object_type'
-                }
+                Query       = ''
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+                ObjectTName = 'Rubrik.EventSeries'
+            }
+            '5.2' = @{
+                Description = 'Retrieve information for event series within Rubrik.'
+                URI         = '/api/v1/event_series/{id}'
+                Method      = 'Get'
+                Body        = ''
+                Query       = ''
                 Result      = 'data'
                 Filter      = ''
                 Success     = '200'

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -547,7 +547,7 @@ function Get-RubrikAPIData {
                 Result      = 'data'
                 Filter      = ''
                 Success     = '200'
-                ObjectTName = 'Rubrik.EventSeries'
+                ObjectTName = 'Rubrik.EventSeries.5.2'
             }
         }
         'Get-RubrikFileset'            = @{

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -503,7 +503,7 @@ function Get-RubrikAPIData {
             }
             '5.2' = @{
                 Description = 'Retrieve information for the latest of related events that match the value specified in any of the following categories: type, status, or ID, and limit events by date.'
-                URI         = '/api/v1/event/csv_download_link'
+                URI         = '/api/v1/event/latest'
                 Method      = 'Get'
                 Body        = ''
                 Query       = @{

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -503,7 +503,7 @@ function Get-RubrikAPIData {
             }
             '5.2' = @{
                 Description = 'Retrieve information for the latest of related events that match the value specified in any of the following categories: type, status, or ID, and limit events by date.'
-                URI         = '/api/internal/event'
+                URI         = '/api/v1/event/csv_download_link'
                 Method      = 'Get'
                 Body        = ''
                 Query       = @{
@@ -523,7 +523,7 @@ function Get-RubrikAPIData {
                 Result      = 'data'
                 Filter      = ''
                 Success     = '200'
-                ObjectTName = 'Rubrik.Event'
+                ObjectTName = 'Rubrik.Event.5.2'
             }
         }
         'Get-RubrikEventSeries' = @{

--- a/Rubrik/Private/Invoke-RubrikWebRequest.ps1
+++ b/Rubrik/Private/Invoke-RubrikWebRequest.ps1
@@ -13,8 +13,9 @@ function Invoke-RubrikWebRequest {
         $Method,
         $Body
     )
+
     if (Test-PowerShellSix) {
-        if ($null -ne $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut -or $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut -gt 99) {
+        if (-not [string]::IsNullOrWhiteSpace($rubrikOptions.ModuleOption.DefaultWebRequestTimeOut) -or $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut -gt 99) {
             Write-Verbose -Message "Invoking request with a custom timeout of $($rubrikOptions.ModuleOption.DefaultWebRequestTimeOut) seconds"
             $result = Invoke-WebRequest -UseBasicParsing -SkipCertificateCheck -TimeoutSec $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut @PSBoundParameters
         } else {
@@ -22,7 +23,7 @@ function Invoke-RubrikWebRequest {
             $result = Invoke-WebRequest -UseBasicParsing -SkipCertificateCheck @PSBoundParameters
         }
     } else {
-        if ($null -ne $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut -or $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut -gt 99) {
+        if (-not [string]::IsNullOrWhiteSpace($rubrikOptions.ModuleOption.DefaultWebRequestTimeOut) -or $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut -gt 99) {
             Write-Verbose -Message "Invoking request with a custom timeout of $($rubrikOptions.ModuleOption.DefaultWebRequestTimeOut) seconds"
             $result = Invoke-WebRequest -UseBasicParsing -TimeoutSec $rubrikOptions.ModuleOption.DefaultWebRequestTimeOut @PSBoundParameters
         } else {

--- a/Rubrik/Public/Get-RubrikEvent.ps1
+++ b/Rubrik/Public/Get-RubrikEvent.ps1
@@ -18,22 +18,27 @@ function Get-RubrikEvent
 
       .EXAMPLE
       Get-RubrikEvent -ObjectName "vm-foo" -EventType Backup
+      
       This will query for any 'Backup' events on the Rubrik VM object named 'vm-foo'
 
       .EXAMPLE
       Get-RubrikVM -Name jbrasser-win | Get-RubrikEvent -Limit 10
+
       Queries the Rubrik Cluster for any vms named jbrasser-win and return the last ten events for each VM found
 
       .EXAMPLE
       Get-RubrikEvent -EventType Archive -Limit 100
+
       This will query the latest 100 Archive events on the currently logged in Rubrik cluster
 
       .EXAMPLE
-      Get-RubrikHost -Name SQLFoo.demo.com | Get-RubrikEvent -EventType Archive
-      This will feed any Archive events against the Rubrik Host object 'SQLFoo.demo.com' via a piped query.
+      Get-RubrikHost -Name SQLFoo.demo.com | Get-RubrikEvent
+
+      This will feed any events against the Rubrik Host object 'SQLFoo.demo.com' via a piped query.
 
       .EXAMPLE
       Get-RubrikEvent -EventSeriesId '1111-2222-3333'
+
       This will retrieve all of the events belonging to the specified EventSeriesId. *Note - This will call Get-RubrikEventSeries*
 
       .EXAMPLE

--- a/Rubrik/Public/Get-RubrikEvent.ps1
+++ b/Rubrik/Public/Get-RubrikEvent.ps1
@@ -90,11 +90,11 @@ function Get-RubrikEvent
     [Alias('object_type')]
     [Parameter(ParameterSetName="eventByID")]
     [string]$ObjectType,
-    # A switch value that determines whether to show only on the most recent event in the series. When 'true' only the most recent event in the series are shown. When 'false' all events in the series are shown. The default value is 'true'.
+    # A switch value that determines whether to show only on the most recent event in the series. When 'true' only the most recent event in the series are shown. When 'false' all events in the series are shown. The default value is 'true'. Note: Deprecated in 5.2
     [Alias('show_only_latest')]
     [Parameter(ParameterSetName="eventByID")]
     [Switch]$ShowOnlyLatest,
-    # A Switch value that determines whether to filter only on the most recent event in the series. When 'true' only the most recent event in the series are filtered. When 'false' all events in the series are filtered. The default value is 'true'.
+    # A Switch value that determines whether to filter only on the most recent event in the series. When 'true' only the most recent event in the series are filtered. When 'false' all events in the series are filtered. The default value is 'true'. Note: Deprecated in 5.2
     [Alias('filter_only_on_latest')]
     [Parameter(ParameterSetName="eventByID")]
     [Switch]$FilterOnlyOnLatest,

--- a/Rubrik/Public/Get-RubrikEvent.ps1
+++ b/Rubrik/Public/Get-RubrikEvent.ps1
@@ -18,7 +18,7 @@ function Get-RubrikEvent
 
       .EXAMPLE
       Get-RubrikEvent -ObjectName "vm-foo" -EventType Backup
-      
+
       This will query for any 'Backup' events on the Rubrik VM object named 'vm-foo'
 
       .EXAMPLE
@@ -98,7 +98,7 @@ function Get-RubrikEvent
     [Alias('filter_only_on_latest')]
     [Parameter(ParameterSetName="eventByID")]
     [Switch]$FilterOnlyOnLatest,
-    # A Switch value that determines whether or not EventSeries events are included in the query
+    # A Switch value that determines whether or not EventSeries events are included in the results
     [Alias('should_include_event_series')]
     [Parameter(ParameterSetName="eventByID")]
     [Switch]$IncludeEventSeries,

--- a/Rubrik/Public/Get-RubrikEvent.ps1
+++ b/Rubrik/Public/Get-RubrikEvent.ps1
@@ -56,7 +56,7 @@ function Get-RubrikEvent
     [Parameter(ParameterSetName="eventByID")]
     [string]$Status,
     # Filter by Event Type.
-    [ValidateSet('Archive', 'Audit', 'AuthDomain', 'Backup', 'CloudNativeSource', 'Configuration', 'Diagnostic', 'Discovery', 'Instantiate', 'Maintenance', 'NutanixCluster', 'Recovery', 'Replication', 'StorageArray', 'StormResource', 'System', 'Vcd', 'VCenter', IgnoreCase = $false)]
+    [ValidateSet('Archive', 'Audit', 'AuthDomain', 'AwsEvent', 'Backup', 'Classification', 'CloudNativeSource', 'CloudNativeVm', 'Configuration', 'Connection', 'Conversion', 'Diagnostic', 'Discovery', 'Failover', 'Fileset', 'Hardware', 'HostEvent', 'HypervScvmm', 'HypervServer', 'Instantiate', 'LegalHold', 'Maintenance', 'NutanixCluster', 'Recovery', 'Replication', 'Storage', 'StorageArray', 'StormResource', 'Support', 'System', 'TestFailover', 'Upgrade', 'VCenter', 'Vcd', 'VolumeGroup', 'UnknownEventType', IgnoreCase = $false)]
     [Alias('event_type')]
     [Parameter(ParameterSetName="eventByID")]
     [string]$EventType,
@@ -77,6 +77,7 @@ function Get-RubrikEvent
     [Parameter(ParameterSetName="eventByID")]
     [System.DateTime]$AfterDate,
     # Filter all the events by object type. Enter any of the following values: 'VmwareVm', 'Mssql', 'LinuxFileset', 'WindowsFileset', 'WindowsHost', 'LinuxHost', 'StorageArrayVolumeGroup', 'VolumeGroup', 'NutanixVm', 'Oracle', 'AwsAccount', and 'Ec2Instance'. WindowsHost maps to both WindowsFileset and VolumeGroup, while LinuxHost maps to LinuxFileset and StorageArrayVolumeGroup.
+    [ValidateSet('AggregateAhvVm', 'AggregateAwsAzure', 'AggregateHypervVm', 'AggregateLinuxUnixHosts', 'AggregateNasShares', 'AggregateOracleDb', 'AggregateStorageArrays', 'AggregateVcdVapps', 'AggregateVsphereVm', 'AggregateWindowsHosts', 'AppBlueprint', 'AuthDomain', 'AwsAccount', 'AwsEventType', 'Certificate', 'Cluster', 'DataLocation', 'Ec2Instance', 'Host', 'HypervScvmm', 'HypervServer', 'HypervVm', 'JobInstance', 'Ldap', 'LinuxHost', 'LinuxFileset', 'ManagedVolume', 'Mssql', 'NasHost', 'NutanixCluster', 'NutanixVm', 'OracleDb', 'OracleHost', 'OracleRac', 'PublicCloudMachineInstance', 'SamlSso', 'ShareFileset', 'SlaDomain', 'SmbDomain', 'StorageArray', 'StorageArrayVolumeGroup', 'Storm', 'SupportBundle', 'UnknownObjectType', 'Upgrade', 'UserActionAudit', 'Vcd', 'VcdVapp', 'Vcenter', 'VmwareVm', 'VolumeGroup', 'WindowsHost', 'WindowsFileset', IgnoreCase = $false)]
     [Alias('object_type')]
     [Parameter(ParameterSetName="eventByID")]
     [string]$ObjectType,
@@ -128,6 +129,13 @@ function Get-RubrikEvent
       
       $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
       if (($rubrikConnection.version.substring(0,5) -as [version]) -ge [version]5.2) {
+        if ($FilterOnlyOnLatest) {
+          Write-Warning -Message 'This switch ''FilterOnlyOnLatest'' is no longer available in versions of Rubrik CDM later than 5.2'
+        }
+        if ($ShowOnlyLatest) {
+          Write-Warning -Message 'This switch ''ShowOnlyLatest'' is no longer available in versions of Rubrik CDM later than 5.2'
+        }
+
         if (Test-PowerShellSix) {
           $result = Invoke-WebRequest -uri $result.downloadLink -header $Header -method Get -SkipCertificateCheck | ConvertFrom-Csv
           

--- a/Rubrik/Public/Get-RubrikEventSeries.ps1
+++ b/Rubrik/Public/Get-RubrikEventSeries.ps1
@@ -26,24 +26,24 @@ function Get-RubrikEventSeries
     # Filter by Event Series ID
     [parameter()]
     [string]$Id,
-    # Filter by Status. Enter any of the following values: 'Failure', 'Warning', 'Running', 'Success', 'Canceled', 'Cancelingâ€™.
+    # Filter by Status. Enter any of the following values: 'Failure', 'Warning', 'Running', 'Success', 'Canceled', 'Canceling'. Note: Deprecated in 5.2
     [ValidateSet('Failure', 'Success', 'Queued', 'Active', IgnoreCase = $false)]
     [parameter()]
     [string]$Status,
-    # Filter by Event Type.
+    # Filter by Event Type. Note: Deprecated in 5.2
     [ValidateSet('Archive', 'Backup', 'Instantiate', 'Recovery', 'Replication', IgnoreCase = $false)]
     [Alias('event_type')]
     [parameter()]
     [string]$EventType,
-    # Filter by a comma separated list of object IDs.
+    # Filter by a comma separated list of object IDs. Note: Deprecated in 5.2
     [Alias('object_ids')]
     [Parameter(ValueFromPipelineByPropertyName = $true)]
     [array]$objectIds,
-    # Filter all the events according to the provided name using infix search for resources and exact search for usernames.
+    # Filter all the events according to the provided name using infix search for resources and exact search for usernames. Note: Deprecated in 5.2
     [Alias('object_name')]
     [parameter()]
     [string]$ObjectName,
-    # Filter all the events by object type. Enter any of the following values: 'VmwareVm', 'Mssql', 'LinuxFileset', 'WindowsFileset', 'WindowsHost', 'LinuxHost', 'StorageArrayVolumeGroup', 'VolumeGroup', 'NutanixVm', 'Oracle', 'AwsAccount', and 'Ec2Instance'. WindowsHost maps to both WindowsFileset and VolumeGroup, while LinuxHost maps to LinuxFileset and StorageArrayVolumeGroup.
+    # Filter all the events by object type. Enter any of the following values: 'VmwareVm', 'Mssql', 'LinuxFileset', 'WindowsFileset', 'WindowsHost', 'LinuxHost', 'StorageArrayVolumeGroup', 'VolumeGroup', 'NutanixVm', 'Oracle', 'AwsAccount', and 'Ec2Instance'. WindowsHost maps to both WindowsFileset and VolumeGroup, while LinuxHost maps to LinuxFileset and StorageArrayVolumeGroup. Note: Deprecated in 5.2
     [Alias('object_type')]
     [parameter()]
     [string]$ObjectType,
@@ -74,8 +74,10 @@ function Get-RubrikEventSeries
   }
 
   Process {
-    if ((($rubrikConnection.version.substring(0,5) -as [version]) -gt [version]5.2) -and (-not $id)) {
+    if ((($rubrikConnection.version.substring(0,5) -as [version]) -ge [version]5.2) -and (-not $id)) {
       Write-Warning 'Functionality of this cmdlet has been deprecated by new version of API endpoints. ID is mandatory'
+    } elseif ((($rubrikConnection.version.substring(0,5) -as [version]) -ge [version]5.2) -and $Status -or $EventType -or $objectIds -or $ObjectName -or $ObjectType) {
+      Write-Warning 'Functionality of this cmdlet has been deprecated by new version of API endpoints, usage of parameters except -id will not have any effect on operation of cmdlet. Please use Get-RubrikEventSeries instead'
     } elseif ($id -and ($rubrikConnection.version.substring(0,5) -as [version]) -lt [version]5.2) {
       $resources.ObjectTName = 'Rubrik.EventSeriesById'
     }

--- a/Tests/Get-RubrikEventSeries.Tests.ps1
+++ b/Tests/Get-RubrikEventSeries.Tests.ps1
@@ -15,7 +15,7 @@ Describe -Name 'Public/Get-RubrikEventSeries' -Tag 'Public', 'Get-RubrikEventSer
         header  = @{ 'Authorization' = 'Bearer test-authorization' }
         time    = (Get-Date)
         api     = 'v1'
-        version = '5.1'
+        version = '5.1.0'
     }
     #endregion
 

--- a/Tests/Invoke-RubrikVgfUpgrade.Tests.ps1
+++ b/Tests/Invoke-RubrikVgfUpgrade.Tests.ps1
@@ -26,7 +26,7 @@ Describe -Name 'Public/Invoke-RubrikVgfUpgrade' -Tag 'Public', 'Invoke-RubrikVgf
         }
         It -Name 'VGList cannot be empty' -Test {
             { Invoke-RubrikVgfUpgrade -VGList '' } |
-                Should -Throw "Cannot validate argument on parameter 'VGList'. The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again."
+                Should -Throw
         }
     }
 }


### PR DESCRIPTION
# Description

Current Behavior:

The endpoint used to query events has changed in 5.2. It now resides in /v1/events rather than /internal/events

## Related Issue

Resolves #626
Resolves #686 
Resolves #439

## Motivation and Context

The endpoint used to query events has changed in 5.2. It now resides in /v1/events rather than /internal/events

## How Has This Been Tested?

* New unit tests have been created, existing ones pass

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
