### PR TITLE
Fix 2 issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * **Fixed** for any bug fixes.
 * **Security** in case of vulnerabilities.
 
+## [6.0.2](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/6.0.2) - 2023-01-06
+
+### Added
+
+* Added `SessionID` property to output in `Connect-Rubrik` for service accounts thanks @tonypags, it was previously defined but had a `$null` value. This ID value can be used to disconnect a specific session listed under $global:RubrikConnections.
+
+### Fixed
+
+* `Connect-Rubrik` issue fixed with new service account implementation, won't run on PSv5 thanks @tonypags, resolves [Issue 817](https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/817)
+
 ## [6.0.1](https://github.com/rubrikinc/rubrik-sdk-for-powershell/tree/6.0.1) - 2022-09-22
 
 ### Added

--- a/Rubrik/Public/Connect-Rubrik.ps1
+++ b/Rubrik/Public/Connect-Rubrik.ps1
@@ -151,18 +151,18 @@ function Connect-Rubrik {
                 Method = 'Post'
                 ContentType = "application/json"
                 URI = "https://$Server/api/v1/service_account/session"
-                SkipCertificateCheck = $true
                 Body = @{
                     serviceAccountId = "$($Id)"
                     secret = "$($Secret)"
                 } | ConvertTo-Json
             }
+            if ($PSVersiontable.PSVersion.Major -gt 5) {$RestSplat.SkipCertificateCheck = $true}
             $response = Invoke-RestMethod @RestSplat -Verbose
             $Token = $response.token
             $head = @{'Authorization' = "Bearer $($Token)";'User-Agent' = $UserAgentString}
             Write-Verbose -Message 'Storing all connection details into $global:rubrikConnection'
             $global:rubrikConnection = @{
-                id      = $null
+                id      = $response.sessionId
                 userId  = $null
                 token   = $Token
                 server  = $Server

--- a/Rubrik/Rubrik.psd1
+++ b/Rubrik/Rubrik.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Rubrik.psm1'
 
 # Version number of this module.
-ModuleVersion = '6.0.1'
+ModuleVersion = '6.0.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Tests/Connect-Rubrik.Tests.ps1
+++ b/Tests/Connect-Rubrik.Tests.ps1
@@ -28,11 +28,23 @@ Describe -Name 'Public/Connect-Rubrik' -Tag 'Public', 'Connect-Rubrik' -Fixture 
         Mock -CommandName New-UserAgentString -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             [pscustomobject]@{
-                id = 11111
-                userId = 22222
-                token = 33333
+                sessionId = "22222"
+                serviceAccountId = "11111"
+                token = "33333"
+                expirationTime = "3022-12-10T06:19:52.250Z"
+                organizationId = "44444"
             }
         }
+        Mock -CommandName Invoke-RestMethod -Verifiable -ModuleName 'Rubrik' -MockWith {
+            [pscustomobject]@{
+                "sessionId": "d417538a-c3f2-4e40-8977-1fd1448c6713",
+                "serviceAccountId": "User:::283c0f27-d4b5-469e-8f1a-663de1195e4c",
+                "token": "xxxxxxx"
+                "expirationTime": "2022-12-10T06:19:52.250Z", <--------------------------------------------------------
+                "organizationId": "e61a0588-53d7-494c-ba7b-a25e9a2068c0"
+            }
+        }
+
         It -Name 'Username / Password combination' -Test {
             (Connect-Rubrik -Server testcluster -Username jaapbrasser -Password $(ConvertTo-SecureString -String password -AsPlainText -Force)) | Out-String |
                 Should -BeLikeExactly '*Basic*'
@@ -51,9 +63,14 @@ Describe -Name 'Public/Connect-Rubrik' -Tag 'Public', 'Connect-Rubrik' -Fixture 
                 Should -BeLikeExactly '*Token*'
         }
 
-        It -Name 'RubrikConnections array should contain 3 entries' -Test {
+        It -Name 'Service Account' -Test {
+            (Connect-Rubrik -Server testcluster -Id Username -Secret 33333) | Out-String |
+                Should -BeLikeExactly '*ServiceAccount*'
+        }
+
+        It -Name 'RubrikConnections array should contain 4 entries' -Test {
             @($RubrikConnections).Count |
-                Should -Be 3
+                Should -Be 4
         }
 
         Assert-VerifiableMock

--- a/Tests/Connect-Rubrik.Tests.ps1
+++ b/Tests/Connect-Rubrik.Tests.ps1
@@ -28,20 +28,18 @@ Describe -Name 'Public/Connect-Rubrik' -Tag 'Public', 'Connect-Rubrik' -Fixture 
         Mock -CommandName New-UserAgentString -Verifiable -ModuleName 'Rubrik' -MockWith { }
         Mock -CommandName Submit-Request -Verifiable -ModuleName 'Rubrik' -MockWith {
             [pscustomobject]@{
+                id = 11111
+                userId = 22222
+                token = 33333
+            }
+        }
+        Mock -CommandName Invoke-RestMethod -Verifiable -ModuleName 'Rubrik' -MockWith {
+            [pscustomobject]@{
                 sessionId = "22222"
                 serviceAccountId = "11111"
                 token = "33333"
                 expirationTime = "3022-12-10T06:19:52.250Z"
                 organizationId = "44444"
-            }
-        }
-        Mock -CommandName Invoke-RestMethod -Verifiable -ModuleName 'Rubrik' -MockWith {
-            [pscustomobject]@{
-                "sessionId": "d417538a-c3f2-4e40-8977-1fd1448c6713",
-                "serviceAccountId": "User:::283c0f27-d4b5-469e-8f1a-663de1195e4c",
-                "token": "xxxxxxx"
-                "expirationTime": "2022-12-10T06:19:52.250Z", <--------------------------------------------------------
-                "organizationId": "e61a0588-53d7-494c-ba7b-a25e9a2068c0"
             }
         }
 


### PR DESCRIPTION
1. PSv5 won't run this function because Invoke-RestMethod doesn't yet support SkipCertificateCheck. Changed logic to add this parameter conditionally.
2. The Session ID is not returned; null values are hard-coded. Added the value from the response to the hashtable.

## Related Issue
1. https://github.com/rubrikinc/rubrik-sdk-for-powershell/issues/817
2. No issue exists

## Motivation and Context
1. I am unable to run code in production using the current version.
2. I am unable to disconnect a specific session without its ID

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://rubrik.gitbook.io/rubrik-sdk-for-powershell/user-documentation/contribution)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
