### PR TITLE
Mpreston serviceaccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added new parameterset to `Connect-Rubrik` containing `ID` and `Secret` parameter to facilitate logging into the SDK with Service Accounts.  Resolves [Issue 812](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/812)
+
 ### Fixed
 
 ## [6.0.0](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/6.0.0) - 2022-01-07

--- a/Rubrik/Public/Connect-Rubrik.ps1
+++ b/Rubrik/Public/Connect-Rubrik.ps1
@@ -170,7 +170,7 @@ function Connect-Rubrik {
                 time    = (Get-Date)
                 api     = Get-RubrikAPIVersion -Server $Server
                 version = Get-RubrikSoftwareVersion -Server $Server
-                authType = 'Token'
+                authType = 'ServiceAccount'
             }
         } else {
             $Credential = Test-RubrikCredential -Username $Username -Password $Password -Credential $Credential


### PR DESCRIPTION


# Description

This PR contains minor changes to the `Connect-Rubrik` cmdlet including the addition of a new parameterset and code to support logging into Rubrik CDM with a Service Account ID and Secret.

## Related Issue

Resolve #812 

## Motivation and Context

This allows for a more secure way to authenticate to Rubrik when running scripts.  Also provides a workaround for those organizations that fully leverage MFA - Acts as a workaround for #767 

## How Has This Been Tested?

Tested against clusters within the Tech Marketing Lab

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
