### PR TITLE
Added `CANCELED` as an exit condition for `Get-RubrikRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-* Added `Find-RubrikFile` which allows end users to automate the search process of finding files within Rubrik snapshots. [Issue 789](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/798)
+* Added `CANCELLED` as an exit condition for `Get-RubrikRequest` as suggested by @IamTHEvilONE, resolves [Issue 794](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/794)
+* Added `Find-RubrikFile` which allows end users to automate the search process of finding files within Rubrik snapshots. [Issue 789](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/789)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-* Added `CANCELLED` as an exit condition for `Get-RubrikRequest` as suggested by @IamTHEvilONE, resolves [Issue 794](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/794)
+* Added `CANCELED` as an exit condition for `Get-RubrikRequest` as suggested by @IamTHEvilONE, resolves [Issue 794](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/794)
 * Added `Find-RubrikFile` which allows end users to automate the search process of finding files within Rubrik snapshots. [Issue 789](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/789)
 
 ### Fixed

--- a/Rubrik/Public/Get-RubrikRequest.ps1
+++ b/Rubrik/Public/Get-RubrikRequest.ps1
@@ -134,7 +134,7 @@ function Get-RubrikRequest {
     #We added new code that will now wait for the Rubrik Async Request to complete. Once completion has happened, we return back the request object. 
     #region WaitForCompletion
     if ($WaitForCompletion) {
-      $ExitList = @("SUCCEEDED", "FAILED")
+      $ExitList = @("SUCCEEDED", "FAILED", "CANCELLED")
       do {
         $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
         $result = Test-ReturnFormat -api $api -result $result -location $resources.Result

--- a/Rubrik/Public/Get-RubrikRequest.ps1
+++ b/Rubrik/Public/Get-RubrikRequest.ps1
@@ -134,7 +134,7 @@ function Get-RubrikRequest {
     #We added new code that will now wait for the Rubrik Async Request to complete. Once completion has happened, we return back the request object. 
     #region WaitForCompletion
     if ($WaitForCompletion) {
-      $ExitList = @("SUCCEEDED", "FAILED", "CANCELLED")
+      $ExitList = @("SUCCEEDED", "FAILED", "CANCELED")
       do {
         $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
         $result = Test-ReturnFormat -api $api -result $result -location $resources.Result


### PR DESCRIPTION
# Description

Create a job that takes some time to complete. (New-RubrikSnapshot)
Pipe that to Get-RubrikRequest -WaitForCompletion so that we are in the wait loop.
Cancel the job via some other method (different PoSH session or Rubrik's GUI)
The wait loop doesn't break due to missing the exit condition of cancelled ... the code just waits for Success or Failure.

## Related Issue

Resolves #794

## Motivation and Context

Why is this change required? What problem does it solve?

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [x] All new and existing tests passed.
