### PR TITLE
Updating Get-RubrikUser for 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added support to `Get-RubrikUser` to work around all of the API endpoint changes in CDM 5.3 as per [Issue 723](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/723)
 * Added new parameter, `SLAPrimaryClusterId`, to `Protect-RubrikFileset` & `New-RubrikSnapshot`, fixing [Issue 720](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/720)
 * Added additional parameters: `-DoNotProtect` & `-Inherit` to `Set-RubrikSQLInstance` as requested in [Issue 717](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/717)
 * Added `Request` parameter to allow `Get-RubrikRequest` to work directly from the pipeline as request in [Issue 715](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/715)
@@ -67,7 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 * The `DynamicDNS` parameter of `New-RubrikLDAP` is no longer a mandatory parameter [Issue 662](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/662)
-* Fixed `Test-RubrikSLA` internal function behaviour to no longer enforce `local` cluster ID when not supplied [Issue 659](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/659) 
+* Fixed `Test-RubrikSLA` internal function behaviour to no longer enforce `local` cluster ID when not supplied [Issue 659](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/659)
 * WhatIf/Verbose messages for `Remove-RubrikSLA` will display SLA name and ID for additional clarification [Issue 653](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/653)
 * Invoke-RubrikRestCall no longer takes Body object for Get Method [Issue 652](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/652)
 * Created entries for 5.2 endpoints in `Get-RubrikAPIData` private function for `Get-RubrikEvent` & `Get-RubrikEventSeries` which caused these cmdlets to no longer work on Rubrik CDM 5.2 [Issue 626](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/626)

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -768,6 +768,21 @@ function Get-RubrikAPIData {
                 Success     = '200'
                 ObjectTName = 'Rubrik.User'
             }
+            '5.3' = @{
+                Description = 'Retrieves settings related to a given user within the Rubrik cluster'
+                URI         = '/api/v1/principal'
+                Method      = 'Get'
+                Body        = ''
+                Query       = @{
+                    name = 'name'
+                    auth_domain_id = 'auth_domain_id'
+                    principal_type = 'principal_type'
+                }
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+                ObjectTName = 'Rubrik.User'
+            }
         }
         'Get-RubrikUserRole'         = @{
             '1.0' = @{

--- a/Rubrik/Public/Get-RubrikUser.ps1
+++ b/Rubrik/Public/Get-RubrikUser.ps1
@@ -113,7 +113,7 @@ function Get-RubrikUser
 
     # if 5.3 or higher and calling with either ID we need to use the older internal endpoint...
     if (($rubrikConnection.version.substring(0,5) -as [version]) -ge [version]5.3 -and $PSBoundParameters.containskey('id') ) {
-      Write-Verbose -Message "Detected 5.3 or above with ID parameter, explicitely setting endpoint"
+      Write-Verbose -Message "Detected 5.3 or above with ID parameter, explicitly setting endpoint"
       $uri = New-URIString -server $Server -endpoint "/api/internal/user" -id $id
     } else {
       $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id


### PR DESCRIPTION
<!-- Please submit Pull Requests to the Devel branch. No Pull Requests are accepted to the Master branch -->

# Description

This PR contains the code to make `Get-RubrikUser` function with CDM 5.3

## Related Issue

Resolves #723 

## Motivation and Context

Allows external applications such as the AsBuiltReport to actually query users from 5.3 - and the PS Module itself.

## How Has This Been Tested?

Tested within the TM Lab
## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
