### PR TITLE
Issue 756 - Fixed New-RubrikHyperVVMMount documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Fixed documentation for `New-RubrikHyperVVMMount` resolving [Issue 756](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/756)
 * Fixed documentation for `Sync-RubrikTag`, resolving [Issue 757](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/757)
 * Updated API endpoints to `v1` for `Get-RubrikHostVolume`, `New-RubrikSnapshot` (VolumeGroup endpoint) & `Protect-RubrikVolumeGroup` cmdlets, fixing [Issue 747](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/747)
 * Fixed bug in `Submit-Request` which causes several issues [Issue 751](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/751) & [Issue 752](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/752)

--- a/Rubrik/Public/New-RubrikHyperVVMMount.ps1
+++ b/Rubrik/Public/New-RubrikHyperVVMMount.ps1
@@ -1,18 +1,18 @@
 #Requires -Version 3
 function New-RubrikHyperVVMMount
 {
-  <#  
+  <#
       .SYNOPSIS
       Create a new Live Mount from a protected Hyper V VM
-      
+
       .DESCRIPTION
       The New-RubrikHyperVVMMount cmdlet is used to create a Live Mount (clone) of a protected HyperV VM and run it in an existing HyperV environment.
-      
+
       .NOTES
       Written by Mike Preston for community usage
       Twitter: @mwpreston
       GitHub: mwpreston
-      
+
       .LINK
       https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/new-rubrikhypervvmmount
 
@@ -20,17 +20,17 @@ function New-RubrikHyperVVMMount
       New-RubrikHyperVVMMount -id '11111111-2222-3333-4444-555555555555'
       This will create a new mount based on snapshot id "11111111-2222-3333-4444-555555555555"
       The original virtual machine's name will be used along with a date and index number suffix
-      The virtual machine will NOT be powered on upon completion of the mount operation
-      
-      .EXAMPLE
-      New-RubrikHyperVVMMount -id '11111111-2222-3333-4444-555555555555' -MountName 'Mount1' -PowerOn -RemoveNetworkDevices
-      This will create a new mount based on snapshot id "11111111-2222-3333-4444-555555555555" and name the mounted virtual machine "Mount1"
-      The virtual machine will be powered on upon completion of the mount operation but without any virtual network adapters
+      The virtual machine will be powered on upon completion of the mount operation
 
       .EXAMPLE
-      Get-RubrikHyperVVM 'Server1' | Get-RubrikSnapshot -Date '03/01/2017 01:00' | New-RubrikHyperVVMMount -MountName 'Mount1' -DisableNetwork
+      New-RubrikHyperVVMMount -id '11111111-2222-3333-4444-555555555555' -MountName 'Mount1' -PowerOn:$false -RemoveNetworkDevices
+      This will create a new mount based on snapshot id "11111111-2222-3333-4444-555555555555" and name the mounted virtual machine "Mount1"
+      The virtual machine will NOT be powered on upon completion of the mount operation but without any virtual network adapters
+
+      .EXAMPLE
+      Get-RubrikHyperVVM 'Server1' | Get-RubrikSnapshot -Date '03/01/2017 01:00' | New-RubrikHyperVVMMount -MountName 'Mount1' -DisableNetwork -PowerOn
       This will create a new mount based on the closet snapshot found on March 1st, 2017 @ 01:00 AM and name the mounted virtual machine "Mount1"
-      The virtual machine will NOT be powered on upon completion of the mount operation
+      The virtual machine will be powered on upon completion of the mount operation
 
   #>
 
@@ -39,12 +39,12 @@ function New-RubrikHyperVVMMount
     # Rubrik id of the snapshot
     [Parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
     [String]$id,
-    # ID of host for the mount to use 
+    # ID of host for the mount to use
     [String]$HostID,
-    # Name of the mounted VM 
+    # Name of the mounted VM
     [Alias('vmName')]
     [String]$MountName,
-    # Whether the network should be disabled on mount.This should be set true to avoid ip conflict in case of static IPs. 
+    # Whether the network should be disabled on mount.This should be set true to avoid ip conflict in case of static IPs.
     [Switch]$DisableNetwork,
     # Whether the network devices should be removed on mount.
     [Switch]$RemoveNetworkDevices,
@@ -60,28 +60,28 @@ function New-RubrikHyperVVMMount
 
     # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
     # If a command needs to be run with each iteration or pipeline input, place it in the Process section
-    
+
     # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
     Test-RubrikConnection
-    
+
     # API data references the name of the function
     # For convenience, that name is saved here to $function
     $function = $MyInvocation.MyCommand.Name
-        
+
     # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
     Write-Verbose -Message "Gather API Data for $function"
     $resources = Get-RubrikAPIData -endpoint $function
     Write-Verbose -Message "Load API data for $($resources.Function)"
     Write-Verbose -Message "Description: $($resources.Description)"
-  
+
   }
 
   Process {
-    # If the switch parameter was not explicitly specified remove from body params 
+    # If the switch parameter was not explicitly specified remove from body params
     if(-not $PSBoundParameters.ContainsKey('DisableNetwork')) { $Resources.Body.Remove('disableNetwork') }
     if(-not $PSBoundParameters.ContainsKey('RemoveNetworkDevices')) { $Resources.Body.Remove('removeNetworkDevices') }
     if(-not $PSBoundParameters.ContainsKey('PowerOn')) { $Resources.Body.Remove('powerOn') }
-    
+
     $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
     $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
     $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)

--- a/Rubrik/Public/New-RubrikHyperVVMMount.ps1
+++ b/Rubrik/Public/New-RubrikHyperVVMMount.ps1
@@ -48,7 +48,7 @@ function New-RubrikHyperVVMMount
     [Switch]$DisableNetwork,
     # Whether the network devices should be removed on mount.
     [Switch]$RemoveNetworkDevices,
-    # Whether the VM should be powered on after mount.
+    # Whether the VM should be powered on after mount. Without this parameter the VM defaults to be powered on. To ensure it isn't, specify -PoweredOn:$false
     [Switch]$PowerOn,
     # Rubrik server IP or FQDN
     [String]$Server = $global:RubrikConnection.server,


### PR DESCRIPTION
# Description

Modified help examples for `New-RubrikHyperVVMMount` as they were not correct.  Not specifying the `-PowerOn` parameter defaults to a powered on live mount.

## Related Issue

Resolves #756 

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

Why is this change required? What problem does it solve?

Makes it easier for people to consume the cmdlet.

## How Has This Been Tested?

Tested within the Tech Marketing lab

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
