### PR TITLE
Add `Get-RubrikClusterUpgradeHistory` cmdlet to module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-* Added `Find-RubrikFile` which allows end users to automate the search process of finding files within Rubrik snapshots. [Issue 789](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/798)
+* Added `Get-RubrikClusterUpgradeHistory` which Retrieves upgrade history for a given cluster, resolves [Issue 789](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/789)
+* Added `Find-RubrikFile` which allows end users to automate the search process of finding files within Rubrik snapshots. [Issue 798](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/798)
 
 ### Fixed
 

--- a/Rubrik/Private/Get-RubrikAPIData.ps1
+++ b/Rubrik/Private/Get-RubrikAPIData.ps1
@@ -423,6 +423,18 @@ function Get-RubrikAPIData {
                 Success     = '200'
             }
         }
+        'Get-RubrikClusterUpgradeHistory'         = @{
+            '5.0' = @{
+                Description = 'Retrieves advanced settings of the Rubrik cluster'
+                URI         = '/api/v1/config/history/list_updates?namespace=local_atlas&source=Upgrade'
+                Method      = 'Get'
+                Body        = ''
+                Query       = ''
+                Result      = 'data'
+                Filter      = ''
+                Success     = '200'
+            }
+        }
         'Get-RubrikBackupServiceDeployment'           = @{
             '1.0' = @{
                 Description = 'Retrieve the global settings for automatic deployment of the Rubrik Backup Service to virtual machines.'

--- a/Rubrik/Public/Get-RubrikClusterUpgradeHistory.ps1
+++ b/Rubrik/Public/Get-RubrikClusterUpgradeHistory.ps1
@@ -1,0 +1,64 @@
+#Requires -Version 3
+function Get-RubrikClusterUpgradeHistory
+{
+  <#
+    .SYNOPSIS
+    Connects to Rubrik and retrieves node information for a given cluster
+
+    .DESCRIPTION
+    The Get-RubrikClusterUpgradeHistory cmdlet will retrieve various information and settings for a given cluster.
+
+    .NOTES
+    Written by Jaap Brasser for community usage
+    Twitter: @jaap_brasser
+    GitHub: jaapbrasser
+
+    .LINK
+    https://rubrik.gitbook.io/rubrik-sdk-for-powershell/command-documentation/reference/get-rubrikclusterupgradehistory
+
+    .EXAMPLE
+    Get-RubrikClusterUpgradeHistory
+    This will return the advanced settings and information around the currently authenticated cluster.
+  #>
+
+  [CmdletBinding()]
+  Param(
+    # Rubrik server IP or FQDN
+    [String]$Server = $global:RubrikConnection.server,
+    # API version
+    [String]$api = $global:RubrikConnection.api
+  )
+
+  Begin {
+
+    # The Begin section is used to perform one-time loads of data necessary to carry out the function's purpose
+    # If a command needs to be run with each iteration or pipeline input, place it in the Process section
+
+    # Check to ensure that a session to the Rubrik cluster exists and load the needed header data for authentication
+    Test-RubrikConnection
+
+    # API data references the name of the function
+    # For convenience, that name is saved here to $function
+    $function = $MyInvocation.MyCommand.Name
+
+    # Retrieve all of the URI, method, body, query, result, filter, and success details for the API endpoint
+    Write-Verbose -Message "Gather API Data for $function"
+    $resources = Get-RubrikAPIData -endpoint $function
+    Write-Verbose -Message "Load API data for $($resources.Function)"
+    Write-Verbose -Message "Description: $($resources.Description)"
+
+  }
+
+  Process {
+
+    $uri = New-URIString -server $Server -endpoint ($resources.URI) -id $id
+    $uri = Test-QueryParam -querykeys ($resources.Query.Keys) -parameters ((Get-Command $function).Parameters.Values) -uri $uri
+    $body = New-BodyString -bodykeys ($resources.Body.Keys) -parameters ((Get-Command $function).Parameters.Values)
+    $result = Submit-Request -uri $uri -header $Header -method $($resources.Method) -body $body
+    $result = Test-ReturnFormat -api $api -result $result -location $resources.Result
+    $result = Test-FilterObject -filter ($resources.Filter) -result $result
+
+    return $result
+
+  } # End of process
+} # End of function

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -127,6 +127,7 @@
                    'Get-RubrikClusterInfo',
                    'Get-RubrikClusterNetworkInterface',
                    'Get-RubrikClusterStorage',
+                   'Get-RubrikClusterUpgradeHistory',
                    'Get-RubrikDatabase',
                    'Get-RubrikDatabaseFiles',
                    'Get-RubrikDatabaseMount',

--- a/Tests/Get-RubrikClusterUpgradeHistory.Tests.ps1
+++ b/Tests/Get-RubrikClusterUpgradeHistory.Tests.ps1
@@ -1,0 +1,76 @@
+Remove-Module -Name 'Rubrik' -ErrorAction 'SilentlyContinue'
+Import-Module -Name './Rubrik/Rubrik.psd1' -Force
+
+foreach ( $privateFunctionFilePath in ( Get-ChildItem -Path './Rubrik/Private' | Where-Object extension -eq '.ps1').FullName  ) {
+    . $privateFunctionFilePath
+}
+
+Describe -Name 'Public/Get-RubrikClusterUpgradeHistory' -Tag 'Public', 'Get-RubrikClusterUpgradeHistory' -Fixture {
+    #region init
+    $global:rubrikConnection = @{
+        id      = 'test-id'
+        userId  = 'test-userId'
+        token   = 'test-token'
+        server  = 'test-server'
+        header  = @{ 'Authorization' = 'Bearer test-authorization' }
+        time    = (Get-Date)
+        api     = 'v1'
+        version = '5.0.5'
+    }
+    #endregion
+
+    Context -Name 'Results Filtering' {
+        Mock -CommandName Test-RubrikConnection -Verifiable -ModuleName 'Rubrik' -MockWith {}
+        Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
+            @{ 
+                'configChangeMetadata'                   = '{"old_state": "DEFAULT", "tarball_version": "5.3.0-18317"}'
+                'modifiedDateTime'                       = '01/15/2021 19:42:06'
+                'source'                                 = 'UPGRADE'
+            },
+            @{ 
+                'configChangeMetadata'                   = '{"old_state": "DEFAULT", "tarball_version": "5.3.0-18317"}'
+                'modifiedDateTime'                       = '01/15/2021 19:42:06'
+                'source'                                 = 'UPGRADE'
+            },
+            @{ 
+                'configChangeMetadata'                   = '{"old_state": "DEFAULT", "tarball_version": "5.4.0-18317"}'
+                'modifiedDateTime'                       = '02/15/2021 19:42:06'
+                'source'                                 = 'UPGRADE'
+            },
+            @{ 
+                'configChangeMetadata'                   = '{"old_state": "DEFAULT", "tarball_version": "5.5.0-18317"}'
+                'modifiedDateTime'                       = '03/15/2021 19:42:06'
+                'source'                                 = 'UPGRADE'
+            },
+            @{ 
+                'configChangeMetadata'                   = '{"old_state": "DEFAULT", "tarball_version": "5.5.0-18317"}'
+                'modifiedDateTime'                       = '03/15/2021 19:42:06'
+                'source'                                 = 'UPGRADE'
+            },
+            @{ 
+                'configChangeMetadata'                   = '{"old_state": "DEFAULT", "tarball_version": "6.3.0-18317"}'
+                'modifiedDateTime'                       = '04/15/2021 19:42:06'
+                'source'                                 = 'UPGRADE'
+            }
+        }
+        It -Name 'Should Return count of 4 Upgrades' -Test {
+            ( Get-RubrikClusterUpgradeHistory).Count |
+                Should -BeExactly 4
+        }
+        It -Name 'Source should be UPGRADE' -Test {
+            (Get-RubrikClusterUpgradeHistory | Select-Object -First 1).source |
+                Should -BeExactly 'UPGRADE'
+        }
+        It -Name 'DateTime field should be present' -Test {
+            ( Get-RubrikClusterUpgradeHistory | Select-Object -First 1).DateTime |
+                Should -Not -BeNullOrEmpty
+        }
+        It -Name 'Last upgraded version should be 6.3.0-18317' -Test {
+            ( Get-RubrikClusterUpgradeHistory | Select-Object -Last 1).Version |
+                Should -BeExactly '6.3.0-18317'
+        }
+        Assert-VerifiableMock
+        Assert-MockCalled -CommandName Test-RubrikConnection -ModuleName 'Rubrik' -Exactly 4
+        Assert-MockCalled -CommandName Submit-Request -ModuleName 'Rubrik' -Exactly 4
+    }
+}


### PR DESCRIPTION
# Description

Inspired by the similar command that @flhoest created for the Rubrik PHP API Framework: flhoest/Rubrik@69a5cb7...5beb509

https://github.com/flhoest/Rubrik

Cmdlet should output the dates and times and version numbers of which can be retrieved through the following API endpoint: /api/v1/config/history/list_updates?namespace=local_atlas&source=Upgrade

## Related Issue

Resolves #789 

## Motivation and Context

New functionality

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12744735/148233844-fa81341c-f016-4559-a33d-7f2f95bc1e4a.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
